### PR TITLE
Fix media route contract for weekly matchup photo reads

### DIFF
--- a/functions/api/matchup/current.ts
+++ b/functions/api/matchup/current.ts
@@ -10,7 +10,7 @@ function isUsablePhoto(item: any): item is PhotoItem {
 }
 
 async function readPhotoById(request: Request, id: number): Promise<PhotoItem | null> {
-  const endpoint = new URL(`/api/photos/get/${id}`, request.url);
+  const endpoint = new URL(`/api/photos/get?id=${id}`, request.url);
   const resp = await fetch(endpoint.toString(), { method: "GET" });
   if (!resp.ok) return null;
   const json = await resp.json().catch(() => null);

--- a/functions/api/photos/get.ts
+++ b/functions/api/photos/get.ts
@@ -1,8 +1,11 @@
 export const onRequestGet = async (context: any): Promise<Response> => {
-  const { env, params } = context;
+  const { env, params, request } = context;
 
   try {
-    const id = Number((params as any)?.id);
+    const url = new URL(request.url);
+    const paramsId = Number((params as any)?.id);
+    const queryId = Number(url.searchParams.get("id"));
+    const id = !Number.isNaN(paramsId) && paramsId > 0 ? paramsId : queryId;
     if (!id || Number.isNaN(id)) {
       return new Response(JSON.stringify({ ok: false, error: "Invalid id" }, null, 2), {
         status: 400,

--- a/functions/api/photos/list.ts
+++ b/functions/api/photos/list.ts
@@ -14,7 +14,7 @@ export const onRequestGet = async (context: any): Promise<Response> => {
       sql += " WHERE is_memorabilia = 1";
     }
 
-    sql += " ORDER BY id ASC LIMIT ? OFFSET ?;";
+    sql += " ORDER BY id DESC LIMIT ? OFFSET ?;";
     args.push(limit, offset);
 
     const rows = await env.DB.prepare(sql).bind(...args).all();


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/696

### Motivation
- Restore homepage weekly matchup images by fixing a route contract mismatch between the matchup code and the photo GET handler.
- Ensure the photo GET handler accepts both path and query styles so callers using either contract continue to work.
- Improve fallback quality by returning newest photos first from the list endpoint.

### Description
- Changed matchup photo fetch to call `/api/photos/get?id=<id>` instead of the path-style `/api/photos/get/<id>` in `functions/api/matchup/current.ts`.
- Updated `functions/api/photos/get.ts` to accept the ID from either `params.id` (path callers) or `query.id` (query-string callers) and pick a valid positive ID.
- Modified `functions/api/photos/list.ts` to use `ORDER BY id DESC` so the list fallback returns the newest photos first.
- No UI files or DB schema/migration changes were made; this is API/functions-only work.

### Testing
- Ran `npm run -s typecheck` which completed successfully.
- Ran `npm run -s test -- functions/api` which exited with code 1 because the filter matched no test files.
- Ran the full test suite with `npm run -s test` which passed (tests/homepage-structure.test.tsx: 10 tests passed) though existing React `act(...)` warnings were emitted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5146714608329803a6145585bfe3f)