### PR TITLE
website: T20-C leaderboard sorting

### DIFF
--- a/docs/ops/tasks/T20-C.md
+++ b/docs/ops/tasks/T20-C.md
@@ -1,10 +1,25 @@
+---
+Doc Type: Task Definition
+Audience: Human + AI
+Authority Level: Task Control
+Owns: T20-C leaderboard sorting task scope and exit criteria
+Does Not Own: Fundraiser design authority, implementation details, production behavior outside this task
+Canonical Reference: /docs/reference/design/LGFC-Production-Design-and-Standards.md
+Last Reviewed: 2026-03-25
+---
+
 # T20-C — Leaderboard sorting
 
-Objective: implement deterministic ranking.
+## Objective
+Implement deterministic leaderboard ranking for fundraiser results.
 
-Scope:
-- sort by points, donor_count, total_amount
-- ensure no ties in output order
+## Scope
+- sort by points (descending)
+- then donor_count (descending)
+- then total_amount (descending)
+- enforce stable deterministic ordering
 
-Exit:
-- stable ranked list
+## Exit Criteria
+- no ambiguous ties in output
+- identical inputs always produce identical ordering
+- ordering is consistent across environments


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/646

T20-C

Cursor:
- sort fundraiser data
- enforce deterministic order

- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/646

### PR Template

#### Reference
Refer to `/.github/pull_request_template.md`

#### Governance Reference
Follow `/docs/governance/PR_GOVERNANCE.md`

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root

## PROGRESS + READINESS
- Phase: Fundraiser / T20
- Task: T20-C — leaderboard sorting
- Status: DRAFT
- Scope Confirmed: YES

## CHANGE SUMMARY
Define deterministic leaderboard sorting rules for fundraiser ranking.

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- `/docs/reference/design/LGFC-Production-Design-and-Standards.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)

Allowed files:
- docs/ops/tasks/T20-C.md

## VISUAL / UX INVARIANTS (MANDATORY)
- No UI changes
- No route changes
- No layout changes
- Documentation-only PR

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] Only allowed file modified
- [x] No ZIP file added
- [x] No application code changed

## TEST PLAN
- Confirm only T20-C.md changed

## ROLLBACK
Revert PR





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the T20-C task spec with required docs header for deterministic leaderboard sorting: points, then donor_count, then total_amount; stable ordering, no ties, clear exit criteria.

<sup>Written for commit 25370ba0768c4fdc66a73afcb810b6c22560df2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

