### PR TITLE
CI — Fix Post-Merge Remediation + Issue Lifecycle

### DIFF
--- a/.github/workflows/post-merge-intent-verification.yml
+++ b/.github/workflows/post-merge-intent-verification.yml
@@ -24,15 +24,14 @@ jobs:
       - name: Collect merged PR metadata
         env:
           GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr view "${PR_NUMBER}" --repo "${REPOSITORY}" --json title,body,files,mergeCommit > pr-intent.json
+          gh pr view "${PR_NUMBER}" --json title,body,files > pr-intent.json
           jq -r '.body // ""' pr-intent.json > pr-body.md
           jq -r '.files[].path' pr-intent.json > pr-files.txt
           jq -r '.title' pr-intent.json > pr-title.txt
 
-      - name: Run verification checks
+      - name: Evaluate verification (non-fatal)
         id: verify
         run: |
           failures=0
@@ -50,16 +49,23 @@ jobs:
 
           echo "failures=${failures}" >> $GITHUB_OUTPUT
 
-          if [ "${failures}" -ne 0 ]; then
-            exit 1
-          fi
-
-      - name: Create Copilot remediation issue on failure
-        if: failure()
+      - name: Create remediation issue if needed
+        if: steps.verify.outputs.failures != '0'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue create --title "Post-Merge Failure: PR #${{ github.event.pull_request.number }}" --body "Post-merge verification failed for PR #${{ github.event.pull_request.number }}. Review workflow logs and open a remediation PR that restores the intended merged outcome." --label "post-merge-failure" --assignee "copilot-swe-agent[bot]"
+          gh issue create \
+            --title "Post-Merge Failure: PR #${{ github.event.pull_request.number }}" \
+            --body "Post-merge verification failed for PR #${{ github.event.pull_request.number }}.\n\nThis is a remediation issue (not a tracker).\n\nRequired:\n- Identify failed checkpoints\n- Create PR to complete intended outcome" \
+            --label "post-merge-failure" \
+            --assignee "copilot-swe-agent[bot]"
+
+      - name: Fail workflow if verification failed
+        run: |
+          if [ "${{ steps.verify.outputs.failures }}" != "0" ]; then
+            echo "Post-merge verification failed"
+            exit 1
+          fi
 
       - name: Summary
         run: echo "Post-merge verification completed"

--- a/.github/workflows/post-merge-intent-verification.yml
+++ b/.github/workflows/post-merge-intent-verification.yml
@@ -22,11 +22,14 @@ jobs:
           fetch-depth: 0
 
       - name: Collect merged PR metadata
+        id: metadata
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr view "${PR_NUMBER}" --json title,body,files > pr-intent.json
+          gh pr view "${PR_NUMBER}" --repo "${REPOSITORY}" --json title,body,files > pr-intent.json
           jq -r '.body // ""' pr-intent.json > pr-body.md
           jq -r '.files[].path' pr-intent.json > pr-files.txt
           jq -r '.title' pr-intent.json > pr-title.txt
@@ -36,27 +39,49 @@ jobs:
         run: |
           failures=0
 
-          for required_section in '## Change Summary' '## Acceptance Criteria' '## Risk' '## Validation'; do
-            grep -Fq "${required_section}" pr-body.md || failures=$((failures + 1))
-          done
+          if [ "${{ steps.metadata.outcome }}" != "success" ]; then
+            failures=$((failures + 1))
+          fi
 
-          grep -Eqi '\b(TBD|TODO|placeholder|populate)\b' pr-body.md && failures=$((failures + 1))
+          if [ -f pr-body.md ]; then
+            for required_section in '## Change Summary' '## Acceptance Criteria' '## Risk' '## Validation'; do
+              grep -Fq "${required_section}" pr-body.md || failures=$((failures + 1))
+            done
 
-          while IFS= read -r file; do
-            [ -z "${file}" ] && continue
-            [ -e "${file}" ] || failures=$((failures + 1))
-          done < pr-files.txt
+            grep -Eqi '\b(TBD|TODO|placeholder|populate)\b' pr-body.md && failures=$((failures + 1))
+          else
+            failures=$((failures + 1))
+          fi
+
+          if [ -f pr-files.txt ]; then
+            while IFS= read -r file; do
+              [ -z "${file}" ] && continue
+              [ -e "${file}" ] || failures=$((failures + 1))
+            done < pr-files.txt
+          else
+            failures=$((failures + 1))
+          fi
 
           echo "failures=${failures}" >> $GITHUB_OUTPUT
 
       - name: Create remediation issue if needed
-        if: steps.verify.outputs.failures != '0'
+        if: always() && steps.verify.outputs.failures != '0'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          cat > remediation-issue-body.md <<'EOF'
+          Post-merge verification failed for PR #${{ github.event.pull_request.number }}.
+
+          This is a remediation issue (not a tracker).
+
+          Required:
+          - Identify failed checkpoints
+          - Create PR to complete intended outcome
+          EOF
+
           gh issue create \
             --title "Post-Merge Failure: PR #${{ github.event.pull_request.number }}" \
-            --body "Post-merge verification failed for PR #${{ github.event.pull_request.number }}.\n\nThis is a remediation issue (not a tracker).\n\nRequired:\n- Identify failed checkpoints\n- Create PR to complete intended outcome" \
+            --body-file remediation-issue-body.md \
             --label "post-merge-failure" \
             --assignee "copilot-swe-agent[bot]"
 


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/862

## Change Summary
- Fix remediation issue creation logic
- Separate tracker issues from remediation issues
- Ensure remediation issues are created BEFORE workflow failure exit
- Maintain tracker issue auto-close behavior

## Acceptance Criteria
- FAIL → remediation issue created
- Issue assigned to Copilot
- Tracker issue auto closes on merge
- Cancelled PR does NOT close issue

## Risk
Low — workflow correction

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the post-merge verification workflow so remediation issues are created before the job fails and kept separate from tracker issues. Handles missing PR data safely and prevents canceled runs from closing issues.

- **Bug Fixes**
  - Make verification non-fatal and explicitly fail at the end to guarantee issue creation happens first.
  - Create remediation issue only when `steps.verify.outputs.failures != '0'`; assign to `copilot-swe-agent[bot]` and mark the body as remediation (not a tracker).
  - Replace `failure()` trigger with `always()` + failures check to avoid churn on canceled runs.
  - Simplify metadata fetch: drop `mergeCommit`, add `continue-on-error`, and count missing metadata/body/files as failures.

<sup>Written for commit c3bd2030ade4f547f42b00208859bf3b32554e37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

