### PR TITLE
website: close T19 footer invariants lock

### DIFF
--- a/docs/as-built/cloudflare-frontend.md
+++ b/docs/as-built/cloudflare-frontend.md
@@ -156,22 +156,23 @@ Per `docs/reference/design/LGFC-Production-Design-and-Standards.md`:
 - Desktop/tablet: Does not include "Home"
 - Mobile: Includes "Home" for easy navigation
 
-**Footer:**
+**Footer:** (per `/docs/reference/design/LGFC-Production-Design-and-Standards.md`)
 - Left:
   - Quote fetched from `/api/footer-quote` (D1-backed)
   - Quote may include Lou Gehrig quotes or quotes about Lou Gehrig
   - Dynamic display, not hardcoded page text
+  - Copyright line: `© {new Date().getFullYear()} Lou Gehrig Fan Club`
 - Center:
   - LG logo button
   - Behavior: scroll to top of current page
-- Right:
-  - Row 1: Terms (`/terms`), Privacy (`/privacy`)
-  - Row 2: Contact (`/contact`)
-- Copyright:
-  - `© {new Date().getFullYear()} Lou Gehrig Fan Club`
+- Right (order fixed):
+  - Privacy (`/privacy`)
+  - Terms (`/terms`)
+  - Contact (`/contact`)
+  - Contact — `mailto:` Support (`Support@LouGehrigFanClub.com`, aligned with contact page)
+  - Admin (`/admin`) — only when `useMemberSession()` reports `role === 'admin'`
 - Constraints:
-  - No Admin link in footer
-  - No visible email or mailto link
+  - No extra footer links beyond the locked set
   - Footer links remain footer-only and are not duplicated into the hamburger menu
 
 ### Styling

--- a/docs/governance/PR_GOVERNANCE.md
+++ b/docs/governance/PR_GOVERNANCE.md
@@ -70,25 +70,23 @@ This requirement applies to changes affecting:
 
 ### Footer Design Enforcement
 All footer changes must preserve the authoritative footer design defined by:
