### PR TITLE
docs: close T18 FAQ preview wiring

### DIFF
--- a/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
+++ b/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
@@ -246,7 +246,9 @@ Summary:
 Calendar section satisfies homepage event visibility requirement.
 
 ## T18 — FAQ / Ask preview wiring
-Status: OPEN
+Status: CLOSED
+Date Closed: 2026-03-24
+Summary: Homepage FAQ preview cards implemented; /faq and /ask validated; PR #609.
 Owner: Cursor
 Scope: homepage FAQ preview section including Ask link.
 Exit: preview renders; routes to `/faq`; Ask link routes to `/ask`.


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/614

Close T18 in the implementation worklist after successful implementation and merge of PR #609.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes T18 — FAQ/Ask preview wiring in the implementation worklist to reflect the shipped homepage FAQ preview and validated `/faq` and `/ask` routes. Adds a close date and brief summary referencing PR #609 in `docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`.

<sup>Written for commit 81a9623d54b32c03a49738c534384a167418a2ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->