### PR TITLE
Docs — ChatGPT Standing Permission for PR/Issue Creation

### DIFF
--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -41,7 +41,10 @@ Before execution:
 3. Identify risks  
 4. WAIT for confirmation  
 
-No execution without confirmation.
+Exception:
+
+- ChatGPT has standing permission to create Issues and Pull Requests without waiting for confirmation when the task scope is clear and low risk.
+- Merge authority remains with the operator.
 
 ---
 
@@ -61,13 +64,6 @@ Allowed observation format:
 
 - Observation: `<separate future-state note>`  
 - Question: `Would you like to start <new task> next?`
-
-Example:
-
-- Current task result: `PR 841 merged and post-merge intent verified.`  
-- Separate observation: `A future workflow could automate this same post-merge verification.`
-
-The existence of a valid future improvement does not change the status of the completed task.
 
 ---
 
@@ -104,7 +100,8 @@ Refer to /docs/ops/ai/CORE-RULES.md (REQUIRED VERIFICATION) for all fact and cit
 
 # PR OWNERSHIP
 
-- Refer to CORE-RULES.md for PR ownership rules  
+- ChatGPT may create PRs and Issues directly under standing permission
+- Operator reviews and approves merges
 
 ---
 
@@ -112,7 +109,6 @@ Refer to /docs/ops/ai/CORE-RULES.md (REQUIRED VERIFICATION) for all fact and cit
 
 Stop if:
 
-- confirmation not received  
 - mode conflict  
 - unverifiable claims required  
 - unclear scope  


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/878

## Change Summary
Add standing permission rule for ChatGPT to create PRs and Issues without confirmation

## Acceptance Criteria
Rule documented in CHATGPT-RULES.md
Clear separation of creation vs merge authority

## Risk
Low

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document a standing permission letting ChatGPT create Issues and PRs without waiting for confirmation, while keeping merge authority with the operator. Updated docs/ops/ai/CHATGPT-RULES.md to add the exception, clarify PR ownership, remove the confirmation-related stop condition, and prune a redundant example in the observation format.

<sup>Written for commit 6451a372223b3845e0b1b81ad7662fdadeea22a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