-- `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
+- `/docs/reference/design/LGFC-Production-Design-and-Standards.md` (canonical link order and behavior)
 - `/docs/NAVIGATION-INVARIANTS.md`
-- `/docs/reference/design/reference/lgfc-homepage-legacy-v6.html`
+- `/docs/reference/design/reference/lgfc-homepage-legacy-v6.html` (layout reference only where it does not contradict the locked design doc)
 - `/docs/as-built/cloudflare-frontend.md`
 
 Required footer invariants:
-- Left: rotating D1-backed quote + dynamic-year copyright
-- Center: LG logo scroll-to-top affordance
-- Right: row 1 = Terms, Privacy; row 2 = Contact
-- No Admin link
-- No visible email or mailto link
-- No extra footer links
+- Left: rotating D1-backed quote (via `/api/footer-quote`) + dynamic-year copyright
+- Center: LG logo scroll-to-top affordance (not route navigation)
+- Right: link order exactly **Privacy**, **Terms**, **Contact** (`/contact`), **Contact** (`mailto:` club support — same address family as `/src/app/contact/page.tsx`), **Admin** (only when member session role is `admin`, via `useMemberSession`)
+- No extra footer links beyond the locked set
 
 Footer-specific rejection conditions:
-- Terms/Privacy order changed
-- Contact moved into row 1 or removed
+- Privacy / Terms / Contact / mailto Contact / Admin (when admin) order or presence wrong relative to the locked design doc
+- Admin link shown without admin role, or hidden when role is admin
 - Logo changed from scroll-to-top to route navigation
-- Quote replaced with hardcoded static copy
-- Footer change made without updating `/docs/as-built/cloudflare-frontend.md`
+- Quote replaced with hardcoded static copy or `/api/footer-quote` fetch removed
+- Footer change made without updating `/docs/as-built/cloudflare-frontend.md` when behavior or link set changes
 
 ### Social Wall Drift & Regressions
 **Historical Context:**

--- a/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
+++ b/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
@@ -252,10 +252,13 @@ Scope: homepage FAQ preview section including Ask link.
 Exit: preview renders; routes to `/faq`; Ask link routes to `/ask`.
 
 ## T19 — Footer invariants lock
-Status: OPEN
+Status: CLOSED
+Date Closed: 2026-03-24
 Owner: Cursor
 Scope: footer only.
 Exit: footer matches locked design authority.
+Summary:
+Footer `Footer.tsx` aligned to LGFC-Production-Design-and-Standards.md: right column Privacy → Terms → Contact → mailto Contact (support) → Admin when session role is admin (`useMemberSession`). PR_GOVERNANCE and `cloudflare-frontend.md` updated to remove stale “no Admin / no mailto” rules that contradicted the locked design doc.
 
 ## T20 — Campaign Spotlight implementation
 Status: OPEN
@@ -387,6 +390,14 @@ Constraints:
 Design hierarchy and as-built configuration are now aligned with live production.
 
 T10 is confirmed complete after revalidation.
+
+---
+
+## UPDATE — T19 Footer invariants lock (2026-03-24)
+
+**Canonical footer (right column)** is defined solely by `/docs/reference/design/LGFC-Production-Design-and-Standards.md`: Privacy, Terms, Contact (`/contact`), Contact (`mailto` support), Admin (admin session only).
+
+Notes in this file that describe an older footer (e.g. Terms-before-Privacy, no mailto, no Admin) reflected stale tracker/governance text before T19; implementation and governance are aligned to the locked design doc as of T19 closeout.
 
 ---
 

--- a/docs/ops/trackers/THREAD-LOG_Master.md
+++ b/docs/ops/trackers/THREAD-LOG_Master.md
@@ -240,7 +240,6 @@ T15 and T16 closed per worklist exit criteria for calendar presentation/event vi
 ### Next Action
 Proceed with the next open homepage integrity task per `IMPLEMENTATION-WORKLIST_Master.md`.
 
-
 ## CLOSEOUT — T11 + T13 (Post-Merge Correction)
 - T11 (Hero Banner Integrity): CLOSED
   - Implementation verified and previously merged (PR #585)
@@ -251,3 +250,28 @@ Proceed with the next open homepage integrity task per `IMPLEMENTATION-WORKLIST_
 - Reason for entry:
   - Close status missing from THREAD-LOG despite successful merge and deployment
   - This entry corrects tracker completeness only (no code changes)
+
+------------------------------------------------------------------------
+
+## THREAD CLOSEOUT RECORD --- 2026-03-24 --- T19 Footer invariants lock
+
+### Starting State
+Footer implementation and repo docs (PR governance, as-built) described a footer that conflicted with the locked design authority in `/docs/reference/design/LGFC-Production-Design-and-Standards.md` (Privacy–Terms–Contact–mailto–Admin).
+
+### Objective
+Resolve the footer authority conflict by aligning `Footer.tsx` and stale documentation to the locked design doc; close T19.
+
+### Work Performed
+- Updated `src/components/Footer.tsx`: preserved rotating `/api/footer-quote`, dynamic year, center logo scroll-to-top; right-side links ordered Privacy, Terms, Contact (`/contact`), Contact (`mailto:Support@LouGehrigFanClub.com`), Admin when `useMemberSession()` role is `admin` (no new auth helpers).
+- Reconciled `docs/governance/PR_GOVERNANCE.md` footer enforcement to match the locked design doc (removed contradictions such as mandatory "no Admin" / "no mailto").
+- Reconciled `docs/as-built/cloudflare-frontend.md` footer section to the same canonical link order and behaviors.
+- Marked T19 CLOSED in `IMPLEMENTATION-WORKLIST_Master.md` with an append-style note clarifying superseded older footer wording elsewhere in the tracker.
+
+### Result
+Footer authority conflict resolved: implementation + docs match LGFC-Production-Design-and-Standards.md. T19 closed.
+
+### Next Action
+Proceed per `IMPLEMENTATION-WORKLIST_Master.md` (e.g. next open Phase 2 task).
+
+------------------------------------------------------------------------
+

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,9 @@
 
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { useMemberSession } from '@/hooks/useMemberSession';
+
+const SUPPORT_EMAIL = 'Support@LouGehrigFanClub.com';
 
 type Quote = { quote: string; source?: string };
 
