### PR TITLE
T20-B: Tighten fundraiser ingest numeric validation

### DIFF
--- a/src/lib/fundraiser.ts
+++ b/src/lib/fundraiser.ts
@@ -35,7 +35,18 @@ function normalizeRequiredString(value: unknown, field: string, index: number): 
 }
 
 function normalizeAmount(value: unknown, field: string, index: number): number {
-  const normalized = typeof value === 'number' ? value : typeof value === 'string' ? Number(value.trim()) : Number.NaN;
+  let normalized = Number.NaN;
+
+  if (typeof value === 'number') {
+    normalized = value;
+  } else if (typeof value === 'string') {
+    const trimmedValue = value.trim();
+    if (!trimmedValue) {
+      throw new Error(`Fundraiser record ${index} has invalid ${field}.`);
+    }
+
+    normalized = Number(trimmedValue);
+  }
 
   if (!Number.isFinite(normalized) || normalized < 0) {
     throw new Error(`Fundraiser record ${index} has invalid ${field}.`);

--- a/src/lib/fundraiser.ts
+++ b/src/lib/fundraiser.ts
@@ -41,11 +41,7 @@ function normalizeAmount(value: unknown, field: string, index: number): number {
     normalized = value;
   } else if (typeof value === 'string') {
     const trimmedValue = value.trim();
-    if (!trimmedValue) {
-      throw new Error(`Fundraiser record ${index} has invalid ${field}.`);
-    }
-
-    normalized = Number(trimmedValue);
+    normalized = trimmedValue === '' ? Number.NaN : Number(trimmedValue);
   }
 
   if (!Number.isFinite(normalized) || normalized < 0) {

--- a/tests/fundraiser.test.ts
+++ b/tests/fundraiser.test.ts
@@ -38,8 +38,8 @@ describe('fundraiser ingest layer', () => {
         {
           team_id: 'team-one',
           team_name: 'Team One',
-          total_amount: '125.5',
-          donor_count: '4',
+          total_amount: ' 125.5 ',
+          donor_count: ' 4 ',
           timestamp: '2026-05-01T12:00:00Z',
         },
       ]),
@@ -79,5 +79,29 @@ describe('fundraiser ingest layer', () => {
         },
       ]),
     ).toThrow(/non-integer donor_count/i);
+
+    expect(() =>
+      normalizeFundraiserRecords([
+        {
+          team_id: 'bad-team',
+          team_name: 'Bad Team',
+          total_amount: '   ',
+          donor_count: 1,
+          timestamp: '2026-05-01T12:00:00Z',
+        },
+      ]),
+    ).toThrow(/invalid total_amount/i);
+
+    expect(() =>
+      normalizeFundraiserRecords([
+        {
+          team_id: 'bad-team',
+          team_name: 'Bad Team',
+          total_amount: 10,
+          donor_count: '',
+          timestamp: '2026-05-01T12:00:00Z',
+        },
+      ]),
+    ).toThrow(/invalid donor_count/i);
   });
 });

--- a/tests/fundraiser.test.ts
+++ b/tests/fundraiser.test.ts
@@ -103,5 +103,17 @@ describe('fundraiser ingest layer', () => {
         },
       ]),
     ).toThrow(/invalid donor_count/i);
+
+    expect(() =>
+      normalizeFundraiserRecords([
+        {
+          team_id: 'bad-team',
+          team_name: 'Bad Team',
+          total_amount: 10,
+          donor_count: '   ',
+          timestamp: '2026-05-01T12:00:00Z',
+        },
+      ]),
+    ).toThrow(/invalid donor_count/i);
   });
 });


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/912

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/912

### PR Template

#### Reference
Refer to `/.github/pull_request_template.md` for required structure and change conventions.

#### Governance Reference
Follow operational, rollback, and testing standards in `/docs/governance/PR_GOVERNANCE.md`.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [ ] OR any ZIP file that was present in the repo root was deleted before any other change
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Phase 2 — Website Implementation
- Task: T20-B — Fundraiser Ingest Layer correction
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: None
- Notes: Reviewer feedback from PR #911 was applied. Gemini found that the empty-string branch duplicated the shared finite-number guard, so empty trimmed numeric strings now become `Number.NaN` and flow through the existing invalid-field validation path. Copilot found that whitespace-only `donor_count` was listed in acceptance criteria without direct coverage, so a focused assertion was added.

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `/docs/ops/tickets/T20-B-fundraiser-ingest-layer.md`
- `/docs/reference/architecture/temporary-campaign-spotlight-data-contract.md`
- `/docs/reference/design/als-fundraiser-2026-campaign-spotlight.md`
- `/.github/pull_request_template.md`

