### PR TITLE
Add Jonathan Eig Lou Gehrig book to Friends of the Fan Club

### DIFF
--- a/migrations/0020_seed_friend_luckiest_man.sql
+++ b/migrations/0020_seed_friend_luckiest_man.sql
@@ -1,0 +1,10 @@
+-- Seed: Luckiest Man Lou Gehrig book
+INSERT INTO friends (name, kind, blurb, url, photo_url, status)
+VALUES (
+  'Luckiest Man: The Life and Death of Lou Gehrig',
+  'business',
+  'Definitive biography of Lou Gehrig by Jonathan Eig',
+  'https://www.jonathaneig.com/luckiest-man-the-life-and-death-of-lou-gehrig',
+  NULL,
+  'posted'
+);


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/812

### PR Template

#### Reference
Refer to `/.github/pull_request_template.md`

#### Governance Reference
/docs/governance/PR_GOVERNANCE.md

## CHANGE SUMMARY
- Adds Luckiest Man Lou Gehrig book to D1 friends table
- Enables homepage Friends section to render new tile via existing API

## IMPLEMENTATION
- Added migration to seed friends table
- No UI changes required (component already DB-driven)

## ACCEPTANCE CRITERIA
- Entry exists in friends table
- Homepage renders new tile
- Link opens externally

## NOTES
This leverages existing `/api/friends/list` endpoint and FriendsOfFanClub component.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Luckiest Man: The Life and Death of Lou Gehrig” by Jonathan Eig to Friends of the Fan Club by seeding the `friends` table. The homepage Friends section will automatically render the new tile via the existing `/api/friends/list` endpoint.

<sup>Written for commit 6979c88d2a5cd98b7a98b0ddfda04a5222ef47bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