@@ -14,7 +17,9 @@ function asString(v: unknown): string | undefined {
 }
 
 export default function Footer() {
+  const { role, isLoading } = useMemberSession();
   const [q, setQ] = useState<Quote | null>(null);
+  const showAdmin = !isLoading && role === 'admin';
 
   useEffect(() => {
     let cancelled = false;
@@ -93,19 +98,22 @@ export default function Footer() {
             flex: '1 1 260px',
             minWidth: 220,
             display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'flex-end',
-            gap: 8,
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            justifyContent: 'flex-end',
+            gap: 14,
             fontSize: 12,
           }}
         >
-          <div style={{ display: 'flex', gap: 14 }}>
-            <Link href="/terms">Terms</Link>
-            <Link href="/privacy">Privacy</Link>
-          </div>
-          <div>
-            <Link href="/contact">Contact</Link>
-          </div>
+          <Link href="/privacy">Privacy</Link>
+          <Link href="/terms">Terms</Link>
+          <Link href="/contact" aria-label="Contact (club contact page)">
+            Contact
+          </Link>
+          <a href={`mailto:${SUPPORT_EMAIL}`} aria-label={`Contact by email (${SUPPORT_EMAIL})`}>
+            Contact
+          </a>
+          {showAdmin ? <Link href="/admin">Admin</Link> : null}
         </nav>
       </div>
     </footer>


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/612

### PR Template

#### Reference
Refer to `/.github/pull_request_template.md` for required structure and change conventions.

#### Governance Reference
Follow operational, rollback, and testing standards in `/docs/governance/PR_GOVERNANCE.md`.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [ ] No ZIP file exists in the repo root
- [ ] OR any ZIP file that was present in the repo root was deleted before any other change
- [ ] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Homepage
- Task: T19 — Footer invariants lock
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Confirmed: YES

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
Authority:
- `/docs/reference/design/LGFC-Production-Design-and-Standards.md`

## WHAT THIS PR DOES
- Aligns footer implementation to locked design authority
- Adds required links in correct order:
  Privacy → Terms → Contact → Contact (mailto) → Admin (admin only)
- Preserves quote, dynamic year, scroll-to-top logo
- Reconciles stale governance/as-built/tracker docs

## OUT OF SCOPE
Everything outside footer

## FILE-TOUCH ALLOWLIST
- `src/components/Footer.tsx`
- `docs/governance/PR_GOVERNANCE.md`
- `docs/as-built/cloudflare-frontend.md`
- `docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
- `docs/ops/trackers/THREAD-LOG_Master.md`

## VALIDATION
- Footer renders correct order
- Admin link conditional
- Quote + logo behavior intact
- No unrelated file drift

## ROLLBACK
Revert PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the website footer to the locked design spec. Fixes link order, adds a conditional Admin link, and updates docs to resolve conflicts with the source of truth.

- New Features
  - Right-side links now exactly: Privacy (`/privacy`), Terms (`/terms`), Contact (`/contact`), Contact (mailto `Support@LouGehrigFanClub.com`), Admin (`/admin` when `useMemberSession().role === 'admin'`).
  - Preserves rotating quote from `/api/footer-quote`, dynamic year, and center logo scroll-to-top.
  - Updates `docs/governance/PR_GOVERNANCE.md` and `docs/as-built/cloudflare-frontend.md`; tracker entries mark T19 closed and remove stale “no Admin/no mailto” rules.

<sup>Written for commit 73acd8302b33532e320c62ef4e5accfa952eb8b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