## DIATAXIS GAP (REQUIRED IF LEGACY_FALLBACK)
- [ ] Gap Identified
- Link to issue: N/A
- Description: N/A — LEGACY_FALLBACK was not used.

## LABEL
- Intent label for this PR: change-website

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical design reference: `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- Additional design/reference docs used for this PR:
  - `/docs/reference/architecture/temporary-campaign-spotlight-data-contract.md`
  - `/docs/reference/design/als-fundraiser-2026-campaign-spotlight.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `src/lib/fundraiser.ts`
- `tests/fundraiser.test.ts`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [ ] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## DOCS-ONLY ASSERTION (REQUIRED FOR change-ops)
- [ ] This PR contains documentation-only changes
- [x] No documentation updates required because this is a scoped website correction PR, not change-ops

## REVIEW FINDINGS + ADJUSTMENTS
- Gemini finding: The first normalization revision threw early for empty or whitespace-only strings, duplicating the final `Number.isFinite` invalid-field guard.
  - Adjustment: `normalizeAmount` now trims string inputs, assigns `Number.NaN` for empty trimmed strings, and lets the shared invalid-field guard produce the error.
- Copilot finding: Acceptance criteria and summary referenced whitespace-only `donor_count`, but tests only covered an empty string.
  - Adjustment: Added a whitespace-only `donor_count: '   '` rejection assertion in `tests/fundraiser.test.ts`.
- Cubic found no issues across the two changed files on the prior revision.

## CHANGE SUMMARY
- Reject empty or whitespace-only numeric strings without coercing them to zero.
- Preserve valid numeric strings with surrounding whitespace by trimming before conversion.
- Route empty trimmed numeric strings through the existing invalid-field validation guard, per reviewer feedback.
- Add focused tests for whitespace-trimmed valid numerics, whitespace-only `total_amount`, empty `donor_count`, and whitespace-only `donor_count`.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `PATH="/tmp/lgfc-node/bin:$PATH" npm ci`
  - `PATH="/tmp/lgfc-node/bin:$PATH" npm run test -- tests/fundraiser.test.ts`
  - `PATH="/tmp/lgfc-node/bin:$PATH" npm run typecheck`
- Result summary:
  - PASS — dependencies installed from `package-lock.json` after bootstrapping Node 22 locally because `npm` was not available in the runner.
  - PASS — `tests/fundraiser.test.ts` passed (3 tests).
  - PASS — `tsc --noEmit` completed successfully.
- If FAIL, explain: N/A

## DOCUMENTATION UPDATES
- [ ] Documentation updated in this PR
- [x] No documentation updates required
- Files:
  - N/A

## ACCEPTANCE CRITERIA
- [x] Fundraiser ingest still accepts valid numeric strings after trimming
- [x] Fundraiser ingest rejects whitespace-only `total_amount`
- [x] Fundraiser ingest rejects empty/whitespace-only `donor_count`
- [x] Points continue to be computed consistently for valid records
- [x] Reviewer simplification request is applied
- [x] Targeted validation passes

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [ ] Intent label correct and singular
- [x] Local checks executed and passed
- [x] Commit message aligns with scope
- [x] No secrets or forbidden artifacts introduced
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c052432-2b3c-474b-80d7-bfa186fd785e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c052432-2b3c-474b-80d7-bfa186fd785e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject empty or whitespace-only numeric inputs in fundraiser ingest instead of coercing to 0. Trim valid numbers and add tests, aligning with T20-B requirements.

- **Bug Fixes**
  - Harden `normalizeAmount`: trim strings, reject empty-after-trim, and avoid implicit coercion; still rejects non-finite or negative values.
  - Accept inputs like " 125.5 " and " 4 ".
  - Add tests for whitespace-only `total_amount` and empty/whitespace `donor_count`, plus the non-integer `donor_count` case.

<sup>Written for commit 5a68db78e26da0ec72945c3e3ad2667e0f3c9301. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

