### PR TITLE
fix: stabilize T14 social wall widget initialization

### DIFF
--- a/src/components/SocialWall.tsx
+++ b/src/components/SocialWall.tsx
@@ -1,79 +1,48 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import styles from './social-wall.module.css';
 
-const PLATFORM_JS = 'https://elfsightcdn.com/platform.js';
-const ELFSIGHT_WIDGET_CLASS = 'elfsight-app-805f3c5c-67cd-4edf-bde6-2d5978e386a8';
+const PLATFORM_SRC = 'https://elfsightcdn.com/platform.js';
+const WIDGET_ID = 'elfsight-app-805f3c5c-67cd-4edf-bde6-2d5978e386a8';
 
-function nudgeResize() {
-  try {
-    window.dispatchEvent(new Event('resize'));
-  } catch {
-    // no-op
-  }
-}
-
-function scheduleResizeSequence(timers: number[]) {
-  nudgeResize();
-  for (const ms of [500, 1500, 3000]) {
-    timers.push(window.setTimeout(nudgeResize, ms));
+declare global {
+  interface Window {
+    elfsight?: {
+      reload?: () => void;
+    };
   }
 }
 
 export default function SocialWall() {
-  const [mounted, setMounted] = useState(false);
-
   useEffect(() => {
-    setMounted(true);
-  }, []);
+    const existingScript = document.querySelector<HTMLScriptElement>(
+      `script[src="${PLATFORM_SRC}"]`
+    );
 
-  useEffect(() => {
-    if (!mounted) return;
+    const init = () => {
+      window.elfsight?.reload?.();
+    };
 
-    let cancelled = false;
-    const timers: number[] = [];
-
-    const existing = document.querySelector<HTMLScriptElement>(`script[src="${PLATFORM_JS}"]`);
-
-    if (existing) {
-      scheduleResizeSequence(timers);
-      return () => {
-        cancelled = true;
-        timers.forEach((t) => window.clearTimeout(t));
-      };
+    if (!existingScript) {
+      const script = document.createElement('script');
+      script.src = PLATFORM_SRC;
+      script.async = true;
+      script.onload = init;
+      document.body.appendChild(script);
+    } else {
+      init();
     }
-
-    const script = document.createElement('script');
-    script.src = PLATFORM_JS;
-    script.async = true;
-    script.onload = () => {
-      if (cancelled) return;
-      scheduleResizeSequence(timers);
-    };
-    document.body.appendChild(script);
-
-    return () => {
-      cancelled = true;
-      timers.forEach((t) => window.clearTimeout(t));
-    };
-  }, [mounted]);
+  }, []);
 
   return (
     <section id="social-wall" className={styles.section}>
       <div className={styles.container}>
         <h2 className={styles.sectionTitle}>Social Wall</h2>
         <p className={styles.subtitle}>Live fan posts from Facebook.</p>
-
         <div className={styles.embed}>
           <p className={styles.fallback}>Loading social wall content...</p>
-          {mounted ? (
-            <div
-              key={`elfsight-${mounted ? 'ready' : 'idle'}`}
-              className={ELFSIGHT_WIDGET_CLASS}
-              data-elfsight-app-lazy
-            />
-          ) : null}
+          <div className={WIDGET_ID} data-elfsight-app-lazy />
         </div>
       </div>
     </section>


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/616

### PR Template

#### Reference
Refer to `/.github/pull_request_template.md` for required structure and change conventions.

#### Governance Reference
Follow operational, rollback, and testing standards in `/docs/governance/PR_GOVERNANCE.md`.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] OR any ZIP file that was present in the repo root was deleted before any other change
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Homepage
- Task: T14 — Social Wall stability fix
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes: NO

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- [x] I reviewed the locked design docs before making changes
- [x] I followed the canonical route, header, footer, and page behavior requirements
- [x] No conflicting legacy doc was used as authority

## FILE-TOUCH ALLOWLIST (MANDATORY)
- [x] Changes are limited to the approved task scope
- [x] No unrelated files were modified
- [x] No config, workflow, or dependency drift was introduced

## CHANGE SUMMARY
- stabilizes Elfsight platform script loading in `src/components/SocialWall.tsx`
- avoids duplicate script injection
- calls widget reload on client when script is already present
- keeps section heading, subtitle, fallback text, and widget container structure intact

## VALIDATION
- [x] Branch contains a real diff against `main`
- [ ] Runtime verification pending PR checks / deployed validation

## ROLLBACK
- Revert branch `website/t14-social-wall-fix` if regression is found.

## FINAL REVIEW CHECK
- [x] Branch name matches task scope
- [x] PR title matches task scope
- [x] Diff is limited to intended files
- [x] Ready for reviewer validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the homepage Social Wall by preventing duplicate Elfsight script loads and reloading the widget when the script is already present. Addresses T14 by ensuring reliable widget initialization without layout jitter.

- **Bug Fixes**
  - Detects existing `https://elfsightcdn.com/platform.js` before injecting to avoid duplicates.
  - Calls `window.elfsight.reload()` if the platform script is already loaded.
  - Removes unnecessary mount state; keeps heading, subtitle, fallback, and widget container intact.
  - Renders the widget container with `data-elfsight-app-lazy` consistently.

<sup>Written for commit 0912fee450040a0508309f6abb5f8c15ec3e7717. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

