### PR TITLE
docs: fix archive routes to match canonical fanclub design

### DIFF
--- a/docs/as-built/cloudflare-frontend.md
+++ b/docs/as-built/cloudflare-frontend.md
@@ -1,6 +1,6 @@
 # Cloudflare Frontend - As-Built Documentation
 
-**Last Updated:** 2026-01-20  
+**Last Updated:** 2026-03-27  
 **Status:** Active Development
 
 ## Overview
@@ -72,10 +72,11 @@ Sections are rendered in **exact spec order**:
 
 5. **Archives Tiles** (`ArchivesTiles.tsx`)
    - Three clickable tiles in responsive grid:
-     1. **Memorabilia Archive** → `/memorabilia`
-     2. **Photo Gallery** → `/photos`
-     3. **Library** → `/library`
+     1. **Memorabilia Archive** → `/fanclub/memorabilia`
+     2. **Photo Gallery** → `/fanclub/photo`
+     3. **Library** → `/fanclub/library`
    - Hover effects for visual feedback
+   - Public routes `/memorabilia`, `/photos`, `/photo`, and `/library` must not exist
 
 6. **Gehrig Timeline** (`GehrigTimeline.tsx`)
    - FanClub-focused timeline with 8 major life events
@@ -232,6 +233,10 @@ Per `/.github/pull_request_template.md` and `/docs/website-PR-governance.md`:
 See `/docs/admin/access-model.md` for complete admin architecture documentation.
 
 ### Change History
+
+**2026-03-27:** Documentation route correction
+- Updated FanClub Archives Tiles documentation to use canonical fanclub-only routes
+- Recorded that public archive routes must not exist
 
 **2026-01-28:** ZIP 41 (PR #457) - Admin Access Model
 - Added admin UI pages: `/admin`, `/admin/d1-test`, `/admin/cms`, `/admin/content`


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/762

### PR Template

### MANDATORY FIRST STEP (ZIP SAFETY)
- No ZIP found in repo root

### DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- /docs/reference/design/LGFC-Production-Design-and-Standards.md
- /docs/reference/design/fanclub.md

### CHANGE SUMMARY
- Fixed stale documentation referencing public routes (/library, /photos, /memorabilia)
- Updated Archives Tiles section to use canonical fanclub routes:
  - /fanclub/library
  - /fanclub/photo
  - /fanclub/memorabilia
- Explicitly documented that public archive routes must not exist

### DRIFT GATE ALIGNMENT
- Aligns as-built docs with canonical routing invariants
- Removes contradiction between implementation and design authority

### ACCEPTANCE CRITERIA
- No references to public archive routes remain
- Documentation reflects fanclub-only routing model

### SELF-CHECK
- No code changes
- Docs-only correction

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated as-built docs to use canonical fanclub-only archive routes and remove stale public route references in Archives Tiles. Clarifies that public archive routes (`/memorabilia`, `/photos`, `/photo`, `/library`) must not exist, aligning docs with the design source of truth.

<sup>Written for commit 08b48e06591cd8cd7620668f186d12bb451f1363. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

