### PR TITLE
Add deterministic PR remediation comment for missing docs headers

### DIFF
--- a/.github/workflows/docs-guardrails.yml
+++ b/.github/workflows/docs-guardrails.yml
@@ -16,12 +16,143 @@ on:
 jobs:
   docs_guardrails:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Resolve changed docs files in PR scope
+        if: github.event_name == 'pull_request'
+        id: docs_targets
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setOutput('count', '0');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const activePrefixes = [
+              'docs/reference/',
+              'docs/governance/',
+              'docs/how-to/',
+              'docs/explanation/',
+              'docs/ops/',
+              'docs/templates/',
+            ];
+
+            const excludedPrefixes = [
+              'docs/archive/',
+              'docs/as-built/',
+              'docs/postmortems/',
+              'docs/reports/',
+              'docs/snapshots/',
+            ];
+
+            const targets = files
+              .map((f) => f.filename)
+              .filter((filename) => filename.endsWith('.md'))
+              .filter((filename) => activePrefixes.some((prefix) => filename.startsWith(prefix)))
+              .filter((filename) => !excludedPrefixes.some((prefix) => filename.startsWith(prefix)));
+
+            core.setOutput('count', String(targets.length));
+            core.setOutput('files', targets.join('\n'));
+
+      - name: Write PR docs file list for header check
+        if: github.event_name == 'pull_request' && steps.docs_targets.outputs.count != '0'
+        run: |
+          printf '%s\n' "${{ steps.docs_targets.outputs.files }}" > "$RUNNER_TEMP/docs_header_targets.txt"
+
       - name: Docs header check (active docs)
+        id: docs_header_check
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        env:
+          DOCS_HEADER_TEMPLATE_FILE: docs/templates/markdown-header-template.md
+          DOCS_HEADER_FILE_LIST: ${{ github.event_name == 'pull_request' && steps.docs_targets.outputs.count != '0' && format('{0}/docs_header_targets.txt', runner.temp) || '' }}
+          DOCS_HEADER_MISSING_FILE: ${{ github.event_name == 'pull_request' && format('{0}/docs_header_missing.txt', runner.temp) || '' }}
         run: ./scripts/ci/docs_check_headers.sh .
