### PR TITLE
OPS — Plan Lifecycle Management (PR 4)

### DIFF
--- a/.github/workflows/orchestrator-issue-factory.yml
+++ b/.github/workflows/orchestrator-issue-factory.yml
@@ -8,7 +8,7 @@ on:
       - 'docs/ops/implementation-plans/**'
 
 permissions:
-  contents: read
+  contents: write
   issues: write
 
 jobs:
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/scripts/orchestrator/create-issues.mjs
+++ b/scripts/orchestrator/create-issues.mjs
@@ -19,8 +19,21 @@ function runGh(args) {
   return execFileSync('gh', args, { encoding: 'utf8' }).trim();
 }
 
+function runGit(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
 function isProductionReady(content) {
   return /Status:\s*production-ready/i.test(content);
+}
+
+function markIssuesCreated(filePath, content) {
+  const updated = content.replace(/Status:\s*production-ready/i, 'Status: issues-created');
+  if (updated !== content) {
+    fs.writeFileSync(filePath, updated);
+    return true;
+  }
+  return false;
 }
 
 function projectSlug(filePath) {
@@ -75,6 +88,8 @@ const files = fs.existsSync(planDir)
   ? fs.readdirSync(planDir).filter((name) => name.endsWith('.md') && name !== 'README.md')
   : [];
 
+const updatedPlans = [];
+
 for (const file of files) {
   const filePath = path.join(planDir, file);
   const content = fs.readFileSync(filePath, 'utf8');
@@ -119,4 +134,16 @@ for (const file of files) {
 
     console.log(`CREATED issue for ${marker}`);
   }
+
+  if (tasks.length > 0 && markIssuesCreated(filePath, content)) {
+    updatedPlans.push(filePath);
+  }
+}
+
+if (updatedPlans.length > 0) {
+  runGit(['config', 'user.name', 'github-actions[bot]']);
+  runGit(['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com']);
+  runGit(['add', ...updatedPlans]);
+  runGit(['commit', '-m', 'ops: mark implementation plans as issues-created']);
+  runGit(['push']);
 }

--- a/scripts/orchestrator/create-issues.mjs
+++ b/scripts/orchestrator/create-issues.mjs
@@ -135,7 +135,7 @@ for (const file of files) {
     console.log(`CREATED issue for ${marker}`);
   }
 
-  if (tasks.length > 0 && markIssuesCreated(filePath, content)) {
+  if (markIssuesCreated(filePath, content)) {
     updatedPlans.push(filePath);
   }
 }
@@ -145,5 +145,5 @@ if (updatedPlans.length > 0) {
   runGit(['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com']);
   runGit(['add', ...updatedPlans]);
   runGit(['commit', '-m', 'ops: mark implementation plans as issues-created']);
-  runGit(['push']);
+  runGit(['push', 'origin', 'HEAD:main']);
 }


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/902

## Reference
/docs/ops/orchestration-tier-design.md

## Change Summary
Adds lifecycle management for implementation plans after issue creation.

## Governance Reference
/docs/governance/PR_GOVERNANCE.md

## Scope
- Updates issue factory script
- Marks plans as issues-created after processing
- Prevents repeated triggering

## Acceptance Criteria
- Plans transition from production-ready → issues-created
- No duplicate issue creation
- Plan remains as audit artifact

## Risk
Low

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates the plan lifecycle by marking implementation plans as "issues-created" after issue generation and committing the change to prevent duplicates; also fixes the push step to reliably persist updates.

- **New Features**
  - Updates plan files from "Status: production-ready" to "Status: issues-created" when issues are created.
  - Commits and pushes updates via `git` using `github-actions[bot]` (fixes push to `main`).
  - Prevents repeated issue creation and keeps plans as audit artifacts.

<sup>Written for commit 3e0a5243b461430c1f6ce153d79ad820e28f5169. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

