### PR TITLE
docs: fix remaining auth route mismatch in auth-and-logout spec

### DIFF
--- a/docs/reference/design/auth-and-logout.md
+++ b/docs/reference/design/auth-and-logout.md
@@ -20,33 +20,31 @@ Last Reviewed: 2026-03-27
 
 ## Purpose
 
-`/auth` is currently implemented as the public authentication entry route.
+`/join` is the primary public Join/Login entry route for Day 1 authentication/session behavior.
 
-It hosts the shared Join and Login experience for Day 1 authentication/session behavior.
+`/login` is a legacy compatibility route that redirects to `/join#login`.
 
-Within that shared experience:
-
-- Join creates the member record only
-- Login creates the authenticated session (`lgfc_session` + D1 `member_sessions`)
-- Successful login proceeds to `/fanclub`
+`/auth` is not the canonical public Join/Login source of truth; if retained, it is a supporting compatibility/auth-processing route only.
 
 `/auth` must not be described as a separate localStorage-based auth source of truth.
 
 ## Behavior
 
-1. On load, presents the public Join/Login entry experience
-1. Supports the shared Day 1 auth model: Join for member creation, Login for cookie-backed session creation
-1. Uses Day 1 session validation expectations through `/api/login` + `/api/session/me`
-1. On successful authenticated state: proceed to `/fanclub`
-1. On failed or invalid login/session state: remain in the public auth flow
+1. Canonical public Join/Login entry is `/join` (with `/join#login` for login mode)
+1. `/login` is handled as legacy routing behavior to `/join#login`
+1. `/auth` is non-primary and must not be treated as the canonical Join/Login host
+1. Day 1 auth model remains cookie-backed: Join creates member record, Login creates authenticated session (`lgfc_session` + D1 `member_sessions`)
+1. Successful login proceeds to `/fanclub`; failed/invalid login/session state remains in the public auth flow
 
 ## UI
 
-Public authentication entry page containing the shared Join and Login experience.
+When used, `/auth` should mirror the same Day 1 Join/Login behavior without becoming a separate canonical public entry route.
 
 ## Notes
 
-- This is a public auth route
+- Primary public auth entry is `/join` (not `/auth`)
+- `/login` remains legacy redirect behavior to `/join#login`
+- `/auth` is supporting/compatibility-only, not canonical
 - Day 1 canonical auth/session behavior is defined in:
   - `docs/reference/design/join-login.md`
   - `docs/reference/design/LGFC-Production-Design-and-Standards.md`


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/772

### Motivation
- The `/auth` section in `docs/reference/design/auth-and-logout.md` claimed `/auth` was the canonical public Join/Login host, which conflicts with the repository’s implemented routing where `/join` is the primary entry and `/login` is a legacy redirect.
- This change is a docs-only alignment to avoid misleading implementers and keep the spec consistent with `join-login.md` and `LGFC-Production-Design-and-Standards.md`.

### Description
- Updated `docs/reference/design/auth-and-logout.md` Purpose and Behavior text to state that `/join` is the primary public Join/Login entry and `/login` is a legacy redirect to `/join#login`.
- Rewrote `/auth` wording to describe it narrowly as a supporting / compatibility / auth-processing route and explicitly removed any language calling it the canonical Join/Login host.
- Adjusted the Behavior and UI sections so Day 1 cookie-backed auth model remains described while making `/auth` non-primary, and left the `/logout` section unchanged.
- Changed files: `docs/reference/design/auth-and-logout.md`.

### Testing
- Verified the doc diff with `git diff -- docs/reference/design/auth-and-logout.md`, which showed the intended replacements and removals, and the diff succeeded.
- Printed the updated file (`nl -ba docs/reference/design/auth-and-logout.md | sed -n '1,220p'`) to confirm the new wording and that the front matter/header format was preserved, and the output matched expectations.
- Opened related canonical docs (`docs/reference/design/join-login.md` and `docs/reference/design/LGFC-Production-Design-and-Standards.md`) to confirm consistency, and no automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6b61f18448329b0f978bbd5ec0281)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the auth route docs to match current routing: `/join` is the canonical Join/Login entry, `/login` redirects to `/join#login`, and `/auth` is a non-primary compatibility/auth-processing route. Preserves Day 1 cookie-backed auth details (`lgfc_session` + D1 `member_sessions`) and leaves `/logout` unchanged.

<sup>Written for commit 1d8e2ede5f2e5c0de4ede291f7511fffe9025a3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

