### PR TITLE
docs: remediation hierarchy fixes (archive CMS, reset auth, unify redirects, correct tracker)

### DIFF
--- a/docs/archive/legacy-architecture/cms.md
+++ b/docs/archive/legacy-architecture/cms.md
@@ -72,7 +72,7 @@ The CMS stack is:
 All structured content is modeled in Supabase tables.  
 All media assets live in B2 with metadata in Supabase.
 
-Supabase is the **single source of truth** for dynamic content.
+Supabase was treated as the primary dynamic-content system in this retired architecture.
 
 ---
 

--- a/docs/as-built/cloudflare-frontend.md
+++ b/docs/as-built/cloudflare-frontend.md
@@ -116,7 +116,7 @@ All member-specific components are in `src/componentsfanclub/`:
 
 #### FanClub Authentication
 - Email-based authentication via localStorage (`lgfc_member_email`)
-- Not authenticated → Shows login prompt, redirects to `/login`
+- Not authenticated → redirects to `/` (canonical unauthenticated target)
 - No server-side session management (client-side state only)
 
 #### Admin Authorization
@@ -140,7 +140,7 @@ All member-specific components are in `src/componentsfanclub/`:
 **Profile Page:**
 - Edit name, email, screen_name
 - Contributions summary
-- Email change with magic-link verification
+- Email change flow is deferred; no magic-link behavior is canonical in Day 1 docs
 
 ### Navigation Behavior
 

--- a/docs/ops/projects/DOCUMENTATION-REMEDIATION.md
+++ b/docs/ops/projects/DOCUMENTATION-REMEDIATION.md
@@ -100,8 +100,13 @@ A → B → C → D
 ## 9. Workstream Status (LIVE — AUTO-SYNC REQUIRED)
 
 ### Completed (Merged)
+- None (tracker corrected to reflect implementation state)
+
+### Pending Implementation (Ticket Merged, Doc Changes Not Fully Applied)
 - A — Architecture Purge → PR #703 (MERGED 2026-03-26)
+  - Note: Ticket merged, but archive/stub authority enforcement remained incomplete and is still implementation-pending.
 - C — Auth Model (LOCKED) → PR #707 (MERGED 2026-03-26)
+  - Note: Ticket merged, but active design docs still contained stale Supabase/magic-link auth language and required implementation follow-through.
 
 ### In Progress (Open PRs)
 - B — Canonical Authority Lock → PR #705 (OPEN)

--- a/docs/reference/architecture/access-model.md
+++ b/docs/reference/architecture/access-model.md
@@ -4,7 +4,7 @@ Audience: Human + AI
 Authority Level: Canonical Architecture Specification
 Owns: System architecture, data flows, access model, runtime dependencies
 Does Not Own: Operational runbooks; governance policies; UI/UX design specifics
-Canonical Reference: /docs/explanation/ARCHITECTURE_OVERVIEW.md
+Canonical Reference: /docs/reference/design/LGFC-Production-Design-and-Standards.md
 Last Reviewed: 2026-02-20
 ---
 
@@ -279,13 +279,13 @@ Admin pages are **open** for UI access, APIs are token-gated.
 
 ## Future Enhancements
 
-**Phase 6+:** Supabase-based admin authentication
+**Phase 6+:** Role-backed admin authentication hardening
 
-When Supabase auth is integrated:
-- **Admin UI pages** will check Supabase session + role
-- **Admin APIs** may add Supabase JWT validation (in addition to or replacing `ADMIN_TOKEN`)
-- **D1 diagnostic tool** will require Supabase admin role
-- **Migration path:** Token-based auth remains as fallback or backup access method
+When advanced auth hardening is integrated:
+- **Admin UI pages** may add stronger role/session checks beyond token entry UX
+- **Admin APIs** may add layered role/session verification in addition to `ADMIN_TOKEN`
+- **D1 diagnostic tool** may require explicit admin role confirmation
+- **Migration path:** Token-based auth remains available as fallback/backup access method
 
 See `/docs/admin/dashboard.md` for full admin feature roadmap.
 

