### PR TITLE
DOCS — DIATAXIS Mapping Scaffold

### DIFF
--- a/docs/reference/DIATAXIS-MAPPING.md
+++ b/docs/reference/DIATAXIS-MAPPING.md
@@ -1,0 +1,81 @@
+---
+Doc Type: Reference
+Audience: Human + AI
+Authority Level: Canonical
+Owns: Diataxis mapping coverage and transition model
+Does Not Own: Design authority; execution details
+Canonical Reference: /docs/governance/DOCUMENT-ARCHITECTURE.md
+Last Reviewed: 2026-05-02
+---
+
+# DIATAXIS MAPPING
+
+## Purpose
+
+Defines complete mapping from legacy documentation to Diataxis structure.
+
+This document is the single source of truth for:
+- transition coverage
+- migration status
+- routing vs full-document decisions
+
+---
+
+## Coverage Model
+
+- Total legacy documents: TBD
+- Total DIATAXIS targets: TBD
+- Coverage status: TBD
+
+DIATAXIS is considered 100% complete when:
+- every required topic has a DIATAXIS entry (full or routed)
+
+---
+
+## Mapping Table
+
+| Legacy File | DIATAXIS Target | Type | Status | Action |
+|------------|----------------|------|--------|--------|
+| (populate) | (populate)     | (populate) | (populate) | (populate) |
+
+---
+
+## Status Definitions
+
+- Viable → clean migration possible
+- Weak → rewrite required
+- Duplicate → remove or consolidate
+- Missing → new DIATAXIS document required
+
+---
+
+## Action Definitions
+
+- Migrate → convert legacy to DIATAXIS with minimal change
+- Rewrite → create new DIATAXIS document
+- Route → create DIATAXIS routing document referencing legacy
+- Retire → remove legacy after validation
+
+---
+
+## Rules
+
+- Every legacy document must appear exactly once
+- Every mapping must resolve to one DIATAXIS target
+- No unmapped legacy documents allowed
+- DIATAXIS must remain authoritative at all times
+
+---
+
+## Transition Tracking
+
+- DIATAXIS coverage remains 100% (full or routed)
+- Legacy usage decreases over time
+- LEGACY_FALLBACK events create mapping gaps
+
+---
+
+## Notes
+
+This file is scaffold-only at creation.
+Population occurs during mapping phase.


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/850

## Reference
- docs/reference/DIATAXIS-MAPPING.md

## Change Summary
- Adds DIATAXIS mapping scaffold
- Defines coverage model and mapping structure
- Establishes transition rules and status definitions

## Governance Reference
- /docs/governance/DOCUMENT-ARCHITECTURE.md

## Acceptance Criteria
- Mapping file exists in reference directory
- Structure supports full legacy → DIATAXIS mapping
- No classification performed yet
- Ready for population phase

## Risk
Low — documentation scaffold only

## Validation
- Header compliance
- Aligns with DIATAXIS framework
- No impact to existing docs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `docs/reference/DIATAXIS-MAPPING.md` as the canonical scaffold for mapping legacy docs to the DIATAXIS structure. It defines coverage metrics, status/action types, transition rules, and tracking, with no classifications yet.

- **Migration**
  - Populate the Mapping Table; each legacy doc maps once to a DIATAXIS target.
  - Use this file as the source of truth for coverage and status; canonical reference: `/docs/governance/DOCUMENT-ARCHITECTURE.md`.

<sup>Written for commit 8de6a936524f1a27c321aba40ca3a4506b7576c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