+
+      - name: Post or update docs header remediation comment
+        if: github.event_name == 'pull_request' && steps.docs_header_check.outcome == 'failure'
+        uses: actions/github-script@v7
+        env:
+          REMEDIATION_MARKER: '<!-- docs-header-remediation -->'
+          MISSING_FILE_LIST: ${{ format('{0}/docs_header_missing.txt', runner.temp) }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = process.env.REMEDIATION_MARKER;
+            const missingFileListPath = process.env.MISSING_FILE_LIST;
+
+            const missingFiles = fs.existsSync(missingFileListPath)
+              ? fs.readFileSync(missingFileListPath, 'utf8').split('\n').map((line) => line.trim()).filter(Boolean)
+              : [];
+
+            if (missingFiles.length === 0) {
+              core.warning('Docs header check failed but no missing files were captured; skipping remediation comment.');
+              return;
+            }
+
+            const template = fs.readFileSync('docs/templates/markdown-header-template.md', 'utf8').trim();
+            const filesList = missingFiles.map((file) => `- \`${file}\``).join('\n');
+            const body = `${marker}
+## 🚨 Copilot Remediation Required: Missing Documentation Headers
+
+@copilot Please fix the missing documentation headers in this PR.
+
+Insert the exact header template shown below at the top of each affected file, then populate every field using that file's context.
+Do **not** leave any placeholder values blank.
+
+### Required Header Template
+\`\`\`md
+${template}
+\`\`\`
+
+### Affected Files
+${filesList}
+`;
+
+            const issue_number = context.payload.pull_request.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Fail PR when docs header remediation is required
+        if: github.event_name == 'pull_request' && steps.docs_header_check.outcome == 'failure'
+        run: |
+          echo "Docs header check failed. See the remediation comment for required fixes."
+          exit 1
 
       - name: Docs path bucket check
         run: ./scripts/ci/docs_check_paths.sh .

--- a/docs/templates/markdown-header-template.md
+++ b/docs/templates/markdown-header-template.md
@@ -1,0 +1,9 @@
+---
+Doc Type: <document type>
+Audience: <intended audience>
+Authority Level: <authority level>
+Owns: <what this document owns>
+Does Not Own: <what this document does not own>
+Canonical Reference: <canonical doc path>
+Last Reviewed: YYYY-MM-DD
+---

--- a/scripts/ci/docs_check_headers.sh
+++ b/scripts/ci/docs_check_headers.sh
@@ -4,34 +4,91 @@
 set +u
 
 ROOT="${1:-.}"
+TEMPLATE_FILE="${DOCS_HEADER_TEMPLATE_FILE:-$ROOT/docs/templates/markdown-header-template.md}"
+FILE_LIST_PATH="${DOCS_HEADER_FILE_LIST:-}"
+MISSING_FILE_LIST_OUTPUT="${DOCS_HEADER_MISSING_FILE:-}"
 
-# Active docs buckets only (exclude historical/archives/snapshots)
-mapfile -t FILES < <(
-  find "$ROOT/docs/reference" "$ROOT/docs/governance" "$ROOT/docs/how-to" "$ROOT/docs/explanation" "$ROOT/docs/ops" "$ROOT/docs/templates" \
-    -type f -name "*.md" \
-    ! -path "$ROOT/docs/archive/*" \
-    ! -path "$ROOT/docs/as-built/*" \
-    ! -path "$ROOT/docs/postmortems/*" \
-    ! -path "$ROOT/docs/reports/*" \
-    ! -path "$ROOT/docs/snapshots/*" \
-    -print
-)
+resolve_required_keys() {
+  local template="$1"
+
+  if [ -f "$template" ]; then
+    awk '
+      BEGIN { fence=0 }
+      /^---$/ { fence++; next }
+      fence == 1 && /^[A-Za-z][A-Za-z ]*:/ {
+        sub(/:.*/, ":")
+        print
+      }
+      fence >= 2 { exit }
+    ' "$template"
+    return
+  fi
+
+  # Backward-compatible fallback if no canonical template file exists.
+  cat <<'KEYS'
+Doc Type:
+Audience:
+Authority Level:
+Owns:
+Does Not Own:
+Canonical Reference:
+Last Reviewed:
+KEYS
+}
+
+mapfile -t REQUIRED_KEYS < <(resolve_required_keys "$TEMPLATE_FILE")
+
+if [ "${#REQUIRED_KEYS[@]}" -eq 0 ]; then
+  echo "FAIL no required documentation header keys were resolved."
+  exit 1
+fi
+
+if [ -n "$FILE_LIST_PATH" ] && [ -f "$FILE_LIST_PATH" ]; then
+  mapfile -t FILES < "$FILE_LIST_PATH"
+else
+  # Active docs buckets only (exclude historical/archives/snapshots)
+  mapfile -t FILES < <(
+    find "$ROOT/docs/reference" "$ROOT/docs/governance" "$ROOT/docs/how-to" "$ROOT/docs/explanation" "$ROOT/docs/ops" "$ROOT/docs/templates" \
+      -type f -name "*.md" \
+      ! -path "$ROOT/docs/archive/*" \
+      ! -path "$ROOT/docs/as-built/*" \
+      ! -path "$ROOT/docs/postmortems/*" \
+      ! -path "$ROOT/docs/reports/*" \
+      ! -path "$ROOT/docs/snapshots/*" \
+      -print
+  )
+fi
 
 missing=0
+missing_files=()
 for f in "${FILES[@]}"; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+
   if ! grep -q '^---$' "$f"; then
     echo "FAIL header fence missing: $f"
     missing=1
+    missing_files+=("$f")
     continue
   fi
 
-  for key in "Doc Type:" "Audience:" "Authority Level:" "Owns:" "Does Not Own:" "Canonical Reference:" "Last Reviewed:"; do
+  file_missing=0
+  for key in "${REQUIRED_KEYS[@]}"; do
     if ! grep -q "^${key}" "$f"; then
       echo "FAIL header key missing (${key}): $f"
       missing=1
+      file_missing=1
     fi
   done
+
+  if [ "$file_missing" -eq 1 ]; then
+    missing_files+=("$f")
+  fi
 done
+
+if [ -n "$MISSING_FILE_LIST_OUTPUT" ]; then
+  printf '%s\n' "${missing_files[@]}" | awk 'NF' | sort -u > "$MISSING_FILE_LIST_OUTPUT"
+fi
 
 if [ "$missing" -ne 0 ]; then
   echo "Docs header check FAILED."


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/768

### Motivation
- Make the docs header gate actionable by providing clear, deterministic remediation for PRs that introduce files missing the required docs header. 
- Detect only the changed active-doc markdown files in a PR and leave the validator as the blocking gate (no CI auto-edits). 
- Ensure the remediation comment is deterministic and updates a single marker-based comment rather than creating duplicates.

### Description
- Add a canonical header template at `docs/templates/markdown-header-template.md` to serve as the single source of truth for required header fields. 
- Enhance `scripts/ci/docs_check_headers.sh` to derive required keys from the canonical template, accept an optional PR-scoped file list, and emit a missing-file list for workflow use. 
- Update `.github/workflows/docs-guardrails.yml` to resolve changed active-doc files in the PR, run the header checker against that file list, and when the checker fails post-or-update a single marker comment `<!-- docs-header-remediation -->` addressed to `@copilot` containing: a direct instruction to fix headers, the exact header template, and the list of affected file paths; the workflow then still fails the PR. 
- The header check remains the blocker and the workflow does not auto-edit repository files or broaden scope beyond header remediation.

### Testing
- Ran `./scripts/ci/docs_check_headers.sh .` against the repository and it reported `Docs header check PASSED.`. 
- Simulated a missing-header case with a temporary markdown file and verified the script failed and produced the missing-file capture (expected failure). 
- Verified the updated shell script syntax with `bash -n scripts/ci/docs_check_headers.sh` and it returned without syntax errors. 
- Attempted a YAML parse check for the workflow but `PyYAML` was not installed in the environment, so that automated parse check was not executed due to the missing module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a2dfe15083298cc4525835fed7f6)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a canonical docs header template and a CI workflow that posts a single remediation comment on PRs with missing headers, listing affected files and the exact template. Only changed active-doc Markdown files are checked, and the header check remains blocking.

- **New Features**
  - Canonical template at `docs/templates/markdown-header-template.md`; validator derives required keys from it.
  - `scripts/ci/docs_check_headers.sh` accepts a PR-scoped file list and writes a missing-files list for the workflow.
  - `.github/workflows/docs-guardrails.yml` resolves changed active-doc files, runs the check, and posts/updates one `<!-- docs-header-remediation -->` comment addressed to `@copilot` with the template and file list, then fails the PR.
  - Grants `pull-requests: write` to post comments. No auto-edits to files.

<sup>Written for commit e2143dcdba1617bc928610f02dd78e8c346ae263. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

