### PR TITLE
Fix homepage Milestones to render real D1 data in chronological order

### DIFF
--- a/functions/api/milestones/list.ts
+++ b/functions/api/milestones/list.ts
@@ -5,11 +5,34 @@ export const onRequestGet = async (context: any): Promise<Response> => {
     const url = new URL(request.url);
     const limit = Math.max(1, Math.min(100, Number(url.searchParams.get('limit') || '50')));
 
-    const sql = `SELECT m.id, m.year, m.title, m.description, m.photo_id, p.url as photo_url
+    const tableInfo = await env.DB.prepare(`PRAGMA table_info(milestones);`).all();
+    const milestoneColumns = new Set(((tableInfo.results ?? []) as Array<{ name?: string }>).map((c) => c.name));
+
+    const candidateDateColumns = ['milestone_date', 'date', 'event_date', 'date_iso', 'occurred_on', 'year'];
+    const selectedDateColumn = candidateDateColumns.find((column) => milestoneColumns.has(column)) ?? 'year';
+
+    const selectDateSql = selectedDateColumn === 'year'
+      ? `NULL AS milestone_date`
+      : `m.${selectedDateColumn} AS milestone_date`;
+
+    const orderBySql = selectedDateColumn === 'year'
+      ? `CASE WHEN m.year IS NULL THEN 1 ELSE 0 END ASC, m.year ASC, m.id ASC`
+      : `CASE WHEN m.${selectedDateColumn} IS NULL OR trim(m.${selectedDateColumn}) = '' THEN 1 ELSE 0 END ASC,
+         date(m.${selectedDateColumn}) ASC,
+         m.${selectedDateColumn} ASC,
+         m.id ASC`;
+
+    const sql = `SELECT m.id,
+                        m.year,
+                        ${selectDateSql},
+                        m.title,
+                        m.description,
+                        m.photo_id,
+                        p.url as photo_url
                  FROM milestones m
                  LEFT JOIN photos p ON p.id = m.photo_id
                  WHERE m.status='posted'
-                 ORDER BY (CASE WHEN m.year IS NULL THEN 99999 ELSE m.year END) ASC, m.id ASC
+                 ORDER BY ${orderBySql}
                  LIMIT ?;`;
 
     const rows = await env.DB.prepare(sql).bind(limit).all();

--- a/src/components/MilestonesSection.tsx
+++ b/src/components/MilestonesSection.tsx
@@ -6,9 +6,44 @@ import { apiGet } from '@/lib/api';
 type Milestone = {
   id: number;
   year: number | null;
+  date?: string | null;
+  milestone_date?: string | null;
   title: string;
   description?: string | null;
   photo_url?: string | null;
+};
+
+const safeText = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const parseDateRank = (m: Milestone): number | null => {
+  const rawDate = safeText(m.milestone_date) ?? safeText(m.date);
+  if (rawDate) {
+    const parsed = Date.parse(rawDate);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+
+  if (typeof m.year === 'number' && Number.isFinite(m.year)) {
+    return Date.UTC(m.year, 0, 1);
+  }
+
+  return null;
+};
+
+const compareMilestones = (a: Milestone, b: Milestone): number => {
+  const aRank = parseDateRank(a);
+  const bRank = parseDateRank(b);
+
+  if (aRank === null && bRank === null) {
+    return a.id - b.id;
+  }
+  if (aRank === null) return 1;
+  if (bRank === null) return -1;
+  if (aRank !== bRank) return aRank - bRank;
+  return a.id - b.id;
 };
 
 export default function MilestonesSection() {
@@ -17,31 +52,26 @@ export default function MilestonesSection() {
 
   useEffect(() => {
     let alive = true;
-    let completed = false;
-    
-    const timer = setTimeout(() => {
-      if (alive && !completed) {
-        setLoading(false);
-        setItems([]);
-      }
-    }, 10000); // 10 second timeout
-    
+
     (async () => {
       try {
         const data = await apiGet<{ ok: boolean; items: Milestone[] }>(`/api/milestones/list?limit=40`);
-        if (alive) setItems(data.items || []);
+        if (!alive) return;
+
+        const normalized = Array.isArray(data.items)
+          ? data.items.filter((m): m is Milestone => typeof m?.id === 'number' && typeof m?.title === 'string')
+          : [];
+
+        setItems([...normalized].sort(compareMilestones));
       } catch {
         if (alive) setItems([]);
       } finally {
-        if (alive) {
-          setLoading(false);
-          completed = true;
-        }
+        if (alive) setLoading(false);
       }
     })();
+
     return () => {
       alive = false;
-      clearTimeout(timer);
     };
   }, []);
 
@@ -53,22 +83,28 @@ export default function MilestonesSection() {
       {loading ? (
         <p className="sub">Loading milestones…</p>
       ) : items.length === 0 ? (
-        <p className="sub">Milestones coming soon. Check back later!</p>
+        <p className="sub">No milestones are available yet.</p>
       ) : (
         <div className="grid">
-          {items.map((m) => (
-            <div key={m.id} className="card">
-              <strong>
-                {(m.year ?? '—')}: {m.title}
-              </strong>
-              {m.photo_url ? (
-                <div style={{ marginTop: 10 }}>
-                  <img src={m.photo_url} alt={m.title} style={{ width: '100%', borderRadius: 12 }} />
-                </div>
-              ) : null}
-              {m.description ? <p className="sub" style={{ marginTop: 10 }}>{m.description}</p> : null}
-            </div>
-          ))}
+          {items.map((m) => {
+            const safeTitle = safeText(m.title) ?? 'Untitled milestone';
+            const safeDescription = safeText(m.description);
+            const safePhotoUrl = safeText(m.photo_url);
+
+            return (
+              <div key={m.id} className="card">
+                <strong>
+                  {(m.year ?? '—')}: {safeTitle}
+                </strong>
+                {safePhotoUrl ? (
+                  <div style={{ marginTop: 10 }}>
+                    <img src={safePhotoUrl} alt={safeTitle} style={{ width: '100%', borderRadius: 12 }} />
+                  </div>
+                ) : null}
+                {safeDescription ? <p className="sub" style={{ marginTop: 10 }}>{safeDescription}</p> : null}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/tests/milestones-section.test.tsx
+++ b/tests/milestones-section.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import MilestonesSection from '@/components/MilestonesSection';
+import { apiGet } from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  apiGet: vi.fn(),
+}));
+
+const mockedApiGet = vi.mocked(apiGet);
+
+describe('MilestonesSection', () => {
+  beforeEach(() => {
+    mockedApiGet.mockReset();
+  });
+
+  it('renders milestones in chronological order (oldest to newest)', async () => {
+    mockedApiGet.mockResolvedValue({
+      ok: true,
+      items: [
+        { id: 3, year: 1939, title: 'Later milestone' },
+        { id: 1, year: 1923, title: 'First milestone' },
+        { id: 2, year: 1939, title: 'Same date, lower id' },
+      ],
+    } as never);
+
+    render(<MilestonesSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/1923: First milestone/i)).toBeInTheDocument();
+    });
+
+    const cards = Array.from(document.querySelectorAll('#milestones .card strong, .grid .card strong'));
+    const texts = cards.map((node) => node.textContent?.trim());
+    expect(texts).toEqual([
+      '1923: First milestone',
+      '1939: Same date, lower id',
+      '1939: Later milestone',
+    ]);
+  });
+
+  it('shows clean empty state when no milestone rows are returned', async () => {
+    mockedApiGet.mockResolvedValue({ ok: true, items: [] } as never);
+
+    render(<MilestonesSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no milestones are available yet/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/800

### Motivation
- The homepage Milestones section was rendering placeholder-driven content instead of real rows from the D1 `milestones` table and used a timeout fallback that hid real data behavior.
- The goal is to surface real milestone records oldest→newest, keep ordering deterministic when dates tie, and preserve the approved layout while being safe for Cloudflare Pages + D1.

### Description
- Updated the API that feeds the homepage to detect the milestone date column via `PRAGMA table_info(milestones)` and select an appropriate date-like column when present, falling back to `year`; ordering is applied at the SQL layer oldest-to-newest with a deterministic secondary key `id ASC` (`functions/api/milestones/list.ts`).
- Replaced the client component’s timeout/placeholder logic with real-data-driven rendering, added guards for optional/malformed fields (`safeText`), and applied a stable chronological sort as a safety net so the UI renders in oldest→newest order (`src/components/MilestonesSection.tsx`).
- Removed hardcoded placeholder messaging and replaced it with a clean empty-state message (`No milestones are available yet.`) when the DB returns no rows (`src/components/MilestonesSection.tsx`).
- Added a focused unit test `tests/milestones-section.test.tsx` that verifies chronological oldest→newest rendering (including deterministic tie-break by `id`) and the empty-table state.

### Testing
- Ran the new focused unit tests with `vitest`: `npm run test -- tests/milestones-section.test.tsx` and the file's tests passed.
- Ran repository linting with `npm run lint`; linter completed with existing non-blocking image warnings and no blocking errors.
- The SQL ordering used: primary sort by the selected date column ascending (or `year` ascending when no date column is present), null/blank dates pushed after valid dates, with deterministic secondary `id ASC` to stabilize ties.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd5333779c832980efee562048c1ad)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders real D1 `milestones` on the homepage in true chronological order and removes placeholder/timeout logic. Adds deterministic SQL ordering and a cleaner empty state.

- **Bug Fixes**
  - API selects a date-like column via `PRAGMA table_info` (prefers `milestone_date`, `date`, etc.; falls back to `year`) and orders oldest→newest with `id ASC` tie-break; null/blank dates go last.
  - Homepage Milestones now renders DB rows, removes timeout/placeholder, normalizes fields, and applies a stable client-side sort as a safety net.
  - Empty state shows: “No milestones are available yet.”

- **Tests**
  - Added `tests/milestones-section.test.tsx` to confirm chronological order (including `id` tie-break) and the empty-state message.

<sup>Written for commit dcdfc0f15f451cf78c5536c151fcf3927fa8ba47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

