### PR TITLE
CI — Split Post-Merge Detection & Remediation

### DIFF
--- a/.github/workflows/post-merge-intent-verification.yml
+++ b/.github/workflows/post-merge-intent-verification.yml
@@ -1,34 +1,34 @@
-name: Post-Merge Intent Verification
+name: Post-Merge Detection
 
 on:
-  pull_request_target:
-    types: [closed]
+  push:
+    branches: [main]
 
 permissions:
   contents: read
   pull-requests: read
-  issues: write
 
 jobs:
-  verify-merged-pr-intent:
-    if: github.event.pull_request.merged == true
+  detect:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Log trigger
-        run: echo "PR merged"
-
-      - name: Checkout merged state
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
-      - name: Collect metadata
-        id: meta
+      - name: Resolve PR
+        id: pr
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr view "${{ github.event.pull_request.number }}" --json body,files > pr.json
+          PR=$(gh pr list --search "${GITHUB_SHA}" --state merged --json number -q '.[0].number')
+          echo "pr=$PR" >> $GITHUB_OUTPUT
+
+      - name: Collect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view "${{ steps.pr.outputs.pr }}" --json body,files > pr.json
           jq -r '.body // ""' pr.json > body.md
           jq -r '.files[].path' pr.json > files.txt
 
@@ -46,19 +46,13 @@ jobs:
           done < files.txt
           echo "failures=$failures" >> $GITHUB_OUTPUT
 
-      - name: Comment on PR
+      - name: Comment
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr comment ${{ github.event.pull_request.number }} --body "Post-merge check failures=${{ steps.verify.outputs.failures }}"
+        run: gh pr comment ${{ steps.pr.outputs.pr }} --body "Detection failures=${{ steps.verify.outputs.failures }}"
 
-      - name: Create remediation issue
-        if: steps.verify.outputs.failures != '0'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh issue create --title "Post-Merge Failure: PR #${{ github.event.pull_request.number }}" --body "Fix required" --label "post-merge-failure" --assignee "copilot-swe-agent[bot]"
-
-      - name: Fail job
+      - name: Fail if needed
         run: |
           if [ "${{ steps.verify.outputs.failures }}" != "0" ]; then
             exit 1

--- a/.github/workflows/post-merge-remediation.yml
+++ b/.github/workflows/post-merge-remediation.yml
@@ -1,0 +1,26 @@
+name: Post-Merge Remediation
+
+on:
+  workflow_run:
+    workflows: ["Post-Merge Detection"]
+    types:
+      - completed
+
+permissions:
+  issues: write
+
+jobs:
+  remediate:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create Issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --title "Post-Merge Failure Detected" \
+            --body "Detection workflow failed. Investigate and fix." \
+            --label "post-merge-failure" \
+            --assignee "copilot-swe-agent[bot]"


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/876

## Change Summary
Split detection and remediation workflows

## Acceptance Criteria
Detection runs on push to main
Remediation triggers on failure
Issues assigned to Copilot

## Risk
Low

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split post-merge checks into two workflows: detection runs on push to `main`, and remediation creates an issue when detection fails. This makes failures visible on the PR and routes fixes to `copilot-swe-agent[bot]`.

- **Refactors**
  - Replaced intent verification with "Post-Merge Detection" triggered on push to `main`.
  - Resolve merged PR by SHA via `gh`, collect body/files, verify, comment results on the PR, and fail on any violations.
  - Removed inline issue creation; added "Post-Merge Remediation" (`workflow_run`) to open a labeled issue on failure and assign `copilot-swe-agent[bot]`.
  - Adjusted permissions: detection uses read-only; remediation has `issues: write`.

<sup>Written for commit dd66136300fb391f6dc4802fd01251a36d6d5084. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

