### PR TITLE
MEDIA-02 image read API

### DIFF
--- a/docs/ops/tasks/MEDIA-02.md
+++ b/docs/ops/tasks/MEDIA-02.md
@@ -1,16 +1,19 @@
+---
 Doc Type: Task
 Audience: Internal
 Authority Level: Working
 Owns: MEDIA-02 implementation scope
 Does Not Own: API implementation, UI, styling
 Canonical Reference: docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
-Last Reviewed: 2026-03-25# MEDIA-02 — Image read API
+Last Reviewed: 2026-03-25
+---
+
+# MEDIA-02 — Image read API
 
 Objective: expose indexed images from D1 for frontend consumption.
 
 Scope:
 - create API route or shared util to fetch images
-- 
 - support limit and simple filtering
 - return normalized image fields needed by homepage and fanclub consumers
 


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/626

Expose indexed images from D1.

Cursor:
- build image read util or endpoint
- support limit/filter
- no UI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the MEDIA-02 task definition for the Image Read API to expose indexed images from D1 for frontend use. Clarifies scope (API route or shared util with limit/filter and normalized fields), constraints (no UI/styling), and exit criteria.

- **Bug Fixes**
  - Corrected frontmatter header fence in `MEDIA-02` documentation.

<sup>Written for commit a19041ad525bd8682a6a690e447015ee16844fc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

