### PR TITLE
Redirect legacy /login to / and update Login links to /join?mode=login

### DIFF
--- a/scripts/ci/verify_lgfc_invariants.mjs
+++ b/scripts/ci/verify_lgfc_invariants.mjs
@@ -14,12 +14,12 @@ const header = fs.readFileSync('src/components/Header.tsx', 'utf8');
 const idxJoin = header.indexOf('href="/join"');
 const idxSearch = header.indexOf('href="/search"');
 const idxStore = header.indexOf('bonfire.com/store/lou-gehrig-fan-club');
-const idxLogin = header.indexOf('href="/login"');
+const idxLogin = header.indexOf('href="/join?mode=login"');
 
 must(idxJoin !== -1, 'Header missing Join link to /join');
 must(idxSearch !== -1, 'Header missing Search link to /search');
 must(idxStore !== -1, 'Header missing Store external link');
-must(idxLogin !== -1, 'Header missing Login link to /login');
+must(idxLogin !== -1, 'Header missing Login link to /join?mode=login');
 must(idxJoin < idxSearch && idxSearch < idxStore && idxStore < idxLogin, 'Header public button order must be Join, Search, Store, Login');
 
 const fanClubHeader = fs.readFileSync('src/components/FanClubHeader.tsx', 'utf8');

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,5 +1,7 @@
 import AuthClient from '../auth/AuthClient';
 
-export default function JoinPage(){
-  return <AuthClient defaultMode="join" />;
+export default async function JoinPage({ searchParams }: { searchParams: Promise<{ mode?: string }> }) {
+  const { mode: modeParam } = await searchParams;
+  const mode = modeParam === 'login' ? 'login' : 'join';
+  return <AuthClient defaultMode={mode} />;
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,5 @@
-import AuthClient from '../auth/AuthClient';
+import { redirect } from "next/navigation";
 
-export default function LoginPage(){
-  return <AuthClient defaultMode="login" />;
+export default function Page() {
+  redirect("/");
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -107,7 +107,7 @@ export default function Header({ homeRoute = '/', showLogo = true }: HeaderProps
           </a>
 
           {!isLoggedIn ? (
-            <Link className={styles.btn} href="/join">Login</Link>
+            <Link className={styles.btn} href="/join?mode=login">Login</Link>
           ) : (
             <>
               <Link className={styles.btn} href="/logout">Logout</Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -107,7 +107,7 @@ export default function Header({ homeRoute = '/', showLogo = true }: HeaderProps
           </a>
 
           {!isLoggedIn ? (
-            <Link className={styles.btn} href="/login">Login</Link>
+            <Link className={styles.btn} href="/join">Login</Link>
           ) : (
             <>
               <Link className={styles.btn} href="/logout">Logout</Link>

--- a/src/components/JoinCTA.tsx
+++ b/src/components/JoinCTA.tsx
@@ -8,7 +8,7 @@ export default function JoinCTA() {
         <p className="join-banner__text">Become a member. Get access to the Gehrig library, media archive, memorabilia archive, group discussions, and more.</p>
         <div className="join-banner__actions">
           <Link className="join-banner__btn" href="/join">Join</Link>
-          <Link className="join-banner__btn" href="/login">Login</Link>
+          <Link className="join-banner__btn" href="/join">Login</Link>
         </div>
       </div>
     </div>

--- a/src/components/JoinCTA.tsx
+++ b/src/components/JoinCTA.tsx
@@ -8,7 +8,7 @@ export default function JoinCTA() {
         <p className="join-banner__text">Become a member. Get access to the Gehrig library, media archive, memorabilia archive, group discussions, and more.</p>
         <div className="join-banner__actions">
           <Link className="join-banner__btn" href="/join">Join</Link>
-          <Link className="join-banner__btn" href="/join">Login</Link>
+          <Link className="join-banner__btn" href="/join?mode=login">Login</Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/810

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] OR any ZIP file that was present in the repo root was deleted before any other change
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Implementation
- Task: Fix legacy /login route and Login CTA routing
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: None
- Notes: Gate check failure resolved by updating Login links to `/join?mode=login` and updating invariant script accordingly.

## LABEL
- Intent label for this PR: codex

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical design reference: `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- Additional design/reference docs used for this PR: N/A

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- src/app/login/page.tsx
- src/components/Header.tsx
- src/components/JoinCTA.tsx
- src/app/join/page.tsx
- scripts/ci/verify_lgfc_invariants.mjs

All other files are out of scope.

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## DOCS-ONLY ASSERTION (REQUIRED FOR change-ops)
- N/A — this PR contains runtime code changes, not docs-only changes.

## CHANGE SUMMARY
- Replaced the runtime implementation of `/login` (`src/app/login/page.tsx`) with a server-side redirect to `/` using `redirect` from `next/navigation`, so `/login` no longer renders login UI.
- Updated public Login CTAs in `src/components/Header.tsx` and `src/components/JoinCTA.tsx` to point to `/join?mode=login` so the Login button lands on the login form (not the join form).
- Updated `src/app/join/page.tsx` to read the `mode` query param from `searchParams` (async, per Next.js 15+ API) and pass it as `defaultMode` to `AuthClient`, so `/join?mode=login` correctly opens the login form.
- Updated `scripts/ci/verify_lgfc_invariants.mjs` to check for `href="/join?mode=login"` in `Header.tsx` instead of `href="/login"`, keeping the GATE — Drift Control invariant aligned with the new canonical Login entry point.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `node scripts/ci/verify_lgfc_invariants.mjs`
- Result summary:
  - PASS
- If FAIL, explain: N/A

## DOCUMENTATION UPDATES
- [x] No documentation updates required
- Files: N/A

## ACCEPTANCE CRITERIA
- `/login` redirects to `/` (legacy compatibility)
- Login CTAs in Header and JoinCTA route to `/join?mode=login`, landing users on the login form
- `/join?mode=login` opens the login form; `/join` (no param) opens the join form
- `verify_lgfc_invariants.mjs` gate check passes
- No active UI routes point to `/login` as a login page
- CI passes fully

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] Local checks executed and passed
- [x] Commit message aligns with scope
- [x] No secrets or forbidden artifacts introduced

------
<a href="https://chatgpt.com/codex/tasks/task_e_69cd6a76abf88329b0d99c04d47b985f">Codex Task</a>