### PR TITLE
website: close T18 FAQ / Ask preview wiring

### DIFF
--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import Link from "next/link";
-import { apiGet, apiPost } from "@/lib/api";
+import { apiGet } from "@/lib/api";
 
 type FAQItem = {
   id: number;
@@ -13,29 +13,80 @@ type FAQItem = {
   updated_at: string;
 };
 
+function answerPreview(text: string, max = 150): string {
+  const t = text.replace(/\s+/g, " ").trim();
+  if (t.length <= max) return t;
+  return `${t.slice(0, max).trimEnd()}…`;
+}
+
+const cardStyle: CSSProperties = {
+  borderRadius: "var(--lgfc-radius-md)",
+  boxShadow: "var(--shadow)",
+  padding: "1.25rem",
+  background: "var(--lgfc-bg-card)",
+  border: "1px solid var(--lgfc-border-light)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.65rem",
+  minHeight: 0,
+};
+
+const gridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 280px), 1fr))",
+  gap: "1.25rem",
+  marginTop: "1rem",
+};
+
+const ctaRowStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "12px",
+  justifyContent: "center",
+  alignItems: "center",
+  marginTop: "var(--rhythm-md)",
+};
+
+const ctaPrimary: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "10px 20px",
+  borderRadius: "var(--lgfc-radius-pill)",
+  fontWeight: 700,
+  textDecoration: "none",
+  background: "var(--lgfc-blue)",
+  color: "#fff",
+  border: "2px solid var(--lgfc-blue)",
+};
+
+const ctaSecondary: CSSProperties = {
+  ...ctaPrimary,
+  background: "var(--lgfc-bg-card)",
+  color: "var(--lgfc-blue)",
+  border: "2px solid var(--lgfc-blue)",
+};
+
 export default function FAQSection() {
   const [items, setItems] = useState<FAQItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [q, setQ] = useState("");
-  const [expandedId, setExpandedId] = useState<number | null>(null);
 
   const query = useMemo(() => q.trim(), [q]);
 
   useEffect(() => {
     let alive = true;
     let completed = false;
-    
+
     const timer = setTimeout(() => {
       if (alive && !completed) {
         setLoading(false);
         setItems([]);
       }
-    }, 10000); // 10 second timeout
-    
+    }, 10000);
+
     (async () => {
       try {
-        // When search is empty, show Top 5 FAQs
-        // When search has text, show up to 10 matching FAQs
         const limit = query ? 10 : 5;
         const data = await apiGet<{ ok: boolean; items: FAQItem[] }>(
           `/api/faq/list?limit=${limit}${query ? `&q=${encodeURIComponent(query)}` : ""}`
@@ -56,25 +107,10 @@ export default function FAQSection() {
     };
   }, [query]);
 
-  const handleItemClick = async (id: number) => {
-    // Toggle expansion
-    const newExpandedId = expandedId === id ? null : id;
-    setExpandedId(newExpandedId);
-    
-    // If expanding (not collapsing), increment view count
-    if (newExpandedId === id) {
-      try {
-        await apiPost("/api/faq/view", { id });
-      } catch {
-        // Silently fail - view count is not critical
-      }
-    }
-  };
-
   return (
     <div>
       <h2 className="section-title">FAQ – Frequently Asked Questions</h2>
-      <p className="sub">
+      <p className="sub" style={{ textAlign: "center", maxWidth: "40rem", marginLeft: "auto", marginRight: "auto" }}>
         Search our FAQ or browse the top questions below.
       </p>
 
@@ -88,41 +124,54 @@ export default function FAQSection() {
             value={q}
             onChange={(e) => setQ(e.target.value)}
           />
-          <button id="faqClear" onClick={() => setQ("")}>Clear</button>
+          <button type="button" id="faqClear" onClick={() => setQ("")}>
+            Clear
+          </button>
         </div>
 
         <div id="faqList">
           {loading ? (
-            <p className="sub">Loading FAQ…</p>
+            <p className="sub" style={{ marginBottom: 0 }}>
+              Loading FAQ…
+            </p>
           ) : items.length === 0 ? (
-            <p className="sub">No matching FAQ answers found.</p>
+            <p className="sub" style={{ marginBottom: 0 }}>
+              No matching FAQ answers found.
+            </p>
           ) : (
-            items.map((item) => (
-              <div key={item.id} className="q" style={{ cursor: 'pointer' }} onClick={() => handleItemClick(item.id)}>
-                <strong>{item.question}</strong>
-                {expandedId === item.id && (
-                  <>
-                    <br />
-                    <span className="sub">{item.answer}</span>
-                  </>
-                )}
-              </div>
-            ))
+            <div style={gridStyle}>
+              {items.map((item) => (
+                <article key={item.id} style={cardStyle}>
+                  <h3 style={{ margin: 0, fontSize: "var(--lgfc-font-size-h3)", fontWeight: 700, color: "var(--lgfc-text-main)", lineHeight: 1.35 }}>
+                    {item.question}
+                  </h3>
+                  <p className="sub" style={{ margin: 0, flex: 1, fontSize: "0.95rem", lineHeight: 1.5 }}>
+                    {answerPreview(item.answer)}
+                  </p>
+                  <div style={{ marginTop: "auto", paddingTop: "0.25rem" }}>
+                    <Link href="/faq" className="link" style={{ fontWeight: 600 }}>
+                      Read full answer in FAQ →
+                    </Link>
+                  </div>
+                </article>
+              ))}
+            </div>
           )}
         </div>
 
-        {query && items.length > 0 && (
-          <p className="sub" style={{ marginTop: 16 }}>
-            <Link className="link" href={`/faq?q=${encodeURIComponent(query)}`}>View all results</Link>
+        {query && items.length > 0 ? (
+          <p className="sub" style={{ marginTop: "1.25rem", marginBottom: 0, textAlign: "center" }}>
+            <Link className="link" href={`/faq?q=${encodeURIComponent(query)}`}>
+              View all results on the FAQ page
+            </Link>
           </p>
-        )}
+        ) : null}
 
-        <div style={{ marginTop: 18, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-          <Link href="/faq" className="link" style={{ fontSize: 16 }}>
-            View all FAQs
+        <div style={ctaRowStyle}>
+          <Link href="/faq" style={ctaPrimary}>
+            View All Questions
           </Link>
-          <span className="sub">•</span>
-          <Link href="/ask" className="link" style={{ fontSize: 16 }}>
+          <Link href="/ask" style={ctaSecondary}>
             Ask a Question
           </Link>
         </div>


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/610

### PR Template

#### Reference
Refer to `/.github/pull_request_template.md` for required structure and change conventions.

#### Governance Reference
Follow operational, rollback, and testing standards in `/docs/governance/PR_GOVERNANCE.md`.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] OR any ZIP file that was present in the repo root was deleted before any other change
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Homepage
- Task: T18 — FAQ / Ask preview wiring
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes: NO

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- [x] I reviewed the locked design docs before making changes
- [x] I followed the canonical route, header, footer, and page behavior requirements
- [x] No conflicting legacy doc was used as authority

## FILE-TOUCH ALLOWLIST (MANDATORY)
- [x] Changes are limited to the approved task scope
- [x] No unrelated files were modified
- [x] No config, workflow, or dependency drift was introduced

## CHANGE SUMMARY
- updated homepage FAQ preview to render as responsive cards
- kept homepage FAQ section preview-only
- preserved CTA links to /faq and /ask
- verified /faq and /ask routes exist and are wired correctly

## VALIDATION
- [x] Local build completed
- [x] Manual review completed
- [x] No unrelated regressions observed

## ROLLBACK
- Revert branch `website/t18-faq-preview` if regression is found.

## FINAL REVIEW CHECK
- [x] Branch name matches task scope
- [x] PR title matches task scope
- [x] Diff is limited to intended files
- [x] Ready for reviewer validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements T18: wires the homepage FAQ/Ask preview by replacing the old accordion with a responsive card grid that shows top FAQs, supports search, and routes users to `/faq` and `/ask`. Keeps the section preview-only and confirms both routes are live.

- **New Features**
  - Card grid shows 5 top FAQs (10 when searching) with trimmed answers and a “Read full answer” link to `/faq`.
  - Search with Clear; adds “View all results on the FAQ page” when there are matches; improved loading/empty states.
  - CTA row: “View All Questions” → `/faq` and “Ask a Question” → `/ask`; removes expand/collapse and view-count POST to keep the preview simple.

<sup>Written for commit f564d124c48fda90749d4898af9ace7847a7898e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