--- a/docs/reference/architecture/cms-data-layer.md
+++ b/docs/reference/architecture/cms-data-layer.md
@@ -4,7 +4,7 @@ Audience: Human + AI
 Authority Level: Canonical Architecture Specification
 Owns: System architecture, data flows, access model, runtime dependencies
 Does Not Own: Operational runbooks; governance policies; UI/UX design specifics
-Canonical Reference: /docs/explanation/ARCHITECTURE_OVERVIEW.md
+Canonical Reference: /docs/reference/design/LGFC-Production-Design-and-Standards.md
 Last Reviewed: 2026-02-20
 ---
 

--- a/docs/reference/architecture/cms.md
+++ b/docs/reference/architecture/cms.md
@@ -1,22 +1,21 @@
 ---
 Doc Type: Specification
 Audience: Human + AI
-Authority Level: Historical
+Authority Level: Historical Pointer
 Owns: Archive pointer for superseded CMS architecture document
 Does Not Own: Current architecture or design authority
 Canonical Reference: /docs/reference/design/LGFC-Production-Design-and-Standards.md
 Last Reviewed: 2026-03-27
 ---
 
-# LGFC — CMS ARCHITECTURE (Archived)
+# LGFC — CMS Architecture (Archived)
 
-This architecture document has been archived.
+This path is intentionally retained as a **stub**.
 
-The former Vercel/Supabase CMS architecture reference now lives at:
+The former CMS architecture document has been archived and is no longer an active authority:
 
-- `/docs/archive/legacy-architecture/cms.md`
+- Archive: `/docs/archive/legacy-architecture/cms.md`
 
