### PR TITLE
SECURITY — Enforce PR-Only Changes to Main

### DIFF
--- a/.github/workflows/enforce-pr-only.yml
+++ b/.github/workflows/enforce-pr-only.yml
@@ -1,0 +1,16 @@
+name: Enforce PR Only Changes
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  block-direct-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fail if direct push
+        run: |
+          echo "Direct pushes to main are not allowed. All changes must go through approved PRs."
+          exit 1


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/890

## Objective
Block all direct commits to main branch. Force all changes through PR with review.

## Change
- Add workflow that fails any direct push to main

## Result
- Agents cannot bypass PR process
- All changes must be reviewed and approved

## Next Step
Apply branch protection rules (required) after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that fails any direct push to main. This guides all changes through reviewed PRs.

- **Migration**
  - Enable branch protection on main to require PRs before merging.
  - Optionally require the “Enforce PR Only Changes” status check.

<sup>Written for commit b1d3ccdc8667cdeabc801cbd656ef7cd6f52fc3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

