### PR TITLE
GOVERNANCE — ChatGPT Task Boundary Rule (No Scope Creep)

### DIFF
--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -12,7 +12,7 @@ Does Not Own: Shared rules, design authority, governance
 
 Canonical Reference: /docs/ops/ai/CORE-RULES.md
 
-Last Reviewed: 2026-04-22
+Last Reviewed: 2026-05-02
 
 ---
 # CHATGPT-RULES.md
@@ -42,6 +42,32 @@ Before execution:
 4. WAIT for confirmation  
 
 No execution without confirmation.
+
+---
+
+# CURRENT TASK BOUNDARY RULE (MANDATORY)
+
+ChatGPT must separate the active task from observations, recommendations, and proposed next work.
+
+When the operator asks for a task and ChatGPT completes it:
+
+1. Confirm whether the current task succeeded or failed.  
+2. Stop the current task dialogue.  
+3. Do not fold future-state recommendations into the current task result.  
+4. If a useful observation exists, label it clearly as a separate observation or question.  
+5. Do not create, plan, or expand into a new task unless the operator explicitly starts that task.
+
+Allowed observation format:
+
+- Observation: `<separate future-state note>`  
+- Question: `Would you like to start <new task> next?`
+
+Example:
+
+- Current task result: `PR 841 merged and post-merge intent verified.`  
+- Separate observation: `A future workflow could automate this same post-merge verification.`
+
+The existence of a valid future improvement does not change the status of the completed task.
 
 ---
 


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/844

## Reference
- /docs/ops/ai/CHATGPT-RULES.md

## Change Summary
- Adds mandatory task boundary rule for ChatGPT
- Enforces separation between active task and future-state observations
- Prevents scope creep during execution
- Defines allowed observation/question format

## Governance Reference
- /docs/ops/ai/CHATGPT-RULES.md

## Acceptance Criteria
- ChatGPT confirms task completion before introducing new work
- Observations are clearly labeled and separated
- No implicit task expansion occurs
- Execution discipline is preserved

## Risk
Low — documentation only

## Validation
- Rule aligns with execution discipline
- No conflict with existing alignment gate or stop conditions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mandatory task boundary rule to `CHATGPT-RULES.md` to prevent scope creep by separating task results from future observations. Also updates the “Last Reviewed” date.

- **New Features**
  - Require explicit success/failure confirmation and end the current task dialogue.
  - Disallow mixing future recommendations with task results; label observations/questions.
  - Include an allowed observation/question format and a short example.
  - Clarify that no new task begins unless the operator starts it.

<sup>Written for commit ac10fb7b8334bcc7203695d62a8095701234d20b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

