### PR TITLE
OPS — Orchestration Labels & Routing (PR 2)

### DIFF
--- a/.github/orchestrator-labels.json
+++ b/.github/orchestrator-labels.json
@@ -1,0 +1,23 @@
+{
+  "labels": [
+    "orchestrator",
+    "status:queued",
+    "status:assigned",
+    "status:pr-draft",
+    "status:implementation",
+    "status:review",
+    "status:merged",
+    "status:post-merge-verify",
+    "status:complete",
+    "status:failed",
+    "type:repository",
+    "type:website",
+    "type:governance",
+    "type:docs",
+    "type:recovery",
+    "agent:codex",
+    "agent:cursor",
+    "agent:copilot",
+    "agent:atlas"
+  ]
+}

--- a/.github/orchestrator-routing.json
+++ b/.github/orchestrator-routing.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "defaultConcurrency": "serial",
+  "taskTypes": {
+    "repository": {
+      "agent": "codex",
+      "labels": ["orchestrator", "type:repository", "agent:codex"]
+    },
+    "website": {
+      "agent": "cursor",
+      "labels": ["orchestrator", "type:website", "agent:cursor"]
+    },
+    "governance": {
+      "agent": "copilot",
+      "labels": ["orchestrator", "type:governance", "agent:copilot"]
+    },
+    "docs": {
+      "agent": "atlas",
+      "labels": ["orchestrator", "type:docs", "agent:atlas"]
+    },
+    "recovery": {
+      "agent": "atlas",
+      "labels": ["orchestrator", "type:recovery", "agent:atlas"]
+    }
+  },
+  "states": [
+    "status:queued",
+    "status:assigned",
+    "status:pr-draft",
+    "status:implementation",
+    "status:review",
+    "status:merged",
+    "status:post-merge-verify",
+    "status:complete",
+    "status:failed"
+  ]
+}

--- a/.github/orchestrator-routing.json
+++ b/.github/orchestrator-routing.json
@@ -1,37 +1,42 @@
 {
   "version": 1,
   "defaultConcurrency": "serial",
+  "concurrencyPolicy": {
+    "mode": "serial",
+    "reason": "Serial execution is the LGFC safety default while orchestration is being proven. Parallel lanes may be added later by explicit design change."
+  },
   "taskTypes": {
     "repository": {
-      "agent": "codex",
-      "labels": ["orchestrator", "type:repository", "agent:codex"]
+      "defaultAgent": "codex",
+      "allowedAgents": ["codex"],
+      "prIntents": ["infra", "platform", "change-ops", "codex"]
     },
     "website": {
-      "agent": "cursor",
-      "labels": ["orchestrator", "type:website", "agent:cursor"]
+      "defaultAgent": "cursor",
+      "allowedAgents": ["cursor"],
+      "prIntents": ["feature"]
     },
     "governance": {
-      "agent": "copilot",
-      "labels": ["orchestrator", "type:governance", "agent:copilot"]
+      "defaultAgent": "copilot",
+      "allowedAgents": ["copilot", "atlas"],
+      "prIntents": ["infra", "change-ops"]
     },
     "docs": {
-      "agent": "atlas",
-      "labels": ["orchestrator", "type:docs", "agent:atlas"]
+      "defaultAgent": "atlas",
+      "allowedAgents": ["atlas", "copilot"],
+      "prIntents": ["docs-only"]
     },
     "recovery": {
-      "agent": "atlas",
-      "labels": ["orchestrator", "type:recovery", "agent:atlas"]
+      "defaultAgent": "atlas",
+      "allowedAgents": ["atlas", "copilot", "codex", "cursor"],
+      "prIntents": ["recovery"]
     }
   },
-  "states": [
-    "status:queued",
-    "status:assigned",
-    "status:pr-draft",
-    "status:implementation",
-    "status:review",
-    "status:merged",
-    "status:post-merge-verify",
-    "status:complete",
-    "status:failed"
-  ]
+  "labelDerivation": {
+    "taskTypeLabelPrefix": "type:",
+    "agentLabelPrefix": "agent:",
+    "baseLabels": ["orchestrator"],
+    "deriveTaskAndAgentLabels": true
+  },
+  "stateSource": ".github/orchestrator-labels.json"
 }


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/898

## Reference
/docs/ops/orchestration-tier-design.md

## Change Summary
Adds orchestrator routing and label configuration.

## Governance Reference
/docs/governance/PR_GOVERNANCE.md

## Scope
- Adds label definitions
- Adds routing configuration
- No workflows yet
- No runtime changes

## Acceptance Criteria
- Routing config present
- Label set defined
- No CI impact

## Risk
Low

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds orchestrator label set and routing config to standardize task assignment and status tracking. No workflows or runtime changes.

- **New Features**
  - Added `.github/orchestrator-labels.json` with status, type, and agent labels.
  - Added `.github/orchestrator-routing.json` (v1) with serial concurrency (`defaultConcurrency` + `concurrencyPolicy`), default agent per task type (repository→codex, website→cursor, governance→copilot, docs→atlas, recovery→atlas), and `allowedAgents`/`prIntents`.
  - Enabled automatic label derivation (type:/agent: prefixes) with `.github/orchestrator-labels.json` as the state source.

<sup>Written for commit 25bc7cc501156aa777048219b54fbe97469869f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

