### PR TITLE
Adjust FloatingLogo positioning, size, padding, and z-index

### DIFF
--- a/src/components/FloatingLogo.module.css
+++ b/src/components/FloatingLogo.module.css
@@ -1,12 +1,12 @@
 .wrap{
   position: fixed;
-  left: max(6px, env(safe-area-inset-left, 0px));
-  top: max(6px, env(safe-area-inset-top, 0px));
-  z-index: 70;
+  left: 0;
+  top: 0;
+  z-index: 60;
   background: transparent;
   border: 0;
   box-shadow: none;
-  padding: 0;
+  padding: 8px;
   pointer-events: none;
 }
 
@@ -19,9 +19,9 @@
 
 .img{
   display: block;
-  height: clamp(72px, 22vw, 110px);
+  height: clamp(120px, 28vw, 180px);
   width: auto;
-  max-width: min(160px, calc(100vw - 16px));
+  max-width: none;
   object-fit: contain;
   border-radius: 12px;
 }


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/698

### Motivation
- Make the floating logo larger and remove width clipping so the mark displays more prominently across viewports. 
- Anchor the logo to the exact top-left and add internal padding while lowering its stacking order to better integrate with surrounding UI.

### Description
- Change `.wrap` positioning from `left: max(... env(...))`/`top: max(... env(...))` to `left: 0` and `top: 0`, set `z-index: 60`, and add `padding: 8px` to provide consistent inset. 
- Increase `.img` sizing by replacing `height: clamp(72px, 22vw, 110px)` with `height: clamp(120px, 28vw, 180px)` and remove the previous `max-width` cap by setting `max-width: none`. 
- Preserve existing layout behavior for the link and image such as `object-fit: contain` and `border-radius: 12px` while removing redundant `padding: 0`.

### Testing
- Ran a production build with `yarn build`, which completed successfully. 
- Executed component unit tests with `yarn test`, and all tests passed. 
- Ran linting with `yarn lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50e2921408329999a5fb6f8c01b8b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the floating logo to the top-left with 8px padding, makes it larger, and lowers its z-index to fit the layout. Removes max-width clipping and updates height to clamp(120px, 28vw, 180px) for better visibility across viewports.

<sup>Written for commit eeefc77e3b5827b438cd73807afe9842d0d181c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

