### PR TITLE
nav-header-footer-invariants

### DIFF
--- a/src/app/fanclub/page.tsx
+++ b/src/app/fanclub/page.tsx
@@ -27,7 +27,7 @@ export default function MemberHomePage() {
 
   return (
     <main>
-      <FloatingLogo homeRoute="/" />
+      <FloatingLogo />
       <h1
         style={{
           fontSize: 32,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import SocialWall from '@/components/SocialWall';
 export default function HomePage() {
   return (
     <>
-      <FloatingLogo homeRoute="/" />
+      <FloatingLogo />
       {/* Section: Hero Banner */}
       <header id="banner" className={styles.hero}>
         <div className={styles.container}>

--- a/src/components/FanClubHeader.tsx
+++ b/src/components/FanClubHeader.tsx
@@ -6,11 +6,10 @@ import styles from './FanClubHeader.module.css';
 import HamburgerMenu from './HamburgerMenu';
 
 type FanClubHeaderProps = {
-  homeRoute?: string;
   showLogo?: boolean;
 };
 
-export default function FanClubHeader({ homeRoute = '/', showLogo = true }: FanClubHeaderProps = {}) {
+export default function FanClubHeader({ showLogo = true }: FanClubHeaderProps = {}) {
   const [open, setOpen] = useState(false);
   const toggleRef = useRef<HTMLButtonElement>(null);
   const leftClassName = showLogo ? styles.left : `${styles.left} ${styles.leftOffset}`;
@@ -21,7 +20,7 @@ export default function FanClubHeader({ homeRoute = '/', showLogo = true }: FanC
         {/* LEFT: Logo (small header logo; hidden when FloatingLogo is active) */}
         <div className={leftClassName}>
           {showLogo ? (
-            <Link href={homeRoute} aria-label="Lou Gehrig Fan Club" className={styles.logoLink}>
+            <Link href="/" aria-label="Lou Gehrig Fan Club" className={styles.logoLink}>
               <img className={styles.logoImg} src="/IMG_1946.png" alt="LGFC" />
             </Link>
           ) : (

--- a/src/components/FloatingLogo.tsx
+++ b/src/components/FloatingLogo.tsx
@@ -4,17 +4,13 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import styles from './FloatingLogo.module.css';
 
-type FloatingLogoProps = {
-  homeRoute?: string;
-};
-
 /**
  * FloatingLogo
  * - Independent overlay layer (NOT part of the sticky header)
  * - Visible at top of "/" and "/fanclub"
  * - Disappears only after the user scrolls past the hero area (threshold tuned)
  */
-export default function FloatingLogo({ homeRoute = '/' }: FloatingLogoProps = {}) {
+export default function FloatingLogo() {
   const [show, setShow] = useState(true);
 
   useEffect(() => {
@@ -32,7 +28,7 @@ export default function FloatingLogo({ homeRoute = '/' }: FloatingLogoProps = {}
 
   return (
     <div className={styles.wrap}>
-      <Link href={homeRoute} aria-label="Lou Gehrig Fan Club" className={styles.link}>
+      <Link href="/" aria-label="Lou Gehrig Fan Club" className={styles.link}>
         <img className={styles.img} src="/IMG_1946.png" alt="LGFC" />
       </Link>
     </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,7 +29,7 @@ export default function Footer() {
         if (!quoteObj) return;
 
         const quote = asString(quoteObj.quote);
-        const source = asString(quoteObj.source);
+        const source = asString(quoteObj.source) ?? asString(quoteObj.attribution);
         if (!quote) return;
 
         if (!cancelled) setQ({ quote, source });

--- a/src/components/HamburgerMenu.tsx
+++ b/src/components/HamburgerMenu.tsx
@@ -7,7 +7,7 @@ import { useClickAway } from '@/hooks/useClickAway';
 /**
  * Visitor hamburger menu.
  * All headers: About, Contact
- * (Support page eliminated by design; Store remains a header button)
+ * Mobile hamburger additionally includes Store as a menu link.
  */
 export default function HamburgerMenu({
   onClose,
@@ -33,6 +33,18 @@ export default function HamburgerMenu({
               <Link href="/contact" onClick={onClose} style={styles.link}>
                 Contact
               </Link>
+            </li>
+            <li style={styles.li}>
+              <a
+                href="https://www.bonfire.com/store/lou-gehrig-fan-club/"
+                target="_blank"
+                rel="noopener noreferrer"
+                referrerPolicy="no-referrer"
+                onClick={onClose}
+                style={styles.link}
+              >
+                Store
+              </a>
             </li>
           </ul>
         </nav>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,6 @@ import styles from './Header.module.css';
 import HamburgerMenu from './HamburgerMenu';
 
 type HeaderProps = {
-  homeRoute?: string;
   showLogo?: boolean;
 };
 
@@ -36,7 +35,7 @@ function asBoolean(v: unknown): boolean | undefined {
  * - Hamburger present on all public pages
  * - Store must open new tab to Bonfire storefront URL
  */
-export default function Header({ homeRoute = '/', showLogo = true }: HeaderProps = {}) {
+export default function Header({ showLogo = true }: HeaderProps = {}) {
   const [session, setSession] = useState<SessionState>({ status: 'unknown' });
   const [open, setOpen] = useState(false);
   const toggleRef = useRef<HTMLButtonElement>(null);
@@ -81,7 +80,7 @@ export default function Header({ homeRoute = '/', showLogo = true }: HeaderProps
       <div className={styles.inner}>
         {showLogo ? (
           <div className={styles.logoContainer}>
-            <Link href={homeRoute} aria-label="Lou Gehrig Fan Club" className={styles.logoLink}>
+            <Link href="/" aria-label="Lou Gehrig Fan Club" className={styles.logoLink}>
               <img className={styles.logo} src="/IMG_1946.png" alt="LGFC Logo" />
             </Link>
           </div>
@@ -107,7 +106,7 @@ export default function Header({ homeRoute = '/', showLogo = true }: HeaderProps
           </a>
 
           {!isLoggedIn ? (
-            <Link className={styles.btn} href="/login">Login</Link>
+            <Link className={styles.btn} href="/join">Login</Link>
           ) : (
             <>
               <Link className={styles.btn} href="/logout">Logout</Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -106,7 +106,7 @@ export default function Header({ showLogo = true }: HeaderProps = {}) {
           </a>
 
           {!isLoggedIn ? (
-            <Link className={styles.btn} href="/join">Login</Link>
+            <Link className={styles.btn} href="/login">Login</Link>
           ) : (
             <>
               <Link className={styles.btn} href="/logout">Logout</Link>

--- a/src/components/JoinCTA.tsx
+++ b/src/components/JoinCTA.tsx
@@ -8,7 +8,7 @@ export default function JoinCTA() {
         <p className="join-banner__text">Become a member. Get access to the Gehrig library, media archive, memorabilia archive, group discussions, and more.</p>
         <div className="join-banner__actions">
           <Link className="join-banner__btn" href="/join">Join</Link>
-          <Link className="join-banner__btn" href="/login">Login</Link>
+          <Link className="join-banner__btn" href="/join">Login</Link>
         </div>
       </div>
     </div>

--- a/src/components/JoinCTA.tsx
+++ b/src/components/JoinCTA.tsx
@@ -8,7 +8,7 @@ export default function JoinCTA() {
         <p className="join-banner__text">Become a member. Get access to the Gehrig library, media archive, memorabilia archive, group discussions, and more.</p>
         <div className="join-banner__actions">
           <Link className="join-banner__btn" href="/join">Join</Link>
-          <Link className="join-banner__btn" href="/join">Login</Link>
+          <Link className="join-banner__btn" href="/join?mode=login">Login</Link>
         </div>
       </div>
     </div>

--- a/src/components/JoinCTA.tsx
+++ b/src/components/JoinCTA.tsx
@@ -8,7 +8,7 @@ export default function JoinCTA() {
         <p className="join-banner__text">Become a member. Get access to the Gehrig library, media archive, memorabilia archive, group discussions, and more.</p>
         <div className="join-banner__actions">
           <Link className="join-banner__btn" href="/join">Join</Link>
-          <Link className="join-banner__btn" href="/join">Login</Link>
+          <Link className="join-banner__btn" href="/login">Login</Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/834

### Motivation
- Enforce the canonical navigation, header, and footer invariants defined in the design docs so public/member header state, button order, logo routing, mobile hamburger behavior, and footer quote rendering match production design exactly.

### Description
- Force all header and floating logo links to route to `/` by removing overridable `homeRoute` props and updating mounts on both `src/app/page.tsx` and `src/app/fanclub/page.tsx`.
- Align public header button mapping so `Login` routes to `/join` and `Join/Club Home → Search → Store → Login/Logout` order is preserved in `src/components/Header.tsx` and `src/components/FanClubHeader.tsx`.
- Add `Store` as an entry in the mobile hamburger menu (external Bonfire link) while keeping `About` and `Contact`, implemented in `src/components/HamburgerMenu.tsx`.
- Make footer quote parsing robust to current API payloads by accepting `attribution` as a fallback to `source` so `/api/footer-quote` responses render correctly in `src/components/Footer.tsx`.
- Update `JoinCTA` login button to point at `/join` to match canonical routing in `src/components/JoinCTA.tsx`.

### Testing
- Ran `npm run lint` and it completed successfully with only Next.js image warnings (no blocking lint failures).
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully with no type errors.
- Attempted automated Playwright-driven mobile screenshot to validate hamburger/footer behavior but the run was blocked by missing host browser dependencies in this environment (Playwright browser launch failed); this E2E check could be completed in CI or a host with Playwright browser deps installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c0bf2c2c83299a15738a766aef19)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes navigation, headers, and footer to match the production design. Locks routing to canonical paths and fixes footer quote rendering.

- **Navigation and footer**
  - Remove `homeRoute`; all header and logo links go to `/`.
  - Keep public header button order; Login routes to `/login`.
  - Add Store to the mobile hamburger; opens Bonfire in a new tab.
  - Footer quote falls back to `attribution` when `source` is missing.
  - Update `JoinCTA` Login to `/login`.

<sup>Written for commit c153c189241846cde39be5a8195c6ff72e2f9461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

