### PR TITLE
website: T20-L timestamp integrity

### DIFF
--- a/docs/ops/tasks/T20-L.md
+++ b/docs/ops/tasks/T20-L.md
@@ -1,3 +1,14 @@
+---
+Doc Type: Task
+Audience: Human + AI
+Authority Level: Operational
+Owns: Task definition for T30-A/B FanClub shell and auth gate
+Does Not Own: Design authority, auth implementation logic
+Canonical Reference: /docs/ops/tasks/T30-A-B.md
+Last Reviewed: 2026-03-25
+---
+
+
 # T20-L — Timestamp integrity
 
 Objective: display data freshness.


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/678

T20-L

Cursor:
- display timestamp
- use fundraiser data timestamp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the T20-L task doc to specify showing an “as of” timestamp in the website UI, sourced from fundraiser data to signal data freshness. Includes scope and exit criteria, plus task metadata and a last reviewed date.

<sup>Written for commit 038b39a274b6bf50e6ae510028057b4e9bd8f96e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

