### PR TITLE
fix(auth): canonical auth model lock (eliminates drift permanently)

### DIFF
--- a/docs/reference/design/auth-model.md
+++ b/docs/reference/design/auth-model.md
@@ -1,0 +1,67 @@
+---
+Doc Type: Design Authority
+Audience: Human + AI
+Authority Level: Canonical
+Owns: Authentication model, session model, auth behavior
+Canonical Reference: SELF
+Last Reviewed: 2026-03-27
+---
+
+# Authentication Model
+
+## Day 1 Canonical Model (LOCKED)
+
+LGFC uses a **cookie-backed server session model**.
+
+### Session
+- Cookie: `lgfc_session`
+- Storage: D1 → `member_sessions`
+- Lookup: `/api/session/me`
+- Identity/role: D1 → `members`
+
+### Behavior
+- Login → create session + cookie → redirect `/fanclub`
+- Logout → clear cookie + invalidate session → redirect `/`
+- Browser close → session remains active
+- Presence → approximate via `last_seen_at`
+
+### Protected Routes
+- `/fanclub`
+- `/fanclub/**`
+
+### Unauthenticated Rule (LOCKED)
+Unauthenticated access → redirect to `/`
+
+---
+
+## PROHIBITED (MUST NOT EXIST IN ANY ACTIVE DOC)
+
+- localStorage as auth source of truth
+- Supabase Auth
+- magic-link auth
+- ADMIN_EMAILS as auth control
+- hybrid cookie + localStorage models
+
+These are not Day 1 implementations.
+
+---
+
+## GOVERNANCE (THIS IS THE FIX)
+
+The following files are **NOT allowed to define auth**:
+
+- join-login.md
+- auth-and-logout.md
+- LGFC-Production-Design-and-Standards.md
+- fanclub.md
+- cloudflare-frontend.md
+
+They must only reference this file.
+
+---
+
+## REQUIRED LINE (MANDATORY)
+
+Every file that mentions auth MUST include:
+
+Canonical auth reference: /docs/reference/design/auth-model.md


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/780

### PR Template

MANDATORY FIRST STEP (ZIP SAFETY)
No ZIP found in repo root

DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
/docs/reference/design/auth-model.md

---

## CHANGE SUMMARY

- Introduces single canonical auth authority
- Eliminates distributed auth definitions
- Establishes governance rule to prevent drift

---

## COPILOT ACTION REQUIRED

1. Update LGFC-Production-Design-and-Standards.md → redirect rules to `/`
2. Update join-login.md → redirect rules to `/`
3. Add canonical reference line to all auth-related docs
4. Update canonical file list + hashes

---

## RESULT

Auth drift permanently eliminated via single source of truth

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a canonical Authentication Model at /docs/reference/design/auth-model.md and locks it as the sole source of truth. Documents the Day 1 cookie-backed session model, protected routes, and prohibits alternative auth patterns to eliminate drift.

- **Migration**
  - Add this line to all auth-related docs: “Canonical auth reference: /docs/reference/design/auth-model.md”.
  - Remove any doc-level auth definitions and point to the canonical file in `LGFC-Production-Design-and-Standards.md`, `join-login.md`, `auth-and-logout.md`, `fanclub.md`, and `cloudflare-frontend.md`; ensure the unauthenticated redirect to `/` is reflected.

<sup>Written for commit cc96290d4c71b8c81094b138434b2c38f3be9083. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

