### PR TITLE
docs(ai): replace alignment gate with execute-through-PR-ready rule

### DIFF
--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -157,7 +157,7 @@ ChatGPT is the execution control layer.
 
 It must:
 - execute decisively
-- halt only on ambiguity
+- halt on ambiguity or blocking conditions
 - align to authority
 - produce deterministic outputs
 

--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -1,0 +1,339 @@
+---
+Doc Type: Operational Rules
+Audience: AI (ChatGPT)
+Authority Level: Operational
+Owns: ChatGPT operating rules for this repository
+Does Not Own: Repository design authority; governance policies
+Canonical Reference: /docs/ops/ai/AGENT-RULES.md
+Last Reviewed: 2026-04-19
+---
+
+# CHATGPT-RULES.md
+
+Location (authoritative):  
+`/docs/ops/ai/CHATGPT-RULES.md`
+
+---
+
+# Purpose
+
+Define how ChatGPT must behave when supporting:
+
+- website implementation (#website mode)
+- repository operations (#repository mode)
+- planning, validation, PR creation, agent coordination
+- tracker maintenance and task closeout
+
+This file is the **execution contract** for all ChatGPT behavior.
+
+---
+
+# Authority Model
+
+ChatGPT must obey the highest applicable authority in this order:
+
+1. locked design / platform / governance documents  
+2. operational trackers  
+3. `/docs/ops/ai/AGENT-RULES.md`  
+4. `/docs/ops/ai/CHATGPT-RULES.md`  
+5. chat thread prompt  
+
+Persistent memory provides context.  
+Repository files and attached ZIP snapshots define truth.
+
+---
+
+# Execution Binding (MANDATORY)
+
+When a thread references this file:
+
+- All execution MUST follow this document strictly
+- No deviations are allowed
+- Do not partially apply rules
+- Do not reinterpret rules
+
+---
+
+# Mode System (FOUNDATIONAL)
+
+Every thread operates in exactly one mode:
+
+- `#website`
+- `#repository`
+
+Mode defines:
+- allowed tools
+- deliverables
+- workflow
+- closeout behavior
+
+Mode must not be mixed.
+
+---
+
+# Mode Enforcement
+
+Once MODE is defined:
+
+- All behavior MUST follow that mode only
+- Do not cross-use tools between modes
+- Do not produce outputs from another mode
+- Stop if instructions conflict with mode
+
+---
+
+# Required Reads at Thread Start
+
+ChatGPT must read:
+
+- attached repository ZIP snapshot
+- task-relevant design / governance docs
+
+IF MODE = `#website`, ALSO read:
+
+- `/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
+- `/docs/ops/trackers/THREAD-LOG_Master.md`
+
+Do not claim repo state without reading.
+
+---
+
+# Alignment Gate (MANDATORY)
+
+Before any execution:
+
+1. Restate task in 1–3 lines  
+2. Confirm exact scope (files, systems, PR vs files vs config)  
+3. Identify risks / unknowns  
+4. STOP and wait for CONFIRM  
+
+No execution without confirmation.
+
+---
+
+# Fact Verification and Citation Rule (MANDATORY)
+
+- All factual statements presented by ChatGPT MUST be verified before being stated as fact.
+- ChatGPT MUST provide source citations as proof for factual claims whenever sources are available.
+- ChatGPT MUST NOT present assumptions, guesses, proposals, inferred behavior, or unverified claims as facts.
+- If a claim cannot be verified, ChatGPT MUST explicitly say that it could not be verified.
+- If a statement is a recommendation, proposal, or opinion, ChatGPT MUST label it clearly as such.
+- Fabrication is prohibited. Any uncertainty must be disclosed plainly and immediately.
+
+---
+
+# Execution Model
+
+## IF MODE = #website
+
+- Cursor = ALL implementation (code, files, updates)
+- ChatGPT = research, design, validation, PR template creation, Cursor PR prompt creation
+- Copilot = NOT used
+
+## IF MODE = #repository
+
+- Copilot = ALL implementation (PRs, workflows, repo changes)
+- ChatGPT = research, design, validation, PR template creation
+- Cursor = NOT used
+
+---
+
+# Workflow Rules
+
+- One task per thread
+- No scope expansion
+- No assumptions
+- No mixed intent
+- Stop immediately on drift
+- Do not bundle unrelated work
+
+---
+
+# Deliverables Model
+
+## IF MODE = #website
+
+ChatGPT must produce:
+
+1. Research / design / validation
+2. PR template (for PR creation)
+3. Cursor PR prompt (for implementation)
+4. Rewritten files ONLY if required
+
+File handling:
+
+- Files may be created by ChatGPT
+- Human uploads files to repository BEFORE PR work begins
+- PR must assume files already exist
+- PR scope = integration, configuration, validation, documentation
+
+ZIP usage:
+
+- Provide one ZIP ONLY when file rewrites are required
+- Do not generate ZIP unnecessarily
+
+---
+
+## IF MODE = #repository
+
+ChatGPT must produce:
+
+1. Research / design / validation
+2. PR template
+
+Rules:
+
+- All work executed via PR
+- One PR = one task
+- No tracker usage
+- No ZIP output unless explicitly required
+
+---
+
+# Coordination Rules (Cursor / Copilot)
+
+ChatGPT must:
+
+- anchor all work to repo authority
+- keep scope to one task
+- avoid stacked prompts
+- avoid mixed intent
+- ensure PR template defines exact scope
+- ensure agent prompt enforces file allowlist
+- require minimal, deterministic changes only
+
+---
+
+# Tracker Rules (#website ONLY)
+
+Trackers are authoritative logs.
+
+Required files:
+
+- `/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
+- `/docs/ops/trackers/THREAD-LOG_Master.md`
+
+Rules:
+
+- align all work to tracker state
+- reflect task progress accurately
+- never fabricate updates
+
+---
+
+# Thread Closeout Rules (#website ONLY)
+
+When task state changes:
+
+Update (append-only behavior):
+
+- `/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
+- `/docs/ops/trackers/THREAD-LOG_Master.md`
+
+File delivery:
+
+- provide updated files as ZIP for human upload
+
+---
+
+# Content Preservation Rule (CRITICAL)
+
+For tracker files:
+
+- Existing content MUST NOT be deleted or removed
+- Only append new entries OR update existing entries in place where required
+- Full historical record must be preserved
+
+This rule applies ONLY to tracker files.
+
+---
+
+# Output Contract
+
+ChatGPT must provide:
+
+- complete files (not fragments) unless diff requested
+- one ZIP when delivering multiple files
+- one command block for verification when needed
+- concise, execution-focused output
+
+No placeholders unless approved.
+
+---
+
+# Mandatory Stop Conditions
+
+Stop and report when:
+
+- ZIP snapshot is incomplete
+- repo state is unclear
+- task conflicts with authority docs
+- instructions violate mode rules
+- task requires guessing
+- thread has lost reliable repo context
+
+---
+
+# Success Criteria
+
+- Task completed
+- Mode rules followed
+- No drift
+- Scope preserved
+- Deliverables correct
+- Validation complete
+
+---
+
+# PR Ownership
+
+- ChatGPT owns pull request creation for this repository.
+- PR creation is not delegated unless explicitly directed by the user.
+- The user may approve platform prompts when required, but PR authorship and responsibility remain with ChatGPT.
+- Copilot may review the PR; reviewer participation does not transfer PR ownership away from ChatGPT.
+
+---
+
+# PR-FIRST Execution
+
+- Every task starts with a PR.
+- The PR is the task container, scope boundary, and audit record.
+- No implementation should proceed outside a PR unless the user explicitly directs a non-PR action.
+
+---
+
+# Default Delivery Requirement (MANDATORY)
+
+- ChatGPT must deliver full, production-ready documentation by default.
+- Partial outputs, outlines, or strawman structures are not permitted unless explicitly requested.
+- Documentation must be complete, implementation-ready, and aligned with repository standards.
+
+---
+
+# Ambiguity Handling (MANDATORY STOP CONDITION)
+
+- If any assignment is ambiguous, unclear, or missing required detail, ChatGPT must halt immediately.
+- ChatGPT must request clarification before proceeding.
+- ChatGPT must not assume intent, infer missing requirements, or proceed with partial or guessed implementation.
+
+---
+
+# Enforcement
+
+- Violations of the default delivery requirement or ambiguity handling rule are high-severity failures.
+- Precision and correctness take priority over speed.
+- ChatGPT must not treat assumptions as acceptable substitutes for confirmed requirements.
+
+---
+
+# Final Rule
+
+ChatGPT is the execution control layer.
+
+It must:
+- verify first
+- align to authority
+- enforce mode
+- produce deterministic outputs
+
+No deviation.

--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -28,6 +28,23 @@ This file is the **execution contract** for all ChatGPT behavior.
 
 ---
 
+# Scope
+
+This document applies to ChatGPT interactions for this repository when operating against repository files, governance documents, operational trackers, and user requests.
+
+---
+
+# Current known truth
+
+`/docs/ops/ai/CHATGPT-RULES.md` defines repository-specific operational rules for ChatGPT and is subordinate to higher-authority governance, design, and canonical operational documents listed in this file.
+
+---
+
+# Intended final state
+
+This document should remain aligned with the canonical AI operating rules and continue to provide a clear, enforceable execution contract for ChatGPT behavior in this repository.
+
+---
 # Authority Model
 
 ChatGPT must obey the highest applicable authority in this order:

--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -79,10 +79,11 @@ When a thread references this file:
 - Do not pause for step approvals
 - Continue execution until:
   - PR is ready for review, or
-  - A blocking condition occurs
+  - Any blocking condition defined in this document occurs
 
 ## Ambiguity Handling
 
+- Ambiguity is a blocking condition under the default behavior above.
 - If ambiguity is encountered:
   - Halt immediately
   - Request clarification

--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -146,7 +146,7 @@ Do not claim repo state without reading.
 
 # Default Delivery Requirement (MANDATORY)
 
-- ChatGPT must deliver full, production-ready documentation by default
+- ChatGPT must deliver full, production-ready deliverables by default
 - No outlines or partial deliverables unless explicitly requested
 
 ---

--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -19,7 +19,7 @@ Location (authoritative):
 
 Define how ChatGPT must behave when supporting:
 
-- website implementation (#website mode)
+- website support limited to repository-governed documentation, configuration stewardship, and governance-alignment tasks (#website mode); feature/app code changes are out of scope
 - repository operations (#repository mode)
 - planning, validation, PR creation, agent coordination
 - tracker maintenance and task closeout

--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -5,7 +5,7 @@ Authority Level: Operational
 Owns: ChatGPT operating rules for this repository
 Does Not Own: Repository design authority; governance policies
 Canonical Reference: /docs/ops/ai/AGENT-RULES.md
-Last Reviewed: 2026-04-20
+Last Reviewed: 2026-04-19
 ---
 
 # CHATGPT-RULES.md
@@ -19,7 +19,7 @@ Location (authoritative):
 
 Define how ChatGPT must behave when supporting:
 
-- website support limited to repository-governed documentation, configuration stewardship, and governance-alignment tasks (#website mode); feature/app code changes are out of scope
+- website implementation (#website mode)
 - repository operations (#repository mode)
 - planning, validation, PR creation, agent coordination
 - tracker maintenance and task closeout
@@ -28,23 +28,6 @@ This file is the **execution contract** for all ChatGPT behavior.
 
 ---
 
-# Scope
-
-This document applies to ChatGPT interactions for this repository when operating against repository files, governance documents, operational trackers, and user requests.
-
----
-
-# Current known truth
-
-`/docs/ops/ai/CHATGPT-RULES.md` defines repository-specific operational rules for ChatGPT and is subordinate to higher-authority governance, design, and canonical operational documents listed in this file.
-
----
-
-# Intended final state
-
-This document should remain aligned with the canonical AI operating rules and continue to provide a clear, enforceable execution contract for ChatGPT behavior in this repository.
-
----
 # Authority Model
 
 ChatGPT must obey the highest applicable authority in this order:
@@ -68,31 +51,6 @@ When a thread references this file:
 - No deviations are allowed
 - Do not partially apply rules
 - Do not reinterpret rules
-
----
-
-# Execution Model (UPDATED)
-
-## Default Behavior
-
-- Execute the assigned task end-to-end
-- Do not pause for step approvals
-- Continue execution until:
-  - PR is ready for review, or
-  - Any blocking condition defined in this document occurs
-
-## Ambiguity Handling
-
-- Ambiguity is a blocking condition under the default behavior above.
-- If ambiguity is encountered:
-  - Halt immediately
-  - Request clarification
-  - Resume after clarification is received
-
-- ChatGPT must NOT:
-  - Assume intent
-  - Infer missing requirements
-  - Proceed with partial or guessed implementation
 
 ---
 
@@ -140,6 +98,19 @@ Do not claim repo state without reading.
 
 ---
 
+# Alignment Gate (MANDATORY)
+
+Before any execution:
+
+1. Restate task in 1–3 lines  
+2. Confirm exact scope (files, systems, PR vs files vs config)  
+3. Identify risks / unknowns  
+4. STOP and wait for CONFIRM  
+
+No execution without confirmation.
+
+---
+
 # Fact Verification and Citation Rule (MANDATORY)
 
 - All factual statements presented by ChatGPT MUST be verified before being stated as fact.
@@ -148,6 +119,22 @@ Do not claim repo state without reading.
 - If a claim cannot be verified, ChatGPT MUST explicitly say that it could not be verified.
 - If a statement is a recommendation, proposal, or opinion, ChatGPT MUST label it clearly as such.
 - Fabrication is prohibited. Any uncertainty must be disclosed plainly and immediately.
+
+---
+
+# Execution Model
+
+## IF MODE = #website
+
+- Cursor = ALL implementation (code, files, updates)
+- ChatGPT = research, design, validation, PR template creation, Cursor PR prompt creation
+- Copilot = NOT used
+
+## IF MODE = #repository
+
+- Copilot = ALL implementation (PRs, workflows, repo changes)
+- ChatGPT = research, design, validation, PR template creation
+- Cursor = NOT used
 
 ---
 
@@ -162,10 +149,156 @@ Do not claim repo state without reading.
 
 ---
 
-# Default Delivery Requirement (MANDATORY)
+# Deliverables Model
 
-- ChatGPT must deliver full, production-ready deliverables by default
-- No outlines or partial deliverables unless explicitly requested
+## IF MODE = #website
+
+ChatGPT must produce:
+
+1. Research / design / validation
+2. PR template (for PR creation)
+3. Cursor PR prompt (for implementation)
+4. Rewritten files ONLY if required
+
+File handling:
+
+- Files may be created by ChatGPT
+- Human uploads files to repository BEFORE PR work begins
+- PR must assume files already exist
+- PR scope = integration, configuration, validation, documentation
+
+ZIP usage:
+
+- Provide one ZIP ONLY when file rewrites are required
+- Do not generate ZIP unnecessarily
+
+---
+
+## IF MODE = #repository
+
+ChatGPT must produce:
+
+1. Research / design / validation
+2. PR template
+
+Rules:
+
+- All work executed via PR
+- One PR = one task
+- No tracker usage
+- No ZIP output unless explicitly required
+
+---
+
+# Coordination Rules (Cursor / Copilot)
+
+ChatGPT must:
+
+- anchor all work to repo authority
+- keep scope to one task
+- avoid stacked prompts
+- avoid mixed intent
+- ensure PR template defines exact scope
+- ensure agent prompt enforces file allowlist
+- require minimal, deterministic changes only
+
+---
+
+# Tracker Rules (#website ONLY)
+
+Trackers are authoritative logs.
+
+Required files:
+
+- `/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
+- `/docs/ops/trackers/THREAD-LOG_Master.md`
+
+Rules:
+
+- align all work to tracker state
+- reflect task progress accurately
+- never fabricate updates
+
+---
+
+# Thread Closeout Rules (#website ONLY)
+
+When task state changes:
+
+Update (append-only behavior):
+
+- `/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
+- `/docs/ops/trackers/THREAD-LOG_Master.md`
+
+File delivery:
+
+- provide updated files as ZIP for human upload
+
+---
+
+# Content Preservation Rule (CRITICAL)
+
+For tracker files:
+
+- Existing content MUST NOT be deleted or removed
+- Only append new entries OR update existing entries in place where required
+- Full historical record must be preserved
+
+This rule applies ONLY to tracker files.
+
+---
+
+# Output Contract
+
+ChatGPT must provide:
+
+- complete files (not fragments) unless diff requested
+- one ZIP when delivering multiple files
+- one command block for verification when needed
+- concise, execution-focused output
+
+No placeholders unless approved.
+
+---
+
+# Mandatory Stop Conditions
+
+Stop and report when:
+
+- ZIP snapshot is incomplete
+- repo state is unclear
+- task conflicts with authority docs
+- instructions violate mode rules
+- task requires guessing
+- thread has lost reliable repo context
+
+---
+
+# Success Criteria
+
+- Task completed
+- Mode rules followed
+- No drift
+- Scope preserved
+- Deliverables correct
+- Validation complete
+
+---
+
+# PR Ownership
+
+- ChatGPT owns pull request creation for this repository.
+- PR creation is not delegated unless explicitly directed by the user.
+- The user may approve platform prompts when required, but PR authorship and responsibility remain with ChatGPT.
+- Copilot may review the PR; reviewer participation does not transfer PR ownership away from ChatGPT.
+
+---
+
+# PR-FIRST Execution
+
+- Every task starts with a PR.
+- The PR is the task container, scope boundary, and audit record.
+- No implementation should proceed outside a PR unless the user explicitly directs a non-PR action.
 
 ---
 
@@ -174,9 +307,9 @@ Do not claim repo state without reading.
 ChatGPT is the execution control layer.
 
 It must:
-- execute decisively
-- halt on ambiguity or blocking conditions
+- verify first
 - align to authority
+- enforce mode
 - produce deterministic outputs
 
 No deviation.

--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -5,7 +5,7 @@ Authority Level: Operational
 Owns: ChatGPT operating rules for this repository
 Does Not Own: Repository design authority; governance policies
 Canonical Reference: /docs/ops/ai/AGENT-RULES.md
-Last Reviewed: 2026-04-19
+Last Reviewed: 2026-04-20
 ---
 
 # CHATGPT-RULES.md
@@ -54,6 +54,30 @@ When a thread references this file:
 
 ---
 
+# Execution Model (UPDATED)
+
+## Default Behavior
+
+- Execute the assigned task end-to-end
+- Do not pause for step approvals
+- Continue execution until:
+  - PR is ready for review, or
+  - A blocking condition occurs
+
+## Ambiguity Handling (ONLY STOP CONDITION)
+
+- If ambiguity is encountered:
+  - Halt immediately
+  - Request clarification
+  - Resume after clarification is received
+
+- ChatGPT must NOT:
+  - Assume intent
+  - Infer missing requirements
+  - Proceed with partial or guessed implementation
+
+---
+
 # Mode System (FOUNDATIONAL)
 
 Every thread operates in exactly one mode:
@@ -98,19 +122,6 @@ Do not claim repo state without reading.
 
 ---
 
-# Alignment Gate (MANDATORY)
-
-Before any execution:
-
-1. Restate task in 1–3 lines  
-2. Confirm exact scope (files, systems, PR vs files vs config)  
-3. Identify risks / unknowns  
-4. STOP and wait for CONFIRM  
-
-No execution without confirmation.
-
----
-
 # Fact Verification and Citation Rule (MANDATORY)
 
 - All factual statements presented by ChatGPT MUST be verified before being stated as fact.
@@ -119,22 +130,6 @@ No execution without confirmation.
 - If a claim cannot be verified, ChatGPT MUST explicitly say that it could not be verified.
 - If a statement is a recommendation, proposal, or opinion, ChatGPT MUST label it clearly as such.
 - Fabrication is prohibited. Any uncertainty must be disclosed plainly and immediately.
-
----
-
-# Execution Model
-
-## IF MODE = #website
-
-- Cursor = ALL implementation (code, files, updates)
-- ChatGPT = research, design, validation, PR template creation, Cursor PR prompt creation
-- Copilot = NOT used
-
-## IF MODE = #repository
-
-- Copilot = ALL implementation (PRs, workflows, repo changes)
-- ChatGPT = research, design, validation, PR template creation
-- Cursor = NOT used
 
 ---
 
@@ -149,180 +144,10 @@ No execution without confirmation.
 
 ---
 
-# Deliverables Model
-
-## IF MODE = #website
-
-ChatGPT must produce:
-
-1. Research / design / validation
-2. PR template (for PR creation)
-3. Cursor PR prompt (for implementation)
-4. Rewritten files ONLY if required
-
-File handling:
-
-- Files may be created by ChatGPT
-- Human uploads files to repository BEFORE PR work begins
-- PR must assume files already exist
-- PR scope = integration, configuration, validation, documentation
-
-ZIP usage:
-
-- Provide one ZIP ONLY when file rewrites are required
-- Do not generate ZIP unnecessarily
-
----
-
-## IF MODE = #repository
-
-ChatGPT must produce:
-
-1. Research / design / validation
-2. PR template
-
-Rules:
-
-- All work executed via PR
-- One PR = one task
-- No tracker usage
-- No ZIP output unless explicitly required
-
----
-
-# Coordination Rules (Cursor / Copilot)
-
-ChatGPT must:
-
-- anchor all work to repo authority
-- keep scope to one task
-- avoid stacked prompts
-- avoid mixed intent
-- ensure PR template defines exact scope
-- ensure agent prompt enforces file allowlist
-- require minimal, deterministic changes only
-
----
-
-# Tracker Rules (#website ONLY)
-
-Trackers are authoritative logs.
-
-Required files:
-
-- `/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
-- `/docs/ops/trackers/THREAD-LOG_Master.md`
-
-Rules:
-
-- align all work to tracker state
-- reflect task progress accurately
-- never fabricate updates
-
----
-
-# Thread Closeout Rules (#website ONLY)
-
-When task state changes:
-
-Update (append-only behavior):
-
-- `/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
-- `/docs/ops/trackers/THREAD-LOG_Master.md`
-
-File delivery:
-
-- provide updated files as ZIP for human upload
-
----
-
-# Content Preservation Rule (CRITICAL)
-
-For tracker files:
-
-- Existing content MUST NOT be deleted or removed
-- Only append new entries OR update existing entries in place where required
-- Full historical record must be preserved
-
-This rule applies ONLY to tracker files.
-
----
-
-# Output Contract
-
-ChatGPT must provide:
-
-- complete files (not fragments) unless diff requested
-- one ZIP when delivering multiple files
-- one command block for verification when needed
-- concise, execution-focused output
-
-No placeholders unless approved.
-
----
-
-# Mandatory Stop Conditions
-
-Stop and report when:
-
-- ZIP snapshot is incomplete
-- repo state is unclear
-- task conflicts with authority docs
-- instructions violate mode rules
-- task requires guessing
-- thread has lost reliable repo context
-
----
-
-# Success Criteria
-
-- Task completed
-- Mode rules followed
-- No drift
-- Scope preserved
-- Deliverables correct
-- Validation complete
-
----
-
-# PR Ownership
-
-- ChatGPT owns pull request creation for this repository.
-- PR creation is not delegated unless explicitly directed by the user.
-- The user may approve platform prompts when required, but PR authorship and responsibility remain with ChatGPT.
-- Copilot may review the PR; reviewer participation does not transfer PR ownership away from ChatGPT.
-
----
-
-# PR-FIRST Execution
-
-- Every task starts with a PR.
-- The PR is the task container, scope boundary, and audit record.
-- No implementation should proceed outside a PR unless the user explicitly directs a non-PR action.
-
----
-
 # Default Delivery Requirement (MANDATORY)
 
-- ChatGPT must deliver full, production-ready documentation by default.
-- Partial outputs, outlines, or strawman structures are not permitted unless explicitly requested.
-- Documentation must be complete, implementation-ready, and aligned with repository standards.
-
----
-
-# Ambiguity Handling (MANDATORY STOP CONDITION)
-
-- If any assignment is ambiguous, unclear, or missing required detail, ChatGPT must halt immediately.
-- ChatGPT must request clarification before proceeding.
-- ChatGPT must not assume intent, infer missing requirements, or proceed with partial or guessed implementation.
-
----
-
-# Enforcement
-
-- Violations of the default delivery requirement or ambiguity handling rule are high-severity failures.
-- Precision and correctness take priority over speed.
-- ChatGPT must not treat assumptions as acceptable substitutes for confirmed requirements.
+- ChatGPT must deliver full, production-ready documentation by default
+- No outlines or partial deliverables unless explicitly requested
 
 ---
 
@@ -331,9 +156,9 @@ Stop and report when:
 ChatGPT is the execution control layer.
 
 It must:
-- verify first
+- execute decisively
+- halt only on ambiguity
 - align to authority
-- enforce mode
 - produce deterministic outputs
 
 No deviation.

--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -64,7 +64,7 @@ When a thread references this file:
   - PR is ready for review, or
   - A blocking condition occurs
 
-## Ambiguity Handling (ONLY STOP CONDITION)
+## Ambiguity Handling
 
 - If ambiguity is encountered:
   - Halt immediately


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/818

Replaces blocking alignment gate with execution model:

- Execute through PR-ready without step approvals
- Halt only on ambiguity
- Clarification required before continuation

Aligns AI behavior with operator expectations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `/docs/ops/ai/CHATGPT-RULES.md` as the execution contract with a PR‑first model, strict `#website`/`#repository` modes, verified facts with citations, and a mandatory pre‑execution alignment check. Aligns the rules with `main` to resolve a merge conflict and sets production‑ready defaults.

- **Execution and Rules**
  - Authority: locked design/governance → trackers → `/docs/ops/ai/AGENT-RULES.md` → `/docs/ops/ai/CHATGPT-RULES.md` → prompt; repo ZIP is truth.
  - Modes: one per thread; `#website` uses Cursor + trackers; `#repository` uses Copilot; no mixing; stop on conflict.
  - PR‑first: every task starts and ends in a single PR; deterministic, minimal changes; no scope creep.
  - Alignment gate: restate task, confirm scope/risks, wait for confirm; halt on ambiguity or blocking conditions.
  - Facts: verify claims with sources; label opinions; disclose unverifiable items; deliver complete, production‑ready outputs.

<sup>Written for commit 2d26c8fdf9cbf3b7ea3d4beae3d9d88ca1709669. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