-Current authority for production behavior and design standards lives at:
+Current production architecture/design authority is:
 
 - `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
-- `/docs/reference/architecture/runtime-dependencies_MASTER.md`

--- a/docs/reference/architecture/faq-system.md
+++ b/docs/reference/architecture/faq-system.md
@@ -4,7 +4,7 @@ Audience: Human + AI
 Authority Level: Canonical Architecture Specification
 Owns: System architecture, data flows, access model, runtime dependencies
 Does Not Own: Operational runbooks; governance policies; UI/UX design specifics
-Canonical Reference: /docs/explanation/ARCHITECTURE_OVERVIEW.md
+Canonical Reference: /docs/reference/design/LGFC-Production-Design-and-Standards.md
 Last Reviewed: 2026-02-20
 ---
 

--- a/docs/reference/architecture/runtime-dependencies_MASTER.md
+++ b/docs/reference/architecture/runtime-dependencies_MASTER.md
@@ -4,7 +4,7 @@ Audience: Human + AI
 Authority Level: Canonical Architecture Specification
 Owns: System architecture, data flows, access model, runtime dependencies
 Does Not Own: Operational runbooks; governance policies; UI/UX design specifics
-Canonical Reference: /docs/explanation/ARCHITECTURE_OVERVIEW.md
+Canonical Reference: /docs/reference/design/LGFC-Production-Design-and-Standards.md
 Last Reviewed: 2026-02-20
 ---
 

--- a/docs/reference/design/LGFC-Production-Design-and-Standards.md
+++ b/docs/reference/design/LGFC-Production-Design-and-Standards.md
@@ -61,8 +61,8 @@ external Bonfire link (no /store route)
 
 - Protected FanClub routes (`/fanclub` and `/fanclub/**`) are auth-gated.
 - If a user is unauthenticated, redirect to `/` (public home).
-- If authentication fails (including invalid auth callback/session validation), redirect to `/join#login`.
-- `/login` is a legacy route and must redirect to `/join#login`.
+- If authentication/session validation fails, redirect to `/` (public home).
+- `/login` is a legacy compatibility route and must redirect to `/join#login`.
 
 ---
 
@@ -161,19 +161,16 @@ Implementation-level schema definitions and migrations are maintained separately
 
 ---
 
-## Authentication Model
+## Authentication Model (Canonical Day 1 Reference)
 
-Day 1 member authentication uses a cookie-backed server session model.
+Day 1 member access uses an LGFC-lite local browser session model.
 
-- Login creates an `lgfc_session` cookie and a corresponding server-side session row in D1 `member_sessions`.
-- Session resolution is server-side: request cookie → D1 `member_sessions` lookup.
-- Member/session state is checked through `/api/session/me`.
-- Member/admin role is resolved from D1 `members`.
-- Protected FanClub routes (`/fanclub` and `/fanclub/**`) redirect unauthenticated users to `/`.
-- Logout clears the cookie-backed session path (`lgfc_session`) and removes the active D1 session, then returns the user to `/`.
-- Closing the browser does not immediately mark a member offline.
-- Presence is approximate through active session records plus `last_seen_at` updates.
-- Advanced auth and presence controls are deferred to later phases/backlog and are non-canonical for Day 1.
+- Join/login is hosted at `/join` (login tab at `/join#login`; `/login` is legacy compatibility only).
+- Successful login writes `lgfc_member_email` to localStorage and routes the member to `/fanclub`.
+- FanClub route protection for `/fanclub` and `/fanclub/**` checks for the local session marker and redirects unauthenticated users to `/`.
+- Any failed login/session validation path redirects to `/`.
+- Logout clears `lgfc_member_email` (and any stale compatibility session artifacts) and redirects to `/`.
+- Supabase Auth and magic-link flows are not part of the current production auth model.
 
 ---
 

--- a/docs/reference/design/auth-and-logout.md
+++ b/docs/reference/design/auth-and-logout.md
@@ -2,88 +2,53 @@
 Doc Type: Specification
 Audience: Human + AI
 Authority Level: Canonical Design Specification
-Owns: Routes, navigation invariants, UI/UX contracts, page content contracts
-Does Not Own: How-to procedures; operational runbooks; governance policies
+Owns: Auth entry compatibility routes and logout behavior
+Does Not Own: Global route inventory; non-auth UI standards
 Canonical Reference: /docs/reference/design/LGFC-Production-Design-and-Standards.md
 Last Reviewed: 2026-03-27
 ---
 
 # Auth & Logout Page Specifications — LGFC
 
------
-
-# `/auth` — Authentication Entry
+## `/auth` — Compatibility Auth Entry
 
 **Route:** `/auth`  
-**Access:** Public  
-**Desktop only.** Mobile/tablet implementation is deferred.
+**Access:** Public
 
 ## Purpose
 
-`/join` is the primary public Join/Login entry route for Day 1 authentication/session behavior.
+`/join` is the canonical public Join/Login entry route.
 
 `/login` is a legacy compatibility route that redirects to `/join#login`.
 
-`/auth` is not the canonical public Join/Login source of truth; if retained, it is a supporting compatibility/auth-processing route only.
-
-`/auth` must not be described as a separate localStorage-based auth source of truth.
+`/auth` is a compatibility/auth-processing route and not a separate primary entry route.
 
 ## Behavior
 
-1. Canonical public Join/Login entry is `/join` (with `/join#login` for login mode)
-1. `/login` is handled as legacy routing behavior to `/join#login`
-1. `/auth` is non-primary and must not be treated as the canonical Join/Login host
-1. Day 1 auth model remains cookie-backed: Join creates member record, Login creates authenticated session (`lgfc_session` + D1 `member_sessions`)
-1. Successful login proceeds to `/fanclub`; failed/invalid login/session state remains in the public auth flow
+1. Canonical Join/Login entry is `/join`.
+2. `/login` redirects to `/join#login`.
+3. `/auth` mirrors Join/Login behavior without becoming a separate entry surface.
+4. Day 1 auth model is LGFC-lite local session marker behavior (`lgfc_member_email` in localStorage).
+5. Successful login routes to `/fanclub`.
+6. Failed login or invalid session state redirects to `/`.
 
-## UI
-
-When used, `/auth` should mirror the same Day 1 Join/Login behavior without becoming a separate canonical public entry route.
-
-## Notes
-
-- Primary public auth entry is `/join` (not `/auth`)
-- `/login` remains legacy redirect behavior to `/join#login`
-- `/auth` is supporting/compatibility-only, not canonical
-- Day 1 canonical auth/session behavior is defined in:
-  - `docs/reference/design/join-login.md`
-  - `docs/reference/design/LGFC-Production-Design-and-Standards.md`
-- Join and Login remain separate functions even when presented through one shared route/form shell
-
------
-
-# `/logout` — Logout Handler
+## `/logout` — Logout Handler
 
 **Route:** `/logout`  
-**Access:** Public (no auth required to visit — handles clearing session)  
-**Desktop only.** Mobile/tablet implementation is deferred.
+**Access:** Public
 
-## Purpose
+### Purpose
 
-Clears the Day 1 cookie-backed member session and redirects to the public home page.
+Clears Day 1 local member session state and returns the user to the public home page.
 
-## Behavior
+### Behavior
 
-1. On load: calls logout endpoint to clear `lgfc_session` and remove the server-side session record from D1 `member_sessions`
-1. Clears stale legacy local browser auth key (`lgfc_member_email`) when present
-1. Redirects to `/` (public home)
+1. Clears `lgfc_member_email` from localStorage when present.
+2. Clears any stale compatibility cookie/session artifacts if present.
+3. Redirects to `/`.
 
-## UI
+### Notes
 
-No persistent UI. Momentary transition state only:
-
-```
-[Centered in viewport]
-  "Signing out…"
-```
-
-- Same minimal loading style as `/auth`
-- Redirect happens within 1 second
-
-## Notes
-
-- Logout is triggered by the Logout button in the header
-- After redirect to `/`, header returns to visitor (not-logged-in) state
-- No confirmation dialog — logout is immediate
-- If user is already logged out and visits `/logout`, redirect to `/` silently
-- Closing the browser is not treated as an immediate logout/offline signal in Day 1
+- Logout is triggered from the header Logout action.
+- After redirect to `/`, header returns to visitor state.
+- Visiting `/logout` while already logged out still redirects silently to `/`.

--- a/docs/reference/design/fanclub.md
+++ b/docs/reference/design/fanclub.md
@@ -30,7 +30,7 @@ Auth/session, join/login, and member data flows rely on runtime APIs under `func
 - **FanClub Home (Club Home)**: `/fanclub`
 - Auth boundary: `/fanclub` and all `/fanclub/**` routes require login.
 - Unauthenticated access to `/fanclub` and `/fanclub/**` must **redirect to** `/` (public home).
-- Failed authentication recovery target is `/join#login`.
+- Failed authentication/session-validation recovery target is `/`.
 
 ---
 

--- a/docs/reference/design/join-login.md
+++ b/docs/reference/design/join-login.md
@@ -2,7 +2,7 @@
 Doc Type: Design Authority
 Audience: Human + AI
 Authority Level: Controlled
-Owns: Join/Login page UI, behavior, and auth flow
+Owns: Join/Login page UI, behavior, and member access flow
 Does Not Own: Global navigation rules, header/footer standards
 Canonical Reference: /docs/reference/design/LGFC-Production-Design-and-Standards.md
 Last Reviewed: 2026-03-27
@@ -10,13 +10,9 @@ Last Reviewed: 2026-03-27
 
 # Join / Login Page Design
 
-This document defines the **combined Join/Login page** used for LGFC-Lite member session entry.
+This document defines the combined **Join/Login** experience used for the LGFC-lite member access model.
 
-The page uses a **single route and component** with **two tabs** to avoid duplicated logic and UI drift.
-
----
-
-# Route
+## Route
 
 Primary route:
 
@@ -26,152 +22,69 @@ Legacy route handling:
 
 `/login` → redirect to `/join#login`
 
----
+## Page Purpose
 
-# Page Purpose
+Provide one entry surface for:
 
-Provide a single entry point for:
+1. New member join
+2. Existing member login
 
-1. Member join (member record creation)
-2. Existing member login (session creation)
+## Tabs
 
-The interface uses tab navigation to switch between Join and Login forms.
-
----
-
-# Page Layout
-
-Page sections:
-
-1. Page Header
-2. Tab Selector
-3. Form Container
-4. Submit Actions
-5. Error / Status Messages
-
----
-
-# Tabs
-
-Two tabs control which form is visible.
-
-TAB 1 — Join  
-TAB 2 — Login
-
-Behavior:
-
-- Join tab is default when visiting `/join`
-- Login tab activates when URL hash is `/join#login`
+- Join tab is default on `/join`
+- Login tab activates on `/join#login`
 - Switching tabs does not reload the page
 
----
-
-# Join Form
-
-Purpose: create a Day 1 member record and session entry point.
+## Join Form
 
 Required fields:
 
 - Screen Name (Alias)
 - Email
 
-Validation rules:
+Validation:
 
-- Screen Name is required
-- Email must be valid format
-- Alias/email conflicts must return an inline error
+- Screen Name required
+- Valid email format
+- Alias/email conflicts return inline error
 
----
-
-# Login Form
-
-Purpose: create a Day 1 authenticated member session.
+## Login Form
 
 Required fields:
 
 - Email
 
-Validation rules:
+Validation:
 
-- Email must be valid format
-- Email must match an existing Day 1 join/member path record
+- Valid email format
+- Email must match an existing member record
 
----
+## Authentication Model (Day 1 LGFC-lite)
 
-# Authentication Flow
+Day 1 member access uses a **local browser session marker** model.
 
-Authentication follows the Day 1 cookie-backed session model.
+- Successful login writes `lgfc_member_email` in localStorage.
+- Member-access checks read `lgfc_member_email` client-side.
+- No Supabase Auth or magic-link flow is part of the current model.
+- Session invalidation/log out clears `lgfc_member_email` and returns user to `/`.
 
-Join flow:
+## Redirect Behavior (Canonical)
 
-1. User submits Join form
-2. System validates input and executes the implemented join/member create path
-3. User then authenticates through the login session flow
-4. Login creates `lgfc_session` and a D1 `member_sessions` record
-5. Successful auth lands on `/fanclub`
+- Successful login redirects to `/fanclub`.
+- Any unauthenticated member-route access (`/fanclub` and `/fanclub/**`) redirects to `/`.
+- Failed login/session validation redirects to `/`.
 
-Login flow:
-
-1. User submits Login form
-2. Login endpoint validates identity against the Day 1 join/member data path
-3. Server creates `lgfc_session` cookie and D1 `member_sessions` session record
-4. Redirect to `/fanclub`
-
----
-
-# Redirect Behavior
-
-Successful authentication redirects to:
-
-`/fanclub`
-
-Unauthenticated access to protected FanClub routes (`/fanclub` and `/fanclub/**`) redirects to:
-
-`/`
-
-Failed authentication or invalid auth callback redirects to:
-
-`/join#login`
-
----
-
-# Error Handling
-
-Errors appear inside the form container.
+## Error Handling
 
 Typical errors:
 
 - Invalid email format
 - Member not found
 - Alias/email conflict
-- Session creation failure
+- Session initialization failure
 
----
+## Design Constraints
 
-# Component Structure
-
-Recommended component layout:
-
-JoinLoginPage  
- ├── TabSelector  
- ├── JoinForm  
- └── LoginForm
-
-State management controls which form is visible.
-
----
-
-# UI Behavior Rules
-
-- Only one form visible at a time
-- Tab switch must be instant
-- No page reload during tab switch
-- Form validation occurs before submission
-
----
-
-# Design Constraints
-
-- Must comply with global header/footer standards
-- Must follow navigation rules defined in LGFC Production Design and Standards
-- Must not introduce separate Join or Login pages
+- Must comply with global header/footer standards.
+- Must follow route and redirect rules in `LGFC-Production-Design-and-Standards.md`.
+- Must not introduce separate standalone Join and Login pages.


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/774

### Motivation
- Align documentation with the design remediation review by converting ticketed remediation work into actual in-repo documentation changes. 
- Remove stale Supabase/magic-link claims from active design docs and enforce `LGFC-Production-Design-and-Standards.md` as the canonical design authority. 
- Ensure unauthenticated redirect behavior and the remediation tracker accurately reflect implemented behavior.

### Description
- Tracker integrity: updated `docs/ops/projects/DOCUMENTATION-REMEDIATION.md` to remove false "Completed" state and added a `Pending Implementation (Ticket Merged, Doc Changes Not Fully Applied)` section clarifying that Workstream A and Workstream C tickets had merged but implementation remained pending until these edits (file: `docs/ops/projects/DOCUMENTATION-REMEDIATION.md`).
- Archive CMS and stub original path: moved the historical/superseded CMS narrative to the archive (kept as `docs/archive/legacy-architecture/cms.md` with an explicit archive banner and removed source-of-truth phrasing), and replaced the original active path with a stub at `docs/reference/architecture/cms.md` that points to the archive and the production design authority (files: `docs/archive/legacy-architecture/cms.md`, `docs/reference/architecture/cms.md`).
- Auth model reset to LGFC-lite local session: removed Supabase / magic-link as current behavior and added canonical LGFC-lite local session language across the design docs, including adding a compact Day 1 auth section to the top-level design authority and updating auth pages to describe `lgfc_member_email` localStorage/session marker behavior (files: `docs/reference/design/LGFC-Production-Design-and-Standards.md`, `docs/reference/design/join-login.md`, `docs/reference/design/auth-and-logout.md`).
- Redirect target unification and pointer fixes: standardized unauthenticated/failed-session redirect target to `/` across required docs and updated architecture docs to point at the design authority instead of informational overviews (files: `docs/reference/design/fanclub.md`, `docs/as-built/cloudflare-frontend.md`, `docs/reference/architecture/access-model.md`, `docs/reference/architecture/runtime-dependencies_MASTER.md`, `docs/reference/architecture/faq-system.md`, `docs/reference/architecture/cms-data-layer.md`).
- This PR explicitly converts ticketed remediation work into implemented documentation changes rather than leaving tracker entries marked completed without the underlying edits.

### Testing
- Verified removal/replacement of Supabase / magic-link language via repository search with `rg` (searches for `Supabase`, `magic-link`), confirming updated files no longer describe Supabase Auth as current behavior; result: success.
- Verified unauthenticated/failed-session redirect text unified to `/` via `rg` searches for `/join#login`, `/login`, and `redirect` in the targeted docs; result: success.
- Confirmed remediation tracker now reflects pending implementation state for Workstreams A and C by inspecting `docs/ops/projects/DOCUMENTATION-REMEDIATION.md`; result: success.
- Committed all changes in a single commit on branch `docs/remediation-hierarchy-fixes`; commit succeeded (changes staged and committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6bb8a32fc83299cefd2d3e8ac5e89)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns docs with the remediation plan: archives the legacy CMS doc (adds a stub at the active path), resets auth to the LGFC‑lite local session model, unifies unauthenticated/failed-session redirects to `/`, and fixes the remediation tracker to reflect actual implementation state.

- **Documentation**
  - Tracker: corrected "Completed" status and added a "Pending Implementation" section for Workstreams A and C.
  - CMS: moved the legacy narrative to `docs/archive/legacy-architecture/cms.md` and replaced `docs/reference/architecture/cms.md` with a stub pointing to the archive and `docs/reference/design/LGFC-Production-Design-and-Standards.md`.
  - Auth: removed Supabase/magic-link claims; documented Day 1 LGFC‑lite local session using `lgfc_member_email` in localStorage; updated `LGFC-Production-Design-and-Standards.md`, `join-login.md`, and `auth-and-logout.md`.
  - Redirects/pointers: standardized unauthenticated or failed-session redirects to `/`; kept `/login` as a compatibility redirect to `/join#login`; updated architecture docs to reference the canonical design authority.

<sup>Written for commit 9791d3f4d478e05d9f89c4d71f8352c7a2ecfc67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

