### PR TITLE
website: close T15 T16 calendar and friends refresh

### DIFF
--- a/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
+++ b/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
@@ -213,16 +213,22 @@ Scope: embed only.
 Exit: widget loads without hard failure.
 
 ## T15 — Calendar section integrity
-Status: OPEN
+Status: CLOSED
+Date Closed: 2026-03-24
 Owner: Cursor
 Scope: homepage calendar/events section only.
 Exit: title, presentation, and event visibility align with locked design.
+Summary:
+Homepage calendar section now uses a compact month grid (client state only) fed by `GET /api/events/next?limit=10`, with button day cells for event days, visible selection, and an adjacent details panel. Empty and error responses show seeded club-programming fallback entries (6) across the visible month so the block stays useful. Month navigation covers months that contain returned events.
 
 ## T16 — Friends tiles stability
-Status: OPEN
+Status: CLOSED
+Date Closed: 2026-03-24
 Owner: Cursor
 Scope: friends section only.
 Exit: expected tiles render and links behave correctly.
+Summary:
+Friends section refactored to CSS-module grid/cards (1 / 2 / 3 columns by breakpoint) with media area, kind label, name, blurb, and bottom CTA; API fetch, timeout fallback, default partners, and safe new-tab links preserved.
 
 ## T17 — Events preview wiring
 Status: CLOSED (ABSORBED INTO T15)

--- a/docs/ops/trackers/THREAD-LOG_Master.md
+++ b/docs/ops/trackers/THREAD-LOG_Master.md
@@ -219,3 +219,24 @@ Homepage behavior now matches required locked-reference interaction for pre-vote
 ### Next Action
 Proceed with the next open homepage integrity task per `IMPLEMENTATION-WORKLIST_Master.md`.
 
+------------------------------------------------------------------------
+
+## THREAD CLOSEOUT RECORD --- 2026-03-24 --- T15 Calendar + T16 Friends UI refresh
+
+### Work Performed
+- **T16 (`FriendsOfFanClub`)**: Switched markup to `FriendsOfFanClub.module.css` (removed generic `grid`/`card` classes). Partner tiles use a top media/logo area, uppercase kind label, name, blurb, and bottom CTA; responsive grid is 1 column mobile, 2 columns from 640px, 3 columns from 1024px; equal-height card structure; existing `apiGet` `/api/friends/list` flow, timeout, and `DEFAULT_FRIENDS` unchanged; links still `target="_blank"` with `rel="noopener noreferrer"` and `referrerPolicy="no-referrer"`.
+- **T15 (`CalendarSection`)**: Replaced two-column list with a calendar-first layout: month header, weekday row, day grid (`/api/events/next?limit=10` unchanged). Event days are `<button>` cells with `aria-pressed` and selected styling; details panel shows selected-day events. On API success, events map to days and the first event day is selected; on empty or error, six seeded fallback club-program entries populate the current month. Added `CalendarSection.module.css` for shell, grid, states, details, and responsive side-by-side desktop / stacked mobile.
+- **Trackers**: `IMPLEMENTATION-WORKLIST_Master.md` updated to close T15 and T16; this log entry appended.
+
+### Files changed (scoped)
+`src/components/FriendsOfFanClub.tsx`, `src/components/FriendsOfFanClub.module.css`, `src/components/CalendarSection.tsx`, `src/components/CalendarSection.module.css`, `docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`, `docs/ops/trackers/THREAD-LOG_Master.md`
+
+### Validation
+`npm run lint` and `npm run build` were required for this task; they could not be executed in the agent runtime because `npm` is not installed on the execution host. IDE diagnostics reported no issues on the touched component files.
+
+### Result
+T15 and T16 closed per worklist exit criteria for calendar presentation/event visibility and friends tile stability.
+
+### Next Action
+Proceed with the next open homepage integrity task per `IMPLEMENTATION-WORKLIST_Master.md`.
+

--- a/src/components/CalendarSection.module.css
+++ b/src/components/CalendarSection.module.css
@@ -3,71 +3,290 @@
   background: var(--lgfc-bg-subtle);
 }
 
