### PR TITLE
docs: align canonical design hash baseline with join-login authority

### DIFF
--- a/docs/reference/design/.canonical-files.txt
+++ b/docs/reference/design/.canonical-files.txt
@@ -11,4 +11,3 @@ join-login.md
 search.md
 style-guide.md
 text-pages.md
-join-login.md


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/557

Fixes docs_guardrails canonical drift failure by replacing stale join.md/login.md entries with join-login.md in docs/reference/design/.canonical-files.txt and regenerating docs/reference/design/.canonical-hashes.sha256.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the canonical design baseline with the unified `join-login.md` page. Deduplicates `join-login.md` in `docs/reference/design/.canonical-files.txt` to resolve docs_guardrails canonical drift for join/login.

<sup>Written for commit 90ce5aa0a5cd4f59e0d023a8efe1bd070cb98aab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

