### PR TITLE
DIATAXIS — Authority Resolution (Canonical Fallback Model)

### DIFF
--- a/docs/governance/standards/DIATAXIS-AUTHORITY-RESOLUTION.md
+++ b/docs/governance/standards/DIATAXIS-AUTHORITY-RESOLUTION.md
@@ -1,0 +1,93 @@
+---
+Doc Type: Governance
+Audience: Human + AI
+Authority Level: Canonical
+Owns: Diataxis-to-legacy authority resolution during transition
+Does Not Own: Folder-purpose rules; product design; operational work tracking
+Canonical Reference: /docs/governance/DOCUMENT-ARCHITECTURE.md
+Last Reviewed: 2026-05-02
+---
+
+# DIATAXIS AUTHORITY RESOLUTION
+
+## Purpose
+
+Defines how authority is resolved while the repository transitions from legacy documentation to the Diataxis documentation model.
+
+This document exists to prevent dual-authority drift during the transition period.
+
+## Resolution Rule
+
+For any documentation topic:
+
+1. If a Diataxis-aligned document exists for that topic, that Diataxis document is authoritative.
+2. If no Diataxis-aligned document exists for that topic, the existing legacy canonical document remains authoritative.
+3. If both a Diataxis-aligned document and a legacy canonical document exist for the same topic, the Diataxis document owns execution going forward and the legacy document remains historical fallback only until archived, rewritten, or explicitly superseded.
+4. No agent, contributor, workflow, or reviewer may treat two documents as simultaneously authoritative for the same topic.
+
+## Legacy Fallback Rule
+
+Missing Diataxis coverage is not a documentation gap that blocks work.
+
+When a required Diataxis document does not yet exist:
+
+- agents must use the current legacy canonical file
+- reviewers must validate against the current legacy canonical file
+- implementation work must not invent new authority from non-canonical notes
+- the missing Diataxis file should be tracked as transition work
+
+## Supersession Rule
+
+A Diataxis document supersedes legacy authority only when it satisfies all of these conditions:
+
+- it exists in the correct folder for its purpose
+- it contains the required authority header
+- it names its ownership boundary
+- it does not contradict higher-level governance or design authority
+- it is merged to the default branch
+
+Drafts, branches, issue comments, PR descriptions, and agent notes do not supersede legacy authority.
+
+## Folder Resolution
+
+Authority resolution follows the strict folder-purpose model:
+
+- `docs/tutorials/` teaches end-to-end learning flows
+- `docs/how-to/` instructs one task with one execution path
+- `docs/reference/` defines facts, contracts, schemas, routes, and product/system specifications
+- `docs/explanation/` explains rationale and tradeoffs
+- `docs/governance/` defines rules, standards, invariants, and enforcement
+- `docs/ops/` tracks execution, projects, tickets, and operating state
+- `docs/archive/` stores deprecated material only
+
+A document in the wrong folder cannot become authoritative for that topic.
+
+## Conflict Handling
+
+When a Diataxis document and a legacy document conflict:
+
+1. Confirm whether the Diataxis document satisfies the supersession rule.
+2. If yes, follow the Diataxis document and open follow-up work to archive, rewrite, or cross-reference the legacy source.
+3. If no, follow the legacy canonical source and open follow-up work to correct the Diataxis document.
+4. If both documents claim equal authority and the conflict cannot be resolved by this rule, escalate before implementation.
+
+## Agent Execution Rule
+
+Before acting on documentation, agents must resolve authority in this order:
+
+1. Governance authority for process and enforcement
+2. Diataxis document for the exact topic, if present and valid
+3. Legacy canonical document for the exact topic, if Diataxis coverage is missing or invalid
+4. Operator clarification only when no canonical source exists or sources conflict without a resolvable precedence
+
+Agents must not ask for clarification when this authority chain already resolves the source of truth.
+
+## Transition Tracking Rule
+
+Every missing Diataxis document that is discovered during work must be tracked as transition debt.
+
+The absence of a Diataxis document does not authorize ad hoc documentation. It authorizes fallback to the legacy canonical source and creation of transition follow-up work.
+
+## Success State
+
+The transition is complete when every active documentation topic has a valid Diataxis-aligned authority document or has been explicitly retained as governance, ops, or archive material.

--- a/docs/governance/standards/DIATAXIS-FOLDER-AUTHORITY.md
+++ b/docs/governance/standards/DIATAXIS-FOLDER-AUTHORITY.md
@@ -5,13 +5,24 @@ Authority Level: Canonical
 Owns: Diataxis folder usage rules and no-drift documentation model
 Does Not Own: Design specifications; operational task details; application behavior
 Canonical Reference: /docs/governance/DOCUMENT-ARCHITECTURE.md
-Last Reviewed: 2026-04-28
+Last Reviewed: 2026-05-02
 ---
 
 # DIÁTAXIS FOLDER AUTHORITY (NO-DRIFT MODEL)
 
 ## Purpose
 Defines strict folder usage rules. No drift allowed.
+
+## Authority Resolution
+
+Folder correctness alone does not determine authority during the transition.
+
+See: `/docs/governance/standards/DIATAXIS-AUTHORITY-RESOLUTION.md`
+
+That document defines:
+- when Diataxis overrides legacy
+- when legacy remains authoritative
+- how conflicts are resolved
 
 ## Structure
 - tutorials/


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/842

## Reference
- /docs/ops/projects/DIATAXIS-TRANSITION.md
- /docs/governance/DOCUMENT-ARCHITECTURE.md

## Change Summary
- Adds canonical Diataxis authority resolution model
- Defines explicit fallback to legacy documentation
- Eliminates dual-authority ambiguity
- Links folder authority to resolution rules

## Governance Reference
- /docs/governance/standards/DIATAXIS-FOLDER-AUTHORITY.md
- /docs/governance/standards/DIATAXIS-AUTHORITY-RESOLUTION.md

## Acceptance Criteria
- Single authoritative document per topic enforced logically
- Clear fallback behavior defined for missing Diataxis docs
- No parallel authority allowed
- Agents have deterministic source-of-truth resolution

## Risk
Low — documentation only, no runtime impact

## Validation
- Governance consistency
- Folder authority alignment
- No conflicts with design authority

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a canonical Diataxis authority resolution model to pick a single source of truth during the transition, with a clear fallback to legacy docs when coverage is missing. Removes dual-authority ambiguity and makes topic ownership deterministic.

- **New Features**
  - Added `/docs/governance/standards/DIATAXIS-AUTHORITY-RESOLUTION.md` defining precedence, legacy fallback, supersession criteria, conflict handling, and agent resolution order.
  - Updated `DIATAXIS-FOLDER-AUTHORITY.md` to link to the new rules and clarify that folder correctness alone does not set authority during the transition.

<sup>Written for commit 52f5b12aba85a9517fd3946b885c2fe134904812. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

