### PR TITLE
website: T20-J full leaderboard UI

### DIFF
--- a/docs/ops/tasks/T20-J.md
+++ b/docs/ops/tasks/T20-J.md
@@ -1,3 +1,13 @@
+---
+Doc Type: Task
+Audience: Human + AI
+Authority Level: Operational
+Owns: Task definition for T30-A/B FanClub shell and auth gate
+Does Not Own: Design authority, auth implementation logic
+Canonical Reference: /docs/ops/tasks/T30-A-B.md
+Last Reviewed: 2026-03-25
+---
+
 # T20-J — Full leaderboard UI
 
 Objective: render full fundraiser leaderboard.


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/674

T20-J

Cursor:
- render full leaderboard
- show rank, stats
- highlight winners

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added T20-J task documentation with metadata. Defines the full fundraiser leaderboard UI: list all teams, show rank, amount raised, donors, points, and highlight winners.

<sup>Written for commit bda7b1238348cebd4c875552996bbbaaf9aa903c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

