### PR TITLE
PR-as-a-Ticket: Priority — Docs Header Guardrail Remediation

### DIFF
--- a/.github/copilot-tasks/priority-docs-header-guardrail-remediation.md
+++ b/.github/copilot-tasks/priority-docs-header-guardrail-remediation.md
@@ -1,0 +1,63 @@
+# Priority Copilot Task — Docs Header Guardrail Remediation
+
+## Priority
+High
+
+## Why this exists
+PR momentum is being blocked repeatedly because active markdown documents under `docs/**` fail the header guardrail.
+
+Current repository behavior fails PRs when required markdown header keys are missing, but the repository does not provide a complete enforcement + repair loop.
+
+## Problem statement
+The current workflow `/.github/workflows/docs-guardrails.yml` runs `./scripts/ci/docs_check_headers.sh .`, which only fails on missing headers.
+
+The current script `scripts/ci/docs_check_headers.sh` validates these required keys for active docs:
+- `Doc Type:`
+- `Audience:`
+- `Authority Level:`
+- `Owns:`
+- `Does Not Own:`
+- `Canonical Reference:`
+- `Last Reviewed:`
+
+This means the repo has a blocker, but no deterministic autofix path.
+
+## Required outcome
+Implement a deterministic docs-header workflow so missing headers stop being a chronic PR failure source.
+
+## Required scope
+1. Add one canonical markdown header template file under `docs/templates/`.
+2. Update `docs/ops/ai/AGENT-RULES.md` to require all agents to use the canonical markdown header template for active docs.
+3. Update `docs/ops/ai/CHATGPT-RULES.md` to require header compliance before ChatGPT opens PRs that touch `docs/**`.
+4. Add a deterministic autofix script, suggested path: `scripts/ci/docs_fix_headers.sh`.
+5. Update `/.github/workflows/docs-guardrails.yml` so the autofix step runs before header validation.
+6. Keep `scripts/ci/docs_check_headers.sh` as the blocking validator.
+
+## Guardrails
+- Do not remove the blocking validator.
+- Do not invent random metadata values.
+- Autofill only deterministic values.
+- If a missing field cannot be derived safely, fail loudly with a clear message.
+- Do not widen scope beyond docs header template + rules + workflow + script updates.
+
+## File-touch allowlist
+- `.github/workflows/docs-guardrails.yml`
+- `scripts/ci/docs_check_headers.sh`
+- `scripts/ci/docs_fix_headers.sh`
+- `docs/templates/markdown-header-template.md`
+- `docs/ops/ai/AGENT-RULES.md`
+- `docs/ops/ai/CHATGPT-RULES.md`
+
+## Implementation notes
+Preferred design:
+- template file becomes the single source for header structure
+- autofix inserts the missing header block only where that can be done deterministically
+- workflow order becomes: autofix -> validate -> remaining docs guardrails
+
+## Acceptance criteria
+- Repo contains a canonical docs header template.
+- Shared agent rules require use of that template.
+- ChatGPT rules require docs header compliance before PR creation for docs changes.
+- Docs guardrails workflow attempts deterministic header autofix before validation.
+- Validation still fails when required values remain unsafe or missing.
+- PRs stop failing for trivial missing-header cases that can be repaired automatically.


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/710

## PR-as-a-Ticket — Docs Header Guardrail Remediation

### Objective
Eliminate chronic PR failures caused by missing markdown headers in active docs.

### Problem
Docs guardrails workflow currently fails PRs for missing headers but does not provide a repair mechanism.

### Required Work (Copilot)
- Add canonical markdown header template under `docs/templates/`
- Enforce usage in `docs/ops/ai/AGENT-RULES.md`
- Enforce ChatGPT PR behavior in `docs/ops/ai/CHATGPT-RULES.md`
- Add `scripts/ci/docs_fix_headers.sh`
- Update `docs-guardrails.yml` to run autofix before validation
- Preserve `docs_check_headers.sh` as blocking validator

### File Scope (Allowlist)
- `.github/workflows/docs-guardrails.yml`
- `scripts/ci/docs_check_headers.sh`
- `scripts/ci/docs_fix_headers.sh`
- `docs/templates/markdown-header-template.md`
- `docs/ops/ai/AGENT-RULES.md`
- `docs/ops/ai/CHATGPT-RULES.md`

### Priority
High — this is currently the primary cause of PR gate failures.

### Execution
Assigned to Copilot Agent for implementation.

### Acceptance Criteria
- Header template exists
- Autofix runs before validation
- Docs PR failures due to missing headers are reduced
- Validation still blocks unsafe or incomplete headers

---

This PR is the execution contract. Copilot Agent should implement strictly within scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.github/copilot-tasks/priority-docs-header-guardrail-remediation.md` to define how we fix recurring docs header guardrail failures. The task scopes a canonical template, an autofix script that runs before validation, and rule updates, while keeping the validator blocking.

<sup>Written for commit aa633891e3abb3e247facae1176eb8a1d4284797. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

