### PR TITLE
CI — Enable DIATAXIS Folder Authority Gate (Scoped)

### DIFF
--- a/.github/workflows/diataxis-folder-authority-check.yml
+++ b/.github/workflows/diataxis-folder-authority-check.yml
@@ -2,25 +2,119 @@ name: DIATAXIS Folder Authority Check
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'docs/tutorials/**'
+      - 'docs/how-to/**'
+      - 'docs/reference/**'
+      - 'docs/explanation/**'
 
 jobs:
   validate-folder-intent:
-    if: contains(github.event.pull_request.labels.*.name, 'DIATAXIS')
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: List changed files
+      - name: Collect DIATAXIS changed files only
         run: |
-          git diff --name-only origin/${{ github.base_ref }}...HEAD | tee changed_files.txt
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            | grep -E '^(docs/tutorials|docs/how-to|docs/reference|docs/explanation)/.*\.md$' \
+            | tee diataxis_changed_files.txt || true
 
-      - name: Validate placeholder
+      - name: Validate DIATAXIS folder authority
         run: |
-          echo "Folder validation skeleton"
+          if [ ! -s diataxis_changed_files.txt ]; then
+            echo "No DIATAXIS markdown files changed."
+            exit 0
+          fi
+
+          failures=0
+
+          while IFS= read -r file; do
+            echo "Validating ${file}"
+
+            if [ ! -f "${file}" ]; then
+              echo "Skipping deleted file: ${file}"
+              continue
+            fi
+
+            case "${file}" in
+              docs/tutorials/*)
+                expected_doc_type="Tutorial"
+                ;;
+              docs/how-to/*)
+                expected_doc_type="How-To"
+                ;;
+              docs/reference/*)
+                expected_doc_type="Reference"
+                ;;
+              docs/explanation/*)
+                expected_doc_type="Explanation"
+                ;;
+              *)
+                echo "ERROR: ${file} is outside approved DIATAXIS content folders."
+                failures=$((failures + 1))
+                continue
+                ;;
+            esac
+
+            if ! head -n 1 "${file}" | grep -qx -- '---'; then
+              echo "ERROR: ${file} missing opening YAML-style authority header delimiter."
+              failures=$((failures + 1))
+            fi
+
+            for required_field in 'Doc Type:' 'Audience:' 'Authority Level:' 'Owns:' 'Does Not Own:' 'Canonical Reference:' 'Last Reviewed:'; do
+              if ! grep -q "^${required_field}" "${file}"; then
+                echo "ERROR: ${file} missing required header field: ${required_field}"
+                failures=$((failures + 1))
+              fi
+            done
+
+            if ! grep -qi "^Doc Type: .*${expected_doc_type}" "${file}"; then
+              echo "ERROR: ${file} Doc Type must match folder intent: ${expected_doc_type}"
+              failures=$((failures + 1))
+            fi
+
+            case "${file}" in
+              docs/reference/*)
+                if grep -Eqi '^##[[:space:]]+(Steps|Procedure|How to|Tutorial)|```(bash|sh|zsh|powershell)' "${file}"; then
+                  echo "ERROR: ${file} reference docs must not contain procedure/tutorial sections or executable command blocks."
+                  failures=$((failures + 1))
+                fi
+                ;;
+              docs/explanation/*)
+                if grep -Eqi '^##[[:space:]]+(Steps|Procedure|Commands|Runbook)|```(bash|sh|zsh|powershell)' "${file}"; then
+                  echo "ERROR: ${file} explanation docs must not contain procedural/runbook sections or executable command blocks."
+                  failures=$((failures + 1))
+                fi
+                ;;
+              docs/how-to/*)
+                if ! grep -Eqi '^##[[:space:]]+(Steps|Procedure|Execution)' "${file}"; then
+                  echo "ERROR: ${file} how-to docs must contain a task execution section."
+                  failures=$((failures + 1))
+                fi
+                ;;
+              docs/tutorials/*)
+                if ! grep -Eqi '^##[[:space:]]+(Goal|Outcome|Steps|Walkthrough)' "${file}"; then
+                  echo "ERROR: ${file} tutorial docs must contain learning-flow structure."
+                  failures=$((failures + 1))
+                fi
+                ;;
+            esac
+          done < diataxis_changed_files.txt
+
+          if [ "${failures}" -ne 0 ]; then
+            echo "DIATAXIS folder authority check failed with ${failures} issue(s)."
+            exit 1
+          fi
+
+          echo "DIATAXIS folder authority check passed."
 
       - name: Summary
         run: |
-          echo "DIATAXIS folder authority check executed"
+          echo "DIATAXIS folder authority check completed for core DIATAXIS folders only."


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/848

## Reference
- .github/workflows/diataxis-folder-authority-check.yml

## Change Summary
- Converts placeholder workflow into active validation gate
- Scopes validation ONLY to DIATAXIS core folders
- Removes any implicit legacy /docs tracking
- Enforces folder intent + header compliance + purity rules

## Governance Reference
- /docs/governance/standards/DIATAXIS-FOLDER-AUTHORITY.md

## Acceptance Criteria
- Workflow triggers ONLY on DIATAXIS folder changes
- Legacy docs are NOT evaluated
- DIATAXIS docs must meet header + folder intent rules
- No false failures from legacy content

## Risk
Low — scoped CI enforcement

## Validation
- Limited to DIATAXIS directories
- Does not impact legacy content
- Aligns with migration strategy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables a scoped CI gate that validates DIATAXIS docs only (`docs/tutorials`, `docs/how-to`, `docs/reference`, `docs/explanation`). It checks authority headers and doc-type purity, and ignores legacy `/docs` content.

- **New Features**
  - Triggers on PR events (opened, synchronize, reopened, ready_for_review) and only when DIATAXIS paths change.
  - Processes only changed DIATAXIS Markdown files; exits cleanly if none are touched.
  - Requires a YAML authority header with key fields (Doc Type, Audience, Authority Level, ownership, Canonical Reference, Last Reviewed); Doc Type must match the folder.
  - Enforces content rules: Reference/Explanation must not include procedures or command blocks; How-To must include a steps/procedure section; Tutorials must include goal/outcome/steps.

<sup>Written for commit c4472a49595b06066e6011bd1156053454e599de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

