### PR TITLE
website: T30 fanclub shell + auth gate

### DIFF
--- a/docs/ops/tasks/T30-A-B.md
+++ b/docs/ops/tasks/T30-A-B.md
@@ -1,3 +1,13 @@
+---
+Doc Type: Task
+Audience: Human + AI
+Authority Level: Operational
+Owns: Task definition for T30-A/B FanClub shell and auth gate
+Does Not Own: Design authority, auth implementation logic
+Canonical Reference: /docs/ops/tasks/T30-A-B.md
+Last Reviewed: 2026-03-25
+---
+
 # T30-A/B — FanClub shell + auth gate
 
 Objective: create launch-safe FanClub home shell backed by existing auth gating.


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/628

T30-A/B

Cursor:
- create /fanclub page shell
- enforce auth redirect
- no chat/profile implementation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ops task doc for T30 FanClub home shell and auth gate, including metadata and objective. Defines scope and exit criteria: build a basic `/fanclub` page for signed-in users, enforce existing auth redirect, and exclude chat and profile editing.

<sup>Written for commit a2c5922f20c2410929238e94669183590955d13c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

