### PR TITLE
CI — Fix Cursor PR handoff

### DIFF
--- a/.github/intent-labeler.json
+++ b/.github/intent-labeler.json
@@ -11,6 +11,7 @@
     "infra": {
       "allow_prefixes": [
         ".github/",
+        "PROMPTS/",
         "scripts/",
         "functions/",
         "src/app/admin/",

--- a/.github/workflows/project-implementation-orchestrator.yml
+++ b/.github/workflows/project-implementation-orchestrator.yml
@@ -111,7 +111,7 @@ $issue_body
 - Keep implementation, verification, and documentation aligned.
 
 ## Agent Handoff
-$([ "$agent" = "cursor" ] && echo "@cursorai Please take this issue. Follow the task body exactly. Open a PR when complete. Do not expand scope.")
+$([ "$agent" = "cursor" ] && echo "@cursor Please take this issue. Follow the task body exactly. Create a working branch and open a PR against main when complete. Do not expand scope.")
 $([ "$agent" = "codex" ] && echo "Codex route selected. Use the Codex-enabled repository workflow or assigned agent queue for execution.")
 $([ "$agent" = "copilot" ] && echo "Copilot route selected. Assigning to copilot-swe-agent[bot] where repository permissions allow.")
 BODY
@@ -148,7 +148,7 @@ BODY
           if [ "$AGENT" = "cursor" ]; then
             gh issue comment "$ISSUE_NUMBER" \
               --repo "${{ github.repository }}" \
-              --body "@cursorai Please take this issue. Follow the task body exactly. Open a PR when complete. Do not expand scope."
+              --body "@cursor Please take this issue. Follow the task body exactly. Create a working branch and open a PR against main when complete. Do not expand scope."
           fi
 
           if [ "$AGENT" = "copilot" ]; then

--- a/.github/workflows/project-implementation-orchestrator.yml
+++ b/.github/workflows/project-implementation-orchestrator.yml
@@ -95,26 +95,27 @@ jobs:
             echo "$issue_title"
             echo "EOF"
             echo "issue_body<<EOF"
-            cat <<BODY
-## Source
-- Source PR: $pr_url
-- Routed agent: $agent
-
-## Assignment
-$issue_body
-
-## Execution Rules
-- Start from this Issue.
-- Do not expand scope.
-- Make the smallest complete change.
-- Open one PR when complete.
-- Keep implementation, verification, and documentation aligned.
-
-## Agent Handoff
-$([ "$agent" = "cursor" ] && echo "@cursor Please take this issue. Follow the task body exactly. Create a working branch and open a PR against main when complete. Do not expand scope.")
-$([ "$agent" = "codex" ] && echo "Codex route selected. Use the Codex-enabled repository workflow or assigned agent queue for execution.")
-$([ "$agent" = "copilot" ] && echo "Copilot route selected. Assigning to copilot-swe-agent[bot] where repository permissions allow.")
-BODY
+            printf '## Source\n'
+            printf -- '- Source PR: %s\n' "$pr_url"
+            printf -- '- Routed agent: %s\n\n' "$agent"
+            printf '## Assignment\n'
+            printf '%s\n\n' "$issue_body"
+            printf '## Execution Rules\n'
+            printf -- '- Start from this Issue.\n'
+            printf -- '- Do not expand scope.\n'
+            printf -- '- Make the smallest complete change.\n'
+            printf -- '- Open one PR when complete.\n'
+            printf -- '- Keep implementation, verification, and documentation aligned.\n\n'
+            printf '## Agent Handoff\n'
+            if [ "$agent" = "cursor" ]; then
+              printf '%s\n' "@cursor Please take this issue. Follow the task body exactly. Create a working branch and open a PR against main when complete. Do not expand scope."
+            fi
+            if [ "$agent" = "codex" ]; then
+              printf '%s\n' "Codex route selected. Use the Codex-enabled repository workflow or assigned agent queue for execution."
+            fi
+            if [ "$agent" = "copilot" ]; then
+              printf '%s\n' "Copilot route selected. Assigning to copilot-swe-agent[bot] where repository permissions allow."
+            fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/PROMPTS/Cursor-Launch-Prompt.md
+++ b/PROMPTS/Cursor-Launch-Prompt.md
@@ -1,7 +1,7 @@
 Follow PR #<number> exactly.
 
 - Edit ONLY allowlisted files
-- Do NOT run git commands
-- Do NOT create branches or PRs
+- Create a branch or PR ONLY when the GitHub issue explicitly instructs you to do so
+- Otherwise, do NOT run git commands and do NOT create branches or PRs
 
 Return when all file edits are complete.

--- a/PROMPTS/Cursor-Rules.md
+++ b/PROMPTS/Cursor-Rules.md
@@ -14,6 +14,7 @@
 - DO NOT run git commands
 - DO NOT create branches
 - DO NOT create PRs
+- EXCEPTION: GitHub-assigned implementation issues that explicitly ask Cursor to open a PR may create a working branch and PR.
 - DO NOT modify files outside scope
 
 ## OUTPUT

--- a/docs/ops/ai/CURSOR-RULES.md
+++ b/docs/ops/ai/CURSOR-RULES.md
@@ -60,8 +60,10 @@ After approval, Cursor may:
 
 - edit ONLY approved files  
 - run ONLY required commands  
-- create branch ONLY if instructed  
-- open PR ONLY if instructed  
+- create a working branch ONLY if the approved GitHub Issue/PR explicitly instructs it
+- open a PR ONLY if the approved GitHub Issue/PR explicitly instructs it
+
+GitHub Issues created by repository automation may be implementation requests. If such an Issue explicitly says to create a branch and open a PR against `main`, that instruction is approved execution scope.
 
 ---
 

--- a/scripts/ci/pr_intent_allowlists.json
+++ b/scripts/ci/pr_intent_allowlists.json
@@ -56,6 +56,7 @@
         "src/app/admin/",
         "docs/governance/",
         "docs/ops/",
+        "PROMPTS/",
         "docs/governance/PR_GOVERNANCE.md",
         "docs/website-PR-process.md",
         "docs/OPERATING_MANUAL.md",


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/894

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### PR Template

#### Reference
Refer to `/.github/pull_request_template.md` for required structure and change conventions.

#### Governance Reference
Follow operational, rollback, and testing standards in `/docs/governance/PR_GOVERNANCE.md`.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [ ] OR any ZIP file that was present in the repo root was deleted before any other change
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Implementation
- Task: Troubleshoot and repair Cursor repository PR handoff path
- Status: DRAFT
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: Repository owner may still need to verify Cursor GitHub app has repository and pull-request write access if Cursor continues to fail after this repo-side fix.
- Notes: This fixes the repo-side invocation/instruction blockers found during troubleshooting.

## DOCUMENTATION SOURCE (MANDATORY)
- [ ] DIATAXIS_FULL
- [x] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `docs/ops/ai/CURSOR-RULES.md`
- `PROMPTS/Cursor-Launch-Prompt.md`
- `PROMPTS/Cursor-Rules.md`
- `.github/workflows/project-implementation-orchestrator.yml`
- `.github/intent-labeler.json`
- `scripts/ci/pr_intent_allowlists.json`

## DIATAXIS GAP (REQUIRED IF LEGACY_FALLBACK)
- [ ] Gap Identified
- Link to issue: N/A
- Description: N/A

## LABEL
- Intent label for this PR: infra

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical design reference: `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- Additional design/reference docs used for this PR:
  - `/docs/ops/ai/CURSOR-RULES.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `.github/workflows/project-implementation-orchestrator.yml`
- `.github/intent-labeler.json`
- `PROMPTS/Cursor-Launch-Prompt.md`
- `PROMPTS/Cursor-Rules.md`
- `docs/ops/ai/CURSOR-RULES.md`
- `scripts/ci/pr_intent_allowlists.json`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## DOCS-ONLY ASSERTION (REQUIRED FOR change-ops)
- [ ] This PR contains documentation-only changes
- [x] No application code or runtime behavior modified; workflow/prompt configuration is modified for infra intent

## CHANGE SUMMARY
- Replace stale `@cursorai` orchestration mentions with Cursor's documented `@cursor` trigger.
- Make Cursor handoff instructions explicitly branch-and-PR based for implementation issues targeting `main`.
- Align Cursor rules/prompts so PR creation is permitted only when an approved GitHub Issue/PR explicitly instructs it.
- Add `PROMPTS/` to infra allowlists so Cursor-ops prompt changes classify under one intent.
- Rewrite the orchestrator issue-body assembly to avoid YAML-invalid unindented heredoc content.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `git diff --check origin/main...HEAD`
  - `jq empty .github/intent-labeler.json && jq empty scripts/ci/pr_intent_allowlists.json`
  - `yq . .github/workflows/project-implementation-orchestrator.yml >/dev/null`
  - `./scripts/ci/docs_check_headers.sh .`
  - `./scripts/ci/docs_canonical_hashes_verify.sh .`
  - `git ls-files '*.zip' '*.ZIP'`
  - `rg '@cursorai|@cursor ' --glob '*.{yml,yaml,md}'`
- Result summary:
  - PASS
- If FAIL, explain: N/A
- Environment note: `python`, `ruby`, `node`, and `npm` are not installed in this Cloud image, so validation used available shell/JQ/YQ/docs guards instead of npm-based checks.

## DOCUMENTATION UPDATES
- [x] Documentation updated in this PR
- [ ] No documentation updates required
- Files:
  - `docs/ops/ai/CURSOR-RULES.md`
  - `PROMPTS/Cursor-Launch-Prompt.md`
  - `PROMPTS/Cursor-Rules.md`

## ACCEPTANCE CRITERIA
- Cursor orchestration uses `@cursor`.
- Cursor implementation issues explicitly authorize branch and PR creation when intended.
- Drift gate can classify the changed files under the `infra` intent.
- Workflow YAML parses successfully.
- CI passes fully.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] Local checks executed and passed where supported by the Cloud image
- [x] Commit message aligns with scope
- [x] No secrets or forbidden artifacts introduced
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08e7443e-8987-4dd8-a93b-21198f891024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08e7443e-8987-4dd8-a93b-21198f891024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cursor PR handoff in CI by switching to `@cursor`, clarifying when it may create branches/PRs, and correcting the orchestrator YAML to produce valid issue bodies. Prompts, rules, and allowlists now ensure PRs open only when an approved issue explicitly allows it under the `infra` intent.

- **Bug Fixes**
  - Switch workflow handoff and comments to `@cursor`; require a working branch and PR against `main` when the Issue authorizes it.
  - Make orchestrator YAML valid by generating the Issue body with `printf` instead of heredocs.
  - Add `PROMPTS/` to infra allowlists and tighten prompts/docs so branches/PRs are created only when explicitly authorized.

<sup>Written for commit 1bc75a4789c1cb9feef271e32deaa86973423cde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

