### PR TITLE
T20-B: Add fundraiser ingest layer

### DIFF
--- a/src/lib/fundraiser.ts
+++ b/src/lib/fundraiser.ts
@@ -1,0 +1,98 @@
+import fundraiserSource from '../../data/fundraiser.json';
+
+export type FundraiserSourceRecord = {
+  team_id: string;
+  team_name: string;
+  total_amount: number | string;
+  donor_count: number | string;
+  timestamp: string;
+};
+
+export type FundraiserTeam = {
+  teamId: string;
+  teamName: string;
+  totalAmount: number;
+  donorCount: number;
+  points: number;
+  timestamp: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeRequiredString(value: unknown, field: string, index: number): string {
+  if (typeof value !== 'string') {
+    throw new Error(`Fundraiser record ${index} has invalid ${field}.`);
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`Fundraiser record ${index} has empty ${field}.`);
+  }
+
+  return normalized;
+}
+
+function normalizeAmount(value: unknown, field: string, index: number): number {
+  const normalized = typeof value === 'number' ? value : typeof value === 'string' ? Number(value.trim()) : Number.NaN;
+
+  if (!Number.isFinite(normalized) || normalized < 0) {
+    throw new Error(`Fundraiser record ${index} has invalid ${field}.`);
+  }
+
+  return normalized;
+}
+
+function normalizeDonorCount(value: unknown, field: string, index: number): number {
+  const normalized = normalizeAmount(value, field, index);
+
+  if (!Number.isInteger(normalized)) {
+    throw new Error(`Fundraiser record ${index} has non-integer ${field}.`);
+  }
+
+  return normalized;
+}
+
+function normalizeTimestamp(value: unknown, index: number): string {
+  const timestamp = normalizeRequiredString(value, 'timestamp', index);
+
+  if (Number.isNaN(Date.parse(timestamp))) {
+    throw new Error(`Fundraiser record ${index} has invalid timestamp.`);
+  }
+
+  return timestamp;
+}
+
+export function normalizeFundraiserRecords(records: unknown): FundraiserTeam[] {
+  if (!Array.isArray(records)) {
+    throw new Error('Fundraiser source must be an array.');
+  }
+
+  return records.map((record, index) => {
+    if (!isRecord(record)) {
+      throw new Error(`Fundraiser record ${index} must be an object.`);
+    }
+
+    const teamId = normalizeRequiredString(record.team_id, 'team_id', index);
+    const teamName = normalizeRequiredString(record.team_name, 'team_name', index);
+    const totalAmount = normalizeAmount(record.total_amount, 'total_amount', index);
+    const donorCount = normalizeDonorCount(record.donor_count, 'donor_count', index);
+    const timestamp = normalizeTimestamp(record.timestamp, index);
+
+    return {
+      teamId,
+      teamName,
+      totalAmount,
+      donorCount,
+      points: totalAmount * donorCount,
+      timestamp,
+    };
+  });
+}
+
+export function getFundraiserTeams(): FundraiserTeam[] {
+  return normalizeFundraiserRecords(fundraiserSource);
+}
+
+export const fundraiserTeams = getFundraiserTeams();

--- a/tests/fundraiser.test.ts
+++ b/tests/fundraiser.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { fundraiserTeams, normalizeFundraiserRecords } from '@/lib/fundraiser';
+
+describe('fundraiser ingest layer', () => {
+  it('loads and normalizes the fundraiser JSON seed data', () => {
+    expect(fundraiserTeams).toEqual([
+      {
+        teamId: 'yankees',
+        teamName: 'New York Yankees',
+        totalAmount: 0,
+        donorCount: 0,
+        points: 0,
+        timestamp: '2026-03-25T00:00:00Z',
+      },
+      {
+        teamId: 'tigers',
+        teamName: 'Detroit Tigers',
+        totalAmount: 0,
+        donorCount: 0,
+        points: 0,
+        timestamp: '2026-03-25T00:00:00Z',
+      },
+      {
+        teamId: 'guardians',
+        teamName: 'Cleveland Guardians',
+        totalAmount: 0,
+        donorCount: 0,
+        points: 0,
+        timestamp: '2026-03-25T00:00:00Z',
+      },
+    ]);
+  });
+
+  it('normalizes numeric strings before calculating points', () => {
+    expect(
+      normalizeFundraiserRecords([
+        {
+          team_id: 'team-one',
+          team_name: 'Team One',
+          total_amount: '125.5',
+          donor_count: '4',
+          timestamp: '2026-05-01T12:00:00Z',
+        },
+      ]),
+    ).toEqual([
+      {
+        teamId: 'team-one',
+        teamName: 'Team One',
+        totalAmount: 125.5,
+        donorCount: 4,
+        points: 502,
+        timestamp: '2026-05-01T12:00:00Z',
+      },
+    ]);
+  });
+
+  it('rejects malformed records', () => {
+    expect(() =>
+      normalizeFundraiserRecords([
+        {
+          team_id: 'bad-team',
+          team_name: '',
+          total_amount: 10,
+          donor_count: 1,
+          timestamp: '2026-05-01T12:00:00Z',
+        },
+      ]),
+    ).toThrow(/empty team_name/i);
+
+    expect(() =>
+      normalizeFundraiserRecords([
+        {
+          team_id: 'bad-team',
+          team_name: 'Bad Team',
+          total_amount: 10,
+          donor_count: 1.5,
+          timestamp: '2026-05-01T12:00:00Z',
+        },
+      ]),
+    ).toThrow(/non-integer donor_count/i);
+  });
+});


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/910

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### PR Template

