### PR TITLE
website: T20-E data access layer

### DIFF
--- a/docs/ops/tasks/T20-E.md
+++ b/docs/ops/tasks/T20-E.md
@@ -1,3 +1,13 @@
+---
+Doc Type: Task
+Audience: Human + AI
+Authority Level: Operational
+Owns: Task definition for T30-A/B FanClub shell and auth gate
+Does Not Own: Design authority, auth implementation logic
+Canonical Reference: /docs/ops/tasks/T30-A-B.md
+Last Reviewed: 2026-03-25
+---
+
 # T20-E — Data access layer
 
 Objective: expose fundraiser data to frontend.


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/650

T20-E

Cursor:
- create getFundraiserData util
- return ranked teams, winners, totals, timestamp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the T20‑E ops task doc with task metadata and objective for the fundraiser data access layer, defining a getFundraiserData util that returns ranked teams, winners, totals, and a timestamp for the frontend.

<sup>Written for commit b1d59c32f409b7a0b27ae66c862a217d7874f5b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

