### PR TITLE
website: T20-D pennant race rules

### DIFF
--- a/docs/ops/tasks/T20-D.md
+++ b/docs/ops/tasks/T20-D.md
@@ -1,11 +1,27 @@
+---
+Doc Type: Task Definition
+Audience: Human + AI
+Authority Level: Task Control
+Owns: T20-D pennant race winner-resolution task scope and exit criteria
+Does Not Own: Fundraiser design authority, implementation details, production behavior outside this task
+Canonical Reference: /docs/reference/design/LGFC-Production-Design-and-Standards.md
+Last Reviewed: 2026-03-25
+---
+
 # T20-D — Pennant race rules
 
-Objective: enforce winner resolution rules.
+## Objective
+Implement winner-resolution rules for pennant race results.
 
-Scope:
-- determine points winner
-- remove winner from other categories
-- determine donors and amount winners
+## Scope
+- determine the points winner first
+- remove the points winner from the remaining categories
+- determine the most donors winner from remaining eligible entries
+- remove the most donors winner from the remaining category
+- determine the most funds winner from remaining eligible entries
+- enforce unique winners across all categories
 
-Exit:
-- unique winners across categories
+## Exit Criteria
+- points winner is resolved first
+- no entry can win more than one category
+- final output always returns unique winners across categories


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/648

T20-D

Cursor:
- implement winner resolution
- enforce unique winners

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the T20-D task definition for pennant race rules with the required header and finalized scope and exit criteria. Documents the winner order (points first, then most donors, then most funds) and enforces unique winners by removing prior winners from the remaining categories.

<sup>Written for commit f8bb72a08c7c0ef3a26b28e6598e487d88419369. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