#### Reference
Refer to `/.github/pull_request_template.md` for required structure and change conventions.

#### Governance Reference
Follow operational, rollback, and testing standards in `/docs/governance/PR_GOVERNANCE.md`.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [ ] OR any ZIP file that was present in the repo root was deleted before any other change
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Phase 2 — Website Implementation
- Task: T20-B — Fundraiser Ingest Layer
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: None
- Notes: Targeted local validation passed after installing a temporary Node 22 toolchain outside the repo because the base Cloud Agent image did not include `node`/`npm`.

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `/Agent.md`
- `/docs/governance/ai/AI-GUIDE.md`
- `/docs/ops/ai/CORE-RULES.md`
- `/docs/ops/ai/CHATGPT-RULES.md`
- `/docs/ops/ai/pr-lifecycle-standard.md`
- `/README.md`
- `/context.md`
- `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- `/docs/reference/design/home.md`
- `/docs/reference/design/home-temporary-campaign-section.md`
- `/docs/reference/design/als-fundraiser-2026-campaign-spotlight.md`
- `/docs/reference/architecture/temporary-campaign-spotlight-data-contract.md`
- `/docs/ops/trackers/LGFC-REPO-RECOVERY-AND-IMPLEMENTATION_PLAN.md`
- `/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
- `/docs/ops/tickets/T20-B-fundraiser-ingest-layer.md`
- `/docs/ops/tasks/T20-A.md`

## DIATAXIS GAP (REQUIRED IF LEGACY_FALLBACK)
- [ ] Gap Identified
- Link to issue: N/A
- Description: N/A — LEGACY_FALLBACK was not used.

## LABEL
- Intent label for this PR: change-website

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical design reference: `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- Additional design/reference docs used for this PR:
  - `/docs/reference/design/home.md`
  - `/docs/reference/design/home-temporary-campaign-section.md`
  - `/docs/reference/design/als-fundraiser-2026-campaign-spotlight.md`
  - `/docs/reference/architecture/temporary-campaign-spotlight-data-contract.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `src/lib/fundraiser.ts`
- `tests/fundraiser.test.ts`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [ ] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## DOCS-ONLY ASSERTION (REQUIRED FOR change-ops)
- [ ] This PR contains documentation-only changes
- [x] No documentation updates required because this is a scoped website implementation PR, not change-ops

## CHANGE SUMMARY
- Added `src/lib/fundraiser.ts` to load `data/fundraiser.json` through a dedicated ingest utility.
- Validates fundraiser source records for required shape, non-empty strings, non-negative numeric amounts, integer donor counts, and parseable timestamps.
- Normalizes source values into typed app output and computes `points = totalAmount * donorCount`.
- Added focused Vitest coverage for seed loading, numeric-string normalization, point calculation, and malformed-record rejection.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `PATH="/tmp/lgfc-node/bin:$PATH" npm ci`
  - `PATH="/tmp/lgfc-node/bin:$PATH" npm run test -- tests/fundraiser.test.ts`
  - `PATH="/tmp/lgfc-node/bin:$PATH" npm run typecheck`
- Result summary:
  - PASS — `tests/fundraiser.test.ts` passed (3 tests).
  - PASS — `tsc --noEmit` completed successfully.
- If FAIL, explain: N/A

## DOCUMENTATION UPDATES
- [ ] Documentation updated in this PR
- [x] No documentation updates required
- Files:
  - N/A

## ACCEPTANCE CRITERIA
- [x] Fundraiser ingest utility exists at `src/lib/fundraiser.ts`
- [x] Utility loads data from `data/fundraiser.json`
- [x] Schema/shape validation is applied
- [x] Points are computed consistently
- [x] Normalized output is ready for downstream T20-C leaderboard logic
- [x] File changes remain limited to the T20-B allowlist
- [x] Targeted validation passes

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [ ] Intent label correct and singular
- [x] Local checks executed and passed
- [x] Commit message aligns with scope
- [x] No secrets or forbidden artifacts introduced
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b897a1e8-c1de-4b7a-bcff-92745564a30e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b897a1e8-c1de-4b7a-bcff-92745564a30e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fundraiser ingest layer that loads `data/fundraiser.json`, validates and normalizes records, and computes team points for downstream leaderboard work. Includes `vitest` tests for seed loading, normalization, and error cases.

- **New Features**
  - New `src/lib/fundraiser.ts` to parse and validate source data.
  - Ensures required strings, non-negative amounts, integer donor counts, and valid timestamps.
  - Normalizes numeric strings and calculates `points = totalAmount * donorCount`.
  - Exports `getFundraiserTeams()` and `fundraiserTeams`.
  - Tests in `tests/fundraiser.test.ts` using `vitest`.

<sup>Written for commit 714fc5703e1181f116fc1b1d39b94678cd0e99f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

