### PR TITLE
Add canonical FanClub API routes and membercard endpoint

### DIFF
--- a/functions/api/content/membercard.ts
+++ b/functions/api/content/membercard.ts
@@ -1,0 +1,33 @@
+import { requireMember } from '../../_lib/session';
+
+export const onRequestGet = async (context: any): Promise<Response> => {
+  const auth = await requireMember(context);
+  if (!auth.ok) {
+    return new Response(JSON.stringify(auth.body), {
+      status: auth.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const row = await auth.db
+      .prepare(
+        `SELECT id, title, body_md, updated_at
+         FROM membership_card_content
+         WHERE status = 'posted'
+         ORDER BY updated_at DESC, id DESC
+         LIMIT 1`
+      )
+      .first();
+
+    return new Response(JSON.stringify({ ok: true, content: row || null }, null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: any) {
+    return new Response(JSON.stringify({ ok: false, error: String(err?.message || err) }, null, 2), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/fanclub/library.ts
+++ b/functions/api/fanclub/library.ts
@@ -1,0 +1,74 @@
+import { requireMember } from '../../_lib/session';
+
+const PAGE_SIZE = 20;
+
+function parsePage(raw: string | null): number {
+  const n = Number(raw || '1');
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 1;
+}
+
+export const onRequestGet = async (context: any): Promise<Response> => {
+  const auth = await requireMember(context);
+  if (!auth.ok) {
+    return new Response(JSON.stringify(auth.body), {
+      status: auth.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const url = new URL(context.request.url);
+    const q = String(url.searchParams.get('q') || '').trim().toLowerCase();
+    const page = parsePage(url.searchParams.get('page'));
+    const offset = (page - 1) * PAGE_SIZE;
+
+    const where: string[] = [];
+    const args: any[] = [];
+
+    if (q) {
+      where.push('(lower(COALESCE(title,\'\')) LIKE ? OR lower(COALESCE(content,\'\')) LIKE ? OR lower(COALESCE(name,\'\')) LIKE ?)');
+      const like = `%${q}%`;
+      args.push(like, like, like);
+    }
+
+    const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+    const countRow = await auth.db
+      .prepare(`SELECT COUNT(1) AS n FROM library_entries ${whereSql}`)
+      .bind(...args)
+      .first();
+    const total = Number((countRow as any)?.n ?? 0) || 0;
+
+    const rows = await auth.db
+      .prepare(
+        `SELECT id, name, title, content, created_at
+         FROM library_entries
+         ${whereSql}
+         ORDER BY created_at DESC, id DESC
+         LIMIT ? OFFSET ?`
+      )
+      .bind(...args, PAGE_SIZE, offset)
+      .all();
+
+    const items = (rows.results || []).map((row: any) => ({
+      id: row.id,
+      // Design expects explicit year; schema stores created_at only.
+      year: row.created_at ? Number(String(row.created_at).slice(0, 4)) || null : null,
+      author: row.name || null,
+      title: row.title || null,
+      description: row.content ? String(row.content).slice(0, 100) : null,
+      url: null,
+      content: row.content || null,
+    }));
+
+    return new Response(
+      JSON.stringify({ ok: true, items, page, page_size: PAGE_SIZE, total }, null, 2),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (err: any) {
+    return new Response(JSON.stringify({ ok: false, error: String(err?.message || err) }, null, 2), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/fanclub/memorabilia.ts
+++ b/functions/api/fanclub/memorabilia.ts
@@ -1,0 +1,88 @@
+import { requireMember } from '../../_lib/session';
+import { normalizePhotoUrl } from '../../_lib/photo-url';
+
+const PAGE_SIZE = 24;
+
+function parsePage(raw: string | null): number {
+  const n = Number(raw || '1');
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 1;
+}
+
+function parseTags(raw: string | null): string[] {
+  return String(raw || '')
+    .split(',')
+    .map((v) => v.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export const onRequestGet = async (context: any): Promise<Response> => {
+  const auth = await requireMember(context);
+  if (!auth.ok) {
+    return new Response(JSON.stringify(auth.body), {
+      status: auth.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const url = new URL(context.request.url);
+    const q = String(url.searchParams.get('q') || '').trim().toLowerCase();
+    const tags = parseTags(url.searchParams.get('tags'));
+    const page = parsePage(url.searchParams.get('page'));
+    const offset = (page - 1) * PAGE_SIZE;
+
+    const where: string[] = ['is_memorabilia = 1'];
+    const args: any[] = [];
+
+    if (q) {
+      where.push('(lower(COALESCE(title,\'\')) LIKE ? OR lower(COALESCE(description,\'\')) LIKE ? OR lower(COALESCE(tags,\'\')) LIKE ?)');
+      const like = `%${q}%`;
+      args.push(like, like, like);
+    }
+
+    for (const t of tags) {
+      where.push('lower(COALESCE(tags,\'\')) LIKE ?');
+      args.push(`%${t}%`);
+    }
+
+    const whereSql = `WHERE ${where.join(' AND ')}`;
+
+    const countRow = await auth.db
+      .prepare(`SELECT COUNT(1) AS n FROM photos ${whereSql}`)
+      .bind(...args)
+      .first();
+    const total = Number((countRow as any)?.n ?? 0) || 0;
+
+    const rows = await auth.db
+      .prepare(
+        `SELECT id, photo_id, url, title, description, tags
+         FROM photos
+         ${whereSql}
+         ORDER BY id DESC
+         LIMIT ? OFFSET ?`
+      )
+      .bind(...args, PAGE_SIZE, offset)
+      .all();
+
+    const items = (rows.results || []).map((row: any) => ({
+      id: row.id,
+      b2_key: row.photo_id || row.url || null,
+      thumbnail_url: normalizePhotoUrl({ rawUrl: row?.url, request: context.request, publicB2BaseUrl: context.env.PUBLIC_B2_BASE_URL }),
+      title: row.title || null,
+      description: row.description || null,
+      tags: row.tags || null,
+      // Design field required; this schema has no library foreign key on photos.
+      library_id: null,
+    }));
+
+    return new Response(
+      JSON.stringify({ ok: true, items, page, page_size: PAGE_SIZE, total }, null, 2),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (err: any) {
+    return new Response(JSON.stringify({ ok: false, error: String(err?.message || err) }, null, 2), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/fanclub/photos.ts
+++ b/functions/api/fanclub/photos.ts
@@ -1,0 +1,90 @@
+import { requireMember } from '../../_lib/session';
+import { normalizePhotoUrl } from '../../_lib/photo-url';
+
+const PAGE_SIZE = 24;
+
+function parsePage(raw: string | null): number {
+  const n = Number(raw || '1');
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 1;
+}
+
+function parseTags(raw: string | null): string[] {
+  return String(raw || '')
+    .split(',')
+    .map((v) => v.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export const onRequestGet = async (context: any): Promise<Response> => {
+  const auth = await requireMember(context);
+  if (!auth.ok) {
+    return new Response(JSON.stringify(auth.body), {
+      status: auth.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const url = new URL(context.request.url);
+    const q = String(url.searchParams.get('q') || '').trim().toLowerCase();
+    const tags = parseTags(url.searchParams.get('tags'));
+    const page = parsePage(url.searchParams.get('page'));
+    const offset = (page - 1) * PAGE_SIZE;
+
+    // NOTE: current schema does not have an explicit approval column for photos.
+    // We treat current rows as already-approved catalog content.
+    const where: string[] = ['(is_memorabilia IS NULL OR is_memorabilia = 0)'];
+    const args: any[] = [];
+
+    if (q) {
+      where.push('(lower(COALESCE(title,\'\')) LIKE ? OR lower(COALESCE(description,\'\')) LIKE ? OR lower(COALESCE(tags,\'\')) LIKE ?)');
+      const like = `%${q}%`;
+      args.push(like, like, like);
+    }
+
+    for (const t of tags) {
+      where.push('lower(COALESCE(tags,\'\')) LIKE ?');
+      args.push(`%${t}%`);
+    }
+
+    const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+    const countRow = await auth.db
+      .prepare(`SELECT COUNT(1) AS n FROM photos ${whereSql}`)
+      .bind(...args)
+      .first();
+    const total = Number((countRow as any)?.n ?? 0) || 0;
+
+    const rows = await auth.db
+      .prepare(
+        `SELECT id, photo_id, url, title, description, tags, source
+         FROM photos
+         ${whereSql}
+         ORDER BY id DESC
+         LIMIT ? OFFSET ?`
+      )
+      .bind(...args, PAGE_SIZE, offset)
+      .all();
+
+    const items = (rows.results || []).map((row: any) => ({
+      id: row.id,
+      b2_key: row.photo_id || row.url || null,
+      thumbnail_url: normalizePhotoUrl({ rawUrl: row?.url, request: context.request, publicB2BaseUrl: context.env.PUBLIC_B2_BASE_URL }),
+      title: row.title || null,
+      description: row.description || null,
+      tags: row.tags || null,
+      // Design field required; nearest available schema field is `source`.
+      uploaded_by: row.source || null,
+    }));
+
+    return new Response(
+      JSON.stringify({ ok: true, items, page, page_size: PAGE_SIZE, total }, null, 2),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (err: any) {
+    return new Response(JSON.stringify({ ok: false, error: String(err?.message || err) }, null, 2), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/fanclub/profile.ts
+++ b/functions/api/fanclub/profile.ts
@@ -1,0 +1,135 @@
+import { requireMember } from '../../_lib/session';
+
+function profileFromRow(row: any, sessionEmail: string) {
+  return {
+    email: sessionEmail,
+    first_name: row?.first_name ?? null,
+    last_name: row?.last_name ?? null,
+    screen_name: row?.screen_name ?? null,
+    email_opt_in: row?.email_opt_in == null ? true : Boolean(row?.email_opt_in),
+    profile_photo_id: row?.profile_photo_id ?? null,
+  };
+}
+
+export const onRequestGet = async (context: any): Promise<Response> => {
+  const auth = await requireMember(context);
+  if (!auth.ok) {
+    return new Response(JSON.stringify(auth.body), {
+      status: auth.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const row = await auth.db
+      .prepare(
+        `SELECT first_name, last_name, screen_name, email_opt_in, profile_photo_id
+         FROM join_requests
+         WHERE lower(email) = lower(?1)
+         LIMIT 1`
+      )
+      .bind(auth.email)
+      .first();
+
+    return new Response(JSON.stringify({ ok: true, profile: profileFromRow(row, auth.email) }, null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: any) {
+    return new Response(JSON.stringify({ ok: false, error: String(err?.message || err) }, null, 2), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};
+
+export const onRequestPost = async (context: any): Promise<Response> => {
+  const auth = await requireMember(context);
+  if (!auth.ok) {
+    return new Response(JSON.stringify(auth.body), {
+      status: auth.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const body = await context.request.json().catch(() => null);
+    if (!body || typeof body !== 'object') {
+      return new Response(JSON.stringify({ ok: false, error: 'Invalid JSON body' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const firstName = String((body as any).first_name ?? '').trim();
+    const lastName = String((body as any).last_name ?? '').trim();
+    const screenName = String((body as any).screen_name ?? '').trim();
+    const emailOptIn = (body as any).email_opt_in == null ? true : Boolean((body as any).email_opt_in);
+    const profilePhotoIdRaw = (body as any).profile_photo_id;
+    const profilePhotoId =
+      profilePhotoIdRaw == null || String(profilePhotoIdRaw).trim() === ''
+        ? null
+        : Number(profilePhotoIdRaw);
+
+    if (!firstName || !lastName) {
+      return new Response(JSON.stringify({ ok: false, error: 'first_name and last_name are required' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (profilePhotoId != null && (!Number.isFinite(profilePhotoId) || profilePhotoId <= 0)) {
+      return new Response(JSON.stringify({ ok: false, error: 'profile_photo_id must be a positive number' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const name = `${firstName} ${lastName}`.trim();
+
+    // Identity comes from authenticated session email only.
+    const upsert = await auth.db
+      .prepare(
+        `UPDATE join_requests
+         SET name = ?1,
+             first_name = ?2,
+             last_name = ?3,
+             screen_name = ?4,
+             email_opt_in = ?5,
+             profile_photo_id = ?6
+         WHERE lower(email) = lower(?7)`
+      )
+      .bind(name, firstName, lastName, screenName || null, emailOptIn ? 1 : 0, profilePhotoId, auth.email)
+      .run();
+
+    if (Number((upsert as any)?.meta?.changes || 0) === 0) {
+      await auth.db
+        .prepare(
+          `INSERT INTO join_requests (name, email, first_name, last_name, screen_name, email_opt_in, profile_photo_id, created_at)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'))`
+        )
+        .bind(name, auth.email, firstName, lastName, screenName || null, emailOptIn ? 1 : 0, profilePhotoId)
+        .run();
+    }
+
+    const row = await auth.db
+      .prepare(
+        `SELECT first_name, last_name, screen_name, email_opt_in, profile_photo_id
+         FROM join_requests
+         WHERE lower(email) = lower(?1)
+         LIMIT 1`
+      )
+      .bind(auth.email)
+      .first();
+
+    return new Response(JSON.stringify({ ok: true, profile: profileFromRow(row, auth.email) }, null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: any) {
+    return new Response(JSON.stringify({ ok: false, error: String(err?.message || err) }, null, 2), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/photos.ts
+++ b/functions/api/photos.ts
@@ -1,0 +1,62 @@
+import { normalizePhotoUrl } from '../_lib/photo-url';
+
+function parseLimit(raw: string | null): number {
+  const n = Number(raw || '20');
+  if (!Number.isFinite(n)) return 20;
+  return Math.max(1, Math.min(100, Math.floor(n)));
+}
+
+function parseOffset(raw: string | null): number {
+  const n = Number(raw || '0');
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.floor(n));
+}
+
+export const onRequestGet = async (context: any): Promise<Response> => {
+  const { env, request } = context;
+
+  try {
+    const url = new URL(request.url);
+    const eligible = String(url.searchParams.get('eligible') || '').trim().toLowerCase();
+    const limit = parseLimit(url.searchParams.get('limit'));
+    const offset = parseOffset(url.searchParams.get('offset'));
+    const memorabilia = url.searchParams.get('memorabilia');
+
+    let sql = 'SELECT id, photo_id, url, is_memorabilia, title, description, tags, created_at FROM photos';
+    const where: string[] = [];
+    const args: any[] = [];
+
+    if (memorabilia === '1') {
+      where.push('is_memorabilia = 1');
+    }
+
+    // Canonical profile avatar source: tag contains profile-avatar-eligible.
+    if (eligible === 'profile-avatar') {
+      where.push("lower(COALESCE(tags,'')) LIKE ?");
+      args.push('%profile-avatar-eligible%');
+    }
+
+    if (where.length) {
+      sql += ` WHERE ${where.join(' AND ')}`;
+    }
+
+    sql += ' ORDER BY id DESC LIMIT ? OFFSET ?';
+    args.push(limit, offset);
+
+    const rows = await env.DB.prepare(sql).bind(...args).all();
+    const items = (rows.results || []).map((row: any) => ({
+      ...row,
+      url: normalizePhotoUrl({ rawUrl: row?.url, request, publicB2BaseUrl: env.PUBLIC_B2_BASE_URL }),
+    }));
+
+    return new Response(JSON.stringify({ ok: true, items, limit, offset }, null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: any) {
+    return new Response(JSON.stringify({ ok: false, error: String(err?.message || err) }, null, 2), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/802

### Motivation
- Provide the missing FanClub backend routing defined by the design docs so the runtime API surface matches the canonical contract for member-only FanClub pages. 
- Keep the existing cookie-backed session model and D1-backed content sources while avoiding risky rewrites to existing endpoints.
- Support front-end needs for profile, membership card, and search/tag/pagination list views for photos, library, and memorabilia.

### Description
- Added member-protected FanClub endpoints under `functions/api/fanclub`: `photos.ts`, `library.ts`, `memorabilia.ts`, and `profile.ts`, each implementing the design-specified query surface, pagination, and normalized JSON envelopes (fields documented in code comments). 
- Added `functions/api/content/membercard.ts` to return the canonical posted membership card content from `membership_card_content` (member session required). 
- Added a compatibility top-level `functions/api/photos.ts` implementing `GET /api/photos` that preserves existing list semantics and adds support for `?eligible=profile-avatar` (filters `tags` for `profile-avatar-eligible`) without removing existing `/api/photos/list` or `/api/photos/get` routes. 
- Reused existing session and D1 helper utilities (`requireMember`, session guards, `normalizePhotoUrl`, `requireD1` semantics) to avoid auth-model drift; profile POST never trusts client-submitted email and uses session identity for updates. 
- Documented and adapted to schema differences in-code: `uploaded_by` maps to `photos.source`, `library_id` for memorabilia is returned as `null` (no FK), library `author`/`year`/`description` are derived from `library_entries` (`name`/`created_at`/`content`), and photos approval is treated as current catalog rows due to no explicit approval column. 

### Testing
- Ran TypeScript checks with `npm run typecheck`, which completed successfully. 
- Verified the new route files exist and export the expected Pages Function handlers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd54376a28832996b362fcef2c3fc4)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds member-protected FanClub API routes and a membercard endpoint to match the design contract for member-only pages without breaking existing APIs. Also adds a compatible `/api/photos` with an avatar-eligibility filter.

- **New Features**
  - FanClub routes (member session required):
    - `GET /api/fanclub/photos`: search, `tags`, pagination; normalized items with `thumbnail_url`; `uploaded_by` sourced from `photos.source`.
    - `GET /api/fanclub/memorabilia`: `is_memorabilia` items with search/tags/pagination; `library_id` returned as `null`.
    - `GET /api/fanclub/library`: search and pagination; `year` derived from `created_at`, `author` from `name`, short `description`.
    - `GET /api/fanclub/profile` and `POST /api/fanclub/profile`: read/update profile; update uses session email, validates names and `profile_photo_id`.
  - `GET /api/content/membercard`: returns the latest posted content from `membership_card_content` (member session required).
  - Compatibility route: `GET /api/photos` keeps existing list semantics and adds `eligible=profile-avatar` (filters `tags`), plus `memorabilia=1`, `limit`, `offset`.

- **Migration**
  - No breaking changes; existing `/api/photos/list` and `/api/photos/get` still work.
  - Frontend for member-only pages should call the new `fanclub` and `content/membercard` routes (requires current cookie-backed session).
  - For avatar pickers, use `GET /api/photos?eligible=profile-avatar` to fetch eligible images.

<sup>Written for commit 970456eec54b211a94eacbbe23af4af08004e6d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