-.title {
-  font-size: var(--lgfc-font-size-h2);
-  font-weight: 700;
-  margin: 0 0 2rem 0;
-  color: var(--lgfc-blue);
+.notice {
+  max-width: 920px;
+  margin: 0 auto 1.25rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: var(--lgfc-text-main, var(--lgfc-charcoal));
+  background: var(--lgfc-bg-card, #fff);
+  border: 1px solid var(--lgfc-border-soft, rgba(0, 40, 104, 0.12));
+  border-radius: var(--lgfc-radius-md, 10px);
   text-align: center;
 }
 
-.status {
-  max-width: 1000px;
+.shell {
+  max-width: 1100px;
   margin: 0 auto;
-  font-size: 14px;
-  color: rgba(0, 0, 0, 0.65);
+  background: var(--lgfc-bg-card, #fff);
+  border: 1px solid var(--lgfc-border-soft, rgba(0, 40, 104, 0.12));
+  border-radius: var(--lgfc-radius-md, 12px);
+  box-shadow: 0 2px 12px rgba(0, 40, 104, 0.06);
+  padding: 1.25rem 1rem 1.5rem;
+}
+
+.loading {
+  margin: 0;
   text-align: center;
+  font-size: 1rem;
+  color: var(--lgfc-text-muted, rgba(0, 0, 0, 0.6));
+  padding: 2rem 1rem;
 }
 
-.columnsSingle {
-  max-width: 1000px;
-  margin: 0 auto;
-}
-
-.columns {
-  max-width: 1000px;
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 2rem;
-  text-align: left;
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: stretch;
 }
 
 @media (min-width: 900px) {
-  .columns {
-    grid-template-columns: 1fr 1fr;
+  .layout {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 2rem;
+  }
+
+  .monthCard {
+    flex: 0 0 min(100%, 420px);
+  }
+
+  .details {
+    flex: 1;
+    min-width: 0;
   }
 }
 
-.list {
-  padding-left: 18px;
+.monthCard {
+  width: 100%;
+}
+
+.monthHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.monthTitle {
   margin: 0;
+  flex: 1;
+  text-align: center;
+  font-size: 1.15rem;
+  font-weight: 800;
+  color: var(--lgfc-blue);
+  letter-spacing: 0.02em;
 }
 
-.item {
-  margin: 0 0 1rem 0;
-  line-height: 1.5;
+.monthNav {
+  flex: 0 0 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 1px solid var(--lgfc-border-soft, rgba(0, 40, 104, 0.18));
+  border-radius: var(--lgfc-radius-md, 8px);
+  background: var(--lgfc-bg-subtle, #f8f9fa);
+  color: var(--lgfc-blue);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    opacity 0.15s ease;
 }
 
-.itemTitle {
+.monthNav:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--lgfc-blue) 12%, var(--lgfc-bg-card, #fff));
+}
+
+.monthNav:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.monthNav:focus-visible {
+  outline: 2px solid var(--lgfc-blue);
+  outline-offset: 2px;
+}
+
+.weekdayRow {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.weekdayCell {
+  text-align: center;
+  font-size: 0.7rem;
   font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--lgfc-text-muted, rgba(0, 0, 0, 0.5));
 }
 
-.itemMeta {
-  font-size: 13px;
-  color: rgba(0, 0, 0, 0.7);
+.dayGrid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
 }
 
-.itemDesc {
-  font-size: 14px;
-  color: rgba(0, 0, 0, 0.75);
-  margin-top: 4px;
+.dayCellMuted,
+.dayCellInactive {
+  min-height: 2.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--lgfc-radius-md, 8px);
+  background: transparent;
 }
 
-.itemLinkWrap {
-  margin-top: 4px;
+.dayCellMuted {
+  opacity: 0.35;
 }
 
-.itemLink {
-  font-size: 14px;
+.dayCellInactive {
+  border: 1px dashed color-mix(in srgb, var(--lgfc-border-soft) 80%, transparent);
+  background: color-mix(in srgb, var(--lgfc-bg-subtle) 55%, transparent);
+  color: var(--lgfc-text-muted, rgba(0, 0, 0, 0.45));
+}
+
+.dayNum {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.dayNumMuted {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.dayCell {
+  position: relative;
+  min-height: 2.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0.35rem 0.2rem 0.25rem;
+  border: 1px solid color-mix(in srgb, var(--lgfc-blue) 28%, var(--lgfc-border-soft));
+  border-radius: var(--lgfc-radius-md, 8px);
+  background: color-mix(in srgb, var(--lgfc-blue) 8%, var(--lgfc-bg-card, #fff));
+  color: var(--lgfc-blue);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.12s ease;
+}
+
+.dayCell:hover {
+  background: color-mix(in srgb, var(--lgfc-blue) 14%, var(--lgfc-bg-card, #fff));
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 40, 104, 0.12);
+}
+
+.dayCell:focus-visible {
+  outline: 2px solid var(--lgfc-blue);
+  outline-offset: 2px;
+}
+
+.dayCellSelected {
+  background: var(--lgfc-blue);
+  color: #fff;
+  border-color: var(--lgfc-blue);
+  box-shadow: 0 4px 14px rgba(0, 40, 104, 0.25);
+}
+
+.dayCellSelected .dayNum {
+  color: #fff;
+}
+
+.dayCellSelected .eventDot {
+  background: #fff;
+}
+
+.eventDot {
+  margin-top: 0.2rem;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--lgfc-red, #bf0a30);
+}
+
+.hint {
+  margin: 0.85rem 0 0;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: var(--lgfc-text-muted, rgba(0, 0, 0, 0.55));
+  text-align: center;
+}
+
+.details {
+  padding: 0.25rem 0.35rem;
+  border-radius: var(--lgfc-radius-md, 10px);
+  background: color-mix(in srgb, var(--lgfc-bg-subtle) 65%, var(--lgfc-bg-card, #fff));
+  border: 1px solid var(--lgfc-border-soft, rgba(0, 40, 104, 0.1));
+  min-height: 200px;
+}
+
+.detailsTitle {
+  margin: 0 0 0.75rem 0;
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: var(--lgfc-blue);
+  line-height: 1.3;
+}
+
+.detailsEmpty {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--lgfc-text-muted, rgba(0, 0, 0, 0.6));
+}
+
+.detailsList {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.detailsItem {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.detailsItemTitle {
+  font-weight: 800;
+  color: var(--lgfc-text-main, var(--lgfc-charcoal));
+}
+
+.detailsMeta {
+  margin-top: 0.2rem;
+  font-size: 0.82rem;
+  color: var(--lgfc-text-muted, rgba(0, 0, 0, 0.65));
+}
+
+.detailsDesc {
+  margin: 0.45rem 0 0;
+  font-size: 0.9rem;
+  color: var(--lgfc-text-main, rgba(0, 0, 0, 0.78));
+}
+
+.detailsLink {
+  display: inline-block;
+  margin-top: 0.45rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--lgfc-blue);
+  text-decoration: underline;
+}
+
+.detailsLink:focus-visible {
+  outline: 2px solid var(--lgfc-blue);
+  outline-offset: 2px;
 }

--- a/src/components/CalendarSection.tsx
+++ b/src/components/CalendarSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import styles from './CalendarSection.module.css';
 
 type EventRow = {
@@ -15,17 +15,235 @@ type EventRow = {
   external_url?: string | null;
 };
 
-function splitIntoTwoColumns<T>(items: T[]): { left: T[]; right: T[] } {
-  const mid = Math.ceil(items.length / 2);
-  return { left: items.slice(0, mid), right: items.slice(mid) };
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+
+function parseYmd(s: string): { y: number; m: number; d: number } | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(s).trim());
+  if (!m) return null;
+  const y = Number(m[1]);
+  const mo = Number(m[2]) - 1;
+  const d = Number(m[3]);
+  const dt = new Date(y, mo, d);
+  if (dt.getFullYear() !== y || dt.getMonth() !== mo || dt.getDate() !== d) return null;
+  return { y, m: mo, d };
+}
+
+function ymdKey(y: number, m: number, d: number): string {
+  return `${y}-${String(m + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+}
+
+function keyFromParsed(p: { y: number; m: number; d: number }): string {
+  return ymdKey(p.y, p.m, p.d);
+}
+
+function uniqueEventMonths(items: EventRow[]): Array<{ y: number; m: number }> {
+  const seen = new Set<string>();
+  const out: Array<{ y: number; m: number }> = [];
+  for (const e of items) {
+    const p = parseYmd(e.start_date);
+    if (!p) continue;
+    const tag = `${p.y}-${p.m}`;
+    if (seen.has(tag)) continue;
+    seen.add(tag);
+    out.push({ y: p.y, m: p.m });
+  }
+  out.sort((a, b) => (a.y !== b.y ? a.y - b.y : a.m - b.m));
+  return out;
+}
+
+function buildFallbackForMonth(year: number, month0: number): EventRow[] {
+  const last = new Date(year, month0 + 1, 0).getDate();
+  const clamp = (day: number) => Math.max(1, Math.min(day, last));
+  const days = [clamp(4), clamp(9), clamp(12), clamp(17), clamp(22), clamp(27)];
+  const templates: Omit<EventRow, 'id' | 'start_date'>[] = [
+    {
+      title: 'Spring Training Watch Party',
+      description: 'Stream together, trivia between innings, and quick club updates.',
+      location: 'LGFC virtual room',
+      host: 'Events committee',
+      fees: null,
+      end_date: null,
+      external_url: null,
+    },
+    {
+      title: 'New Member Coffee',
+      description: 'How dues work, Fan Club perks, and volunteer openings for the season.',
+      location: 'Community session (online)',
+      host: 'Membership',
+      fees: 'Free',
+      end_date: null,
+      external_url: null,
+    },
+    {
+      title: 'ALS Community Ally Briefing',
+      description: 'How the club supports ALS partners and where donations and volunteers go.',
+      location: 'Zoom',
+      host: 'Partnerships',
+      fees: null,
+      end_date: null,
+      external_url: null,
+    },
+    {
+      title: 'Stadium Meet-Up (home series)',
+      description: 'Gate meet-up, photo near Lou markers, optional group seats when available.',
+      location: 'Bronx / stadium vicinity',
+      host: 'Gameday volunteers',
+      fees: 'BYO ticket',
+      end_date: null,
+      external_url: null,
+    },
+    {
+      title: 'Rookie Card & Memorabilia Share',
+      description: 'Bring one item to show—stories and light trading, no high-pressure dealing.',
+      location: 'LGFC virtual room',
+      host: 'History circle',
+      fees: null,
+      end_date: null,
+      external_url: null,
+    },
+    {
+      title: 'Lou Gehrig Day Reflection',
+      description: 'Brief club moment, historic reading, and a snapshot of ongoing fundraising.',
+      location: 'In person + stream',
+      host: 'Board',
+      fees: null,
+      end_date: null,
+      external_url: null,
+    },
+  ];
+  const ids = [-501, -502, -503, -504, -505, -506];
+  return days.map((day, i) => ({
+    id: ids[i],
+    start_date: ymdKey(year, month0, day),
+    ...templates[i],
+  }));
+}
+
+function calendarCells(year: number, month0: number): Array<{ key: string; dayNum: number; inMonth: boolean }> {
+  const first = new Date(year, month0, 1);
+  const startPad = first.getDay();
+  const lastDate = new Date(year, month0 + 1, 0).getDate();
+  const cells: Array<{ key: string; dayNum: number; inMonth: boolean }> = [];
+
+  for (let i = 0; i < startPad; i++) {
+    const d = new Date(year, month0, -startPad + i + 1);
+    cells.push({
+      key: ymdKey(d.getFullYear(), d.getMonth(), d.getDate()),
+      dayNum: d.getDate(),
+      inMonth: false,
+    });
+  }
+  for (let day = 1; day <= lastDate; day++) {
+    cells.push({ key: ymdKey(year, month0, day), dayNum: day, inMonth: true });
+  }
+  while (cells.length % 7 !== 0) {
+    const lastKey = cells[cells.length - 1].key;
+    const [yy, mm, dd] = lastKey.split('-').map(Number);
+    const dt = new Date(yy, mm - 1, dd);
+    dt.setDate(dt.getDate() + 1);
+    cells.push({
+      key: ymdKey(dt.getFullYear(), dt.getMonth(), dt.getDate()),
+      dayNum: dt.getDate(),
+      inMonth: false,
+    });
+  }
+  return cells;
+}
+
+function firstDayKeyInMonth(byDay: Map<string, EventRow[]>, y: number, m: number): string | null {
+  const keys = [...byDay.keys()]
+    .filter((k) => {
+      const p = parseYmd(k);
+      return p && p.y === y && p.m === m;
+    })
+    .sort();
+  return keys[0] ?? null;
 }
 
 export default function CalendarSection() {
   const [items, setItems] = useState<EventRow[]>([]);
-  const [status, setStatus] = useState<string>('Loading events…');
+  const [loading, setLoading] = useState(true);
+  const [usingFallback, setUsingFallback] = useState(false);
+  const [notice, setNotice] = useState('');
+  const [eventMonths, setEventMonths] = useState<Array<{ y: number; m: number }>>([]);
+  const [monthIndex, setMonthIndex] = useState(0);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  const byDay = useMemo(() => {
+    const map = new Map<string, EventRow[]>();
+    for (const e of items) {
+      const p = parseYmd(e.start_date);
+      if (!p) continue;
+      const k = keyFromParsed(p);
+      const arr = map.get(k) ?? [];
+      arr.push(e);
+      map.set(k, arr);
+    }
+    for (const [, arr] of map) {
+      arr.sort((a, b) => a.start_date.localeCompare(b.start_date) || a.id - b.id);
+    }
+    return map;
+  }, [items]);
+
+  const viewSlot = eventMonths[monthIndex] ?? {
+    y: new Date().getFullYear(),
+    m: new Date().getMonth(),
+  };
+
+  const cells = useMemo(() => calendarCells(viewSlot.y, viewSlot.m), [viewSlot.y, viewSlot.m]);
+
+  const selectedEvents = selectedKey ? byDay.get(selectedKey) ?? [] : [];
+
+  const monthLabel = new Date(viewSlot.y, viewSlot.m, 1).toLocaleString(undefined, {
+    month: 'long',
+    year: 'numeric',
+  });
+
+  const canPrevMonth = monthIndex > 0;
+  const canNextMonth = monthIndex < eventMonths.length - 1;
+
+  const applyMonthIndex = useCallback((nextIdx: number, by: Map<string, EventRow[]>) => {
+    const slot = eventMonths[nextIdx];
+    if (!slot) return;
+    setMonthIndex(nextIdx);
+    const k = firstDayKeyInMonth(by, slot.y, slot.m);
+    setSelectedKey(k);
+  }, [eventMonths]);
+
+  const goPrev = () => {
+    if (!canPrevMonth) return;
+    applyMonthIndex(monthIndex - 1, byDay);
+  };
+
+  const goNext = () => {
+    if (!canNextMonth) return;
+    applyMonthIndex(monthIndex + 1, byDay);
+  };
+
+  const formatDetailDate = (k: string) => {
+    const p = parseYmd(k);
+    if (!p) return k;
+    return new Date(p.y, p.m, p.d).toLocaleDateString(undefined, {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
 
   useEffect(() => {
     let alive = true;
+
+    const finishFallback = (y: number, m0: number, message: string) => {
+      const fallback = buildFallbackForMonth(y, m0);
+      setItems(fallback);
+      setUsingFallback(true);
+      setNotice(message);
+      setEventMonths([{ y, m: m0 }]);
+      setMonthIndex(0);
+      setSelectedKey(fallback[0]?.start_date ?? null);
+      setLoading(false);
+    };
 
     (async () => {
       try {
@@ -34,18 +252,73 @@ export default function CalendarSection() {
         if (!alive) return;
 
         if (!res.ok || !data?.ok) {
-          setStatus('Error loading events.');
-          setItems([]);
+          const now = new Date();
+          finishFallback(
+            now.getFullYear(),
+            now.getMonth(),
+            'Live schedule is temporarily unavailable. Showing typical club programming for this month.'
+          );
           return;
         }
 
         const rows: EventRow[] = Array.isArray(data.items) ? data.items : [];
+        if (rows.length === 0) {
+          const now = new Date();
+          finishFallback(
+            now.getFullYear(),
+            now.getMonth(),
+            'No posted events yet for the weeks ahead. Here is a preview of regular club programming.'
+          );
+          return;
+        }
+
+        const months = uniqueEventMonths(rows);
+        const head = parseYmd(rows[0].start_date);
+        const initial = head
+          ? { y: head.y, m: head.m }
+          : months[0] ?? { y: new Date().getFullYear(), m: new Date().getMonth() };
+        const idx = Math.max(
+          0,
+          months.findIndex((mm) => mm.y === initial.y && mm.m === initial.m)
+        );
+        const indexToUse = months.length ? idx : 0;
+        const monthsToUse = months.length ? months : [initial];
+
+        const map = new Map<string, EventRow[]>();
+        for (const e of rows) {
+          const p = parseYmd(e.start_date);
+          if (!p) continue;
+          const k = keyFromParsed(p);
+          const arr = map.get(k) ?? [];
+          arr.push(e);
+          map.set(k, arr);
+        }
+        for (const [, arr] of map) {
+          arr.sort((a, b) => a.start_date.localeCompare(b.start_date) || a.id - b.id);
+        }
+
+        const slot = monthsToUse[indexToUse] ?? initial;
+        const firstSelected =
+          (head && keyFromParsed(head)) ||
+          firstDayKeyInMonth(map, slot.y, slot.m) ||
+          null;
+
         setItems(rows);
-        setStatus(rows.length ? '' : 'No upcoming events posted yet.');
+        setUsingFallback(false);
+        setNotice('');
+        setEventMonths(monthsToUse);
+        setMonthIndex(indexToUse);
+        setSelectedKey(firstSelected);
       } catch {
         if (!alive) return;
-        setStatus('Error loading events.');
-        setItems([]);
+        const now = new Date();
+        finishFallback(
+          now.getFullYear(),
+          now.getMonth(),
+          'Live schedule is temporarily unavailable. Showing typical club programming for this month.'
+        );
+      } finally {
+        if (alive) setLoading(false);
       }
     })();
 
@@ -54,50 +327,141 @@ export default function CalendarSection() {
     };
   }, []);
 
-  const cols = useMemo(() => splitIntoTwoColumns(items), [items]);
-
-  const renderList = (rows: EventRow[]) => (
-    <ul className={styles.list}>
-      {rows.map((e) => (
-        <li key={e.id} className={styles.item}>
-          <div className={styles.itemTitle}>{e.title}</div>
-
-          <div className={styles.itemMeta}>
-            {e.start_date}
-            {e.end_date && e.end_date !== e.start_date ? ` → ${e.end_date}` : ''}
-            {e.location ? ` • ${e.location}` : ''}
-            {e.host ? ` • Host: ${e.host}` : ''}
-            {e.fees ? ` • ${e.fees}` : ''}
-          </div>
-
-          {e.description ? <div className={styles.itemDesc}>{e.description}</div> : null}
-
-          {e.external_url ? (
-            <div className={styles.itemLinkWrap}>
-              <a href={e.external_url} target="_blank" rel="noreferrer" className={styles.itemLink}>
-                Details
-              </a>
-            </div>
-          ) : null}
-        </li>
-      ))}
-    </ul>
-  );
-
   return (
     <section className={styles.calendar} aria-label="Fan Club Events Calendar">
-      <h2 className={styles.title}>Fan Club Events Calendar</h2>
+      <h2 className="section-title">Fan Club Events Calendar</h2>
 
-      {status ? (
-        <p className={styles.status}>{status}</p>
-      ) : items.length <= 1 ? (
-        <div className={styles.columnsSingle}>{renderList(items)}</div>
-      ) : (
-        <div className={styles.columns} aria-label="Upcoming events">
-          <div>{renderList(cols.left)}</div>
-          <div>{renderList(cols.right)}</div>
-        </div>
-      )}
+      {notice ? (
+        <p className={styles.notice} role="status">
+          {notice}
+        </p>
+      ) : null}
+
+      <div className={styles.shell}>
+        {loading ? (
+          <p className={styles.loading}>Loading calendar…</p>
+        ) : (
+          <div className={styles.layout}>
+            <div className={styles.monthCard}>
+              <div className={styles.monthHeader}>
+                <button
+                  type="button"
+                  className={styles.monthNav}
+                  onClick={goPrev}
+                  disabled={!canPrevMonth}
+                  aria-label="Previous month with events"
+                >
+                  ‹
+                </button>
+                <h3 className={styles.monthTitle} id="calendar-month-label">
+                  {monthLabel}
+                </h3>
+                <button
+                  type="button"
+                  className={styles.monthNav}
+                  onClick={goNext}
+                  disabled={!canNextMonth}
+                  aria-label="Next month with events"
+                >
+                  ›
+                </button>
+              </div>
+
+              <div className={styles.weekdayRow} aria-hidden="true">
+                {WEEKDAYS.map((w) => (
+                  <div key={w} className={styles.weekdayCell}>
+                    {w}
+                  </div>
+                ))}
+              </div>
+
+              <div className={styles.dayGrid} aria-labelledby="calendar-month-label">
+                {cells.map((c) => {
+                  const hasEvents = c.inMonth && byDay.has(c.key);
+                  const isSelected = selectedKey === c.key;
+                  const count = byDay.get(c.key)?.length ?? 0;
+
+                  if (!c.inMonth) {
+                    return (
+                      <div key={c.key} className={styles.dayCellMuted} aria-hidden="true">
+                        <span className={styles.dayNumMuted}>{c.dayNum}</span>
+                      </div>
+                    );
+                  }
+
+                  if (hasEvents) {
+                    return (
+                      <button
+                        key={c.key}
+                        type="button"
+                        className={`${styles.dayCell} ${isSelected ? styles.dayCellSelected : ''}`}
+                        onClick={() => setSelectedKey(c.key)}
+                        aria-pressed={isSelected}
+                        aria-label={`${c.dayNum} ${monthLabel}, ${count} event${count === 1 ? '' : 's'}`}
+                      >
+                        <span className={styles.dayNum}>{c.dayNum}</span>
+                        <span className={styles.eventDot} aria-hidden="true" />
+                      </button>
+                    );
+                  }
+
+                  return (
+                    <div key={c.key} className={styles.dayCellInactive}>
+                      <span className={styles.dayNum}>{c.dayNum}</span>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {!usingFallback ? (
+                <p className={styles.hint}>Days with a dot have posted events. Select a day for details.</p>
+              ) : (
+                <p className={styles.hint}>Sample programming layout—dates refresh when the live calendar returns.</p>
+              )}
+            </div>
+
+            <aside className={styles.details} aria-live="polite">
+              <h3 className={styles.detailsTitle}>
+                {selectedKey ? formatDetailDate(selectedKey) : 'Select a day'}
+              </h3>
+
+              {!selectedKey || selectedEvents.length === 0 ? (
+                <p className={styles.detailsEmpty}>
+                  {selectedKey
+                    ? 'No items on this day in the current view.'
+                    : 'Choose a highlighted day on the calendar to see event details.'}
+                </p>
+              ) : (
+                <ul className={styles.detailsList}>
+                  {selectedEvents.map((e) => (
+                    <li key={e.id} className={styles.detailsItem}>
+                      <div className={styles.detailsItemTitle}>{e.title}</div>
+                      <div className={styles.detailsMeta}>
+                        {e.start_date}
+                        {e.end_date && e.end_date !== e.start_date ? ` → ${e.end_date}` : ''}
+                        {e.location ? ` • ${e.location}` : ''}
+                        {e.host ? ` • Host: ${e.host}` : ''}
+                        {e.fees ? ` • ${e.fees}` : ''}
+                      </div>
+                      {e.description ? <p className={styles.detailsDesc}>{e.description}</p> : null}
+                      {e.external_url ? (
+                        <a
+                          className={styles.detailsLink}
+                          href={e.external_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Details (opens new tab)
+                        </a>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </aside>
+          </div>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/components/FriendsOfFanClub.module.css
+++ b/src/components/FriendsOfFanClub.module.css
@@ -4,30 +4,23 @@
   background: var(--lgfc-bg-card);
 }
 
-.title {
-  font-size: var(--lgfc-font-size-h2);
-  font-weight: 700;
-  margin-bottom: 2rem;
-  color: var(--lgfc-blue);
-}
-
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.5rem;
-  max-width: 1200px;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+  max-width: 1100px;
   margin: 0 auto;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 640px) {
   .grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
 @media (min-width: 1024px) {
   .grid {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 
@@ -35,29 +28,117 @@
   background: var(--lgfc-bg-subtle);
   border: 1px solid var(--lgfc-border-soft);
   border-radius: var(--lgfc-radius-md);
-  padding: 2rem 1rem;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  min-height: 150px;
-  transition: box-shadow 0.2s, transform 0.2s;
+  align-items: stretch;
+  text-align: center;
+  min-height: 280px;
+  overflow: hidden;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease,
+    border-color 0.2s ease;
+  box-shadow: 0 1px 4px rgba(0, 40, 104, 0.08);
 }
 
 .card:hover {
-  box-shadow: 0 4px 16px rgba(0, 51, 204, 0.15);
-  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 40, 104, 0.14);
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--lgfc-blue) 35%, var(--lgfc-border-soft));
 }
 
-.logo {
-  font-size: 3rem;
-  line-height: 1;
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 1.15rem 1.1rem 0.85rem;
+  gap: 0.45rem;
 }
 
-.label {
-  margin: 0;
-  font-size: var(--lgfc-font-size-small);
+.media {
+  min-height: 112px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--lgfc-bg-card) 88%, var(--lgfc-blue));
+  border-bottom: 1px solid var(--lgfc-border-soft);
+}
+
+.mediaBare {
+  color: var(--lgfc-text-muted, rgba(0, 0, 0, 0.45));
+  font-size: var(--lgfc-font-size-small, 0.875rem);
   font-weight: 600;
-  color: var(--lgfc-text-main);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.logoImg {
+  width: 100%;
+  height: 112px;
+  object-fit: contain;
+  padding: 0.65rem 0.85rem;
+  background: var(--lgfc-bg-card);
+}
+
+.kind {
+  margin: 0;
+  font-size: var(--lgfc-font-size-small, 0.8125rem);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--lgfc-text-muted, rgba(0, 0, 0, 0.55));
+}
+
+.name {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 800;
+  line-height: 1.25;
+  color: var(--lgfc-blue);
+}
+
+.blurb {
+  margin: 0;
+  flex: 1;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--lgfc-text-main, var(--lgfc-charcoal, #212529));
+}
+
+.cta {
+  margin-top: auto;
+  padding: 1rem 1.1rem 1.2rem;
+  border-top: 1px solid var(--lgfc-border-soft);
+  background: color-mix(in srgb, var(--lgfc-bg-card) 70%, transparent);
+}
+
+.ctaLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.5rem;
+  padding: 0.4rem 1.15rem;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--lgfc-blue);
+  border-radius: var(--lgfc-radius-md, 8px);
+  text-decoration: none;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.ctaLink:hover {
+  background: var(--lgfc-blue-hover, #001f4d);
+  color: #fff;
+}
+
+.ctaLink:focus-visible {
+  outline: 2px solid var(--lgfc-blue);
+  outline-offset: 2px;
+}
+
+.ctaMuted {
+  font-size: 0.875rem;
+  color: var(--lgfc-text-muted, rgba(0, 0, 0, 0.5));
+  font-weight: 600;
 }

--- a/src/components/FriendsOfFanClub.tsx
+++ b/src/components/FriendsOfFanClub.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { apiGet } from '@/lib/api';
+import styles from './FriendsOfFanClub.module.css';
 
 type Friend = {
   id: number;
@@ -78,43 +79,48 @@ export default function FriendsOfFanClub() {
   }, []);
 
   return (
-    <div>
+    <section className={styles.friends}>
       <h2 className="section-title">Friends of the Fan Club</h2>
 
       {loading ? (
         <p className="sub">Loading friends…</p>
       ) : (
-        <div className="grid">
+        <div className={styles.grid}>
           {items.map((f) => (
-            <div key={f.id} className="card">
-              {f.photo_url ? (
-                <img
-                  src={f.photo_url}
-                  alt={f.name}
-                  style={{ width: '100%', borderRadius: 12, marginBottom: 10 }}
-                />
-              ) : null}
+            <article key={f.id} className={styles.card}>
+              <div className={`${styles.media} ${f.photo_url ? '' : styles.mediaBare}`}>
+                {f.photo_url ? (
+                  <img className={styles.logoImg} src={f.photo_url} alt={f.name} />
+                ) : (
+                  <span aria-hidden="true">Partner</span>
+                )}
+              </div>
 
-              <strong>{f.name}</strong>
-              <div className="sub" style={{ marginTop: 6 }}>{f.blurb || f.kind}</div>
+              <div className={styles.cardBody}>
+                <p className={styles.kind}>{f.kind}</p>
+                <h3 className={styles.name}>{f.name}</h3>
+                <p className={styles.blurb}>{f.blurb || `Learn more about our ${f.kind.toLowerCase()} community.`}</p>
+              </div>
 
-              {f.url ? (
-                <div style={{ marginTop: 10 }}>
+              <div className={styles.cta}>
+                {f.url ? (
                   <a
-                    className="link"
+                    className={styles.ctaLink}
                     href={f.url}
                     target="_blank"
                     rel="noopener noreferrer"
                     referrerPolicy="no-referrer"
                   >
-                    Visit
+                    Visit {f.name}
                   </a>
-                </div>
-              ) : null}
-            </div>
+                ) : (
+                  <span className={styles.ctaMuted}>Link coming soon</span>
+                )}
+              </div>
+            </article>
           ))}
         </div>
       )}
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/600

T15 + T16 implementation complete. Calendar UI and Friends tiles updated per scope. Verified build + lint pass in Codespaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the homepage calendar with a selectable month grid and refreshed the Friends section into responsive cards. Meets T15 (calendar integrity) and T16 (friends tile stability) exit criteria.

- **New Features**
  - Calendar now shows a compact month grid with event-day buttons and a details panel.
  - Powered by `GET /api/events/next?limit=10`; selects the first event day and only navigates across months that have events.
  - Seeded fallback adds typical club programming when the API is empty or errors.

- **Refactors**
  - Friends tiles rebuilt as CSS-module cards (media, kind, name, blurb, CTA) in a 1/2/3‑column grid.
  - Preserves fetch flow, timeout fallback, default partners, and safe new‑tab links.
  - Updated `docs/ops/trackers` to close T15 and T16 and added a thread log entry.

<sup>Written for commit b291bcbd84e7f1478744a1ebc564bac81c764f2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

