### PR TITLE
OPS — Orchestrator Post-Merge Integration (PR 8)

### DIFF
--- a/.github/workflows/orchestrator-pr-state-sync.yml
+++ b/.github/workflows/orchestrator-pr-state-sync.yml
@@ -1,0 +1,29 @@
+name: Orchestrator — PR State Sync
+
+on:
+  pull_request:
+    types: [ready_for_review, closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Sync PR state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SYNC_ACTION: ${{ github.event.action == 'closed' && github.event.pull_request.merged && 'merged' || github.event.action }}
+        run: node scripts/orchestrator/sync-pr-state.mjs

--- a/scripts/orchestrator/sync-pr-state.mjs
+++ b/scripts/orchestrator/sync-pr-state.mjs
@@ -16,7 +16,7 @@ function runGh(args) {
 }
 
 function linkedIssueNumber(body) {
-  const match = body.match(/(?:Issue:\*\*\s*#|Issue:\s*#|#)(\d+)/i);
+  const match = body.match(/(?:Issue:(?:\*\*)?\s*#)(\d+)/i);
   return match ? match[1] : '';
 }
 
@@ -44,9 +44,20 @@ if (action === 'ready_for_review') {
 
 if (action === 'merged') {
   if (!pr.merged) process.exit(0);
-  setStatus(issueNumber, 'status:review', 'status:merged', `PR #${prNumber} merged. Post-merge verification pending: ${pr.url}`);
-  setStatus(issueNumber, 'status:merged', 'status:post-merge-verify', null);
+  setStatus(issueNumber, 'status:review', 'status:post-merge-verify', `PR #${prNumber} merged. Post-merge verification pending: ${pr.url}`);
   process.exit(0);
 }
 
-console.log(`Unsupported SYNC_ACTION: ${action}`);
+if (action === 'post_merge_success') {
+  setStatus(issueNumber, 'status:post-merge-verify', 'status:complete', `Post-merge verification passed for PR #${prNumber}: ${pr.url}`);
+  runGh(['issue', 'close', issueNumber, '--repo', repo, '--comment', `Task complete. PR #${prNumber} merged and post-merge verification passed.`]);
+  process.exit(0);
+}
+
+if (action === 'post_merge_failure') {
+  setStatus(issueNumber, 'status:post-merge-verify', 'status:failed', `Post-merge verification failed for PR #${prNumber}. Recovery issue/PR required: ${pr.url}`);
+  process.exit(0);
+}
+
+console.error(`Unsupported SYNC_ACTION: ${action}`);
+process.exit(1);

--- a/scripts/orchestrator/sync-pr-state.mjs
+++ b/scripts/orchestrator/sync-pr-state.mjs
@@ -16,7 +16,7 @@ function runGh(args) {
 }
 
 function linkedIssueNumber(body) {
-  const match = body.match(/(?:Issue:(?:\*\*)?\s*#)(\d+)/i);
+  const match = body.match(/(?:\*\*Issue:\*\*|Issue:)\s*(?:https?:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/|#)(\d+)/i);
   return match ? match[1] : '';
 }
 
@@ -33,7 +33,7 @@ const pr = JSON.parse(prJson);
 const issueNumber = linkedIssueNumber(pr.body || '');
 
 if (!issueNumber) {
-  console.log(`No linked issue found for PR #${prNumber}.`);
+  console.log(`No linked orchestrator issue found for PR #${prNumber}.`);
   process.exit(0);
 }
 
@@ -58,6 +58,8 @@ if (action === 'post_merge_failure') {
   setStatus(issueNumber, 'status:post-merge-verify', 'status:failed', `Post-merge verification failed for PR #${prNumber}. Recovery issue/PR required: ${pr.url}`);
   process.exit(0);
 }
+
+if (action === 'closed') process.exit(0);
 
 console.error(`Unsupported SYNC_ACTION: ${action}`);
 process.exit(1);

--- a/scripts/orchestrator/sync-pr-state.mjs
+++ b/scripts/orchestrator/sync-pr-state.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+
+const repo = process.env.GITHUB_REPOSITORY;
+const prNumber = process.env.PR_NUMBER;
+const action = process.env.SYNC_ACTION;
+
+if (!repo || !prNumber || !action) {
+  console.error('GITHUB_REPOSITORY, PR_NUMBER, and SYNC_ACTION are required.');
+  process.exit(1);
+}
+
+function runGh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+
+function linkedIssueNumber(body) {
+  const match = body.match(/(?:Issue:\*\*\s*#|Issue:\s*#|#)(\d+)/i);
+  return match ? match[1] : '';
+}
+
+function setStatus(issueNumber, removeLabel, addLabel, comment) {
+  const args = ['issue', 'edit', issueNumber, '--repo', repo];
+  if (removeLabel) args.push('--remove-label', removeLabel);
+  if (addLabel) args.push('--add-label', addLabel);
+  runGh(args);
+  if (comment) runGh(['issue', 'comment', issueNumber, '--repo', repo, '--body', comment]);
+}
+
+const prJson = runGh(['pr', 'view', prNumber, '--repo', repo, '--json', 'body,url,merged,state']);
+const pr = JSON.parse(prJson);
+const issueNumber = linkedIssueNumber(pr.body || '');
+
+if (!issueNumber) {
+  console.log(`No linked issue found for PR #${prNumber}.`);
+  process.exit(0);
+}
+
+if (action === 'ready_for_review') {
+  setStatus(issueNumber, 'status:implementation', 'status:review', `PR #${prNumber} is ready for review: ${pr.url}`);
+  process.exit(0);
+}
+
+if (action === 'merged') {
+  if (!pr.merged) process.exit(0);
+  setStatus(issueNumber, 'status:review', 'status:merged', `PR #${prNumber} merged. Post-merge verification pending: ${pr.url}`);
+  setStatus(issueNumber, 'status:merged', 'status:post-merge-verify', null);
+  process.exit(0);
+}
+
+console.log(`Unsupported SYNC_ACTION: ${action}`);


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/914

## Reference
/docs/ops/orchestration-tier-design.md

## Change Summary
Integrates orchestrator task completion with the existing post-merge verification path instead of creating a competing post-merge workflow.

## Governance Reference
/docs/governance/PR_GOVERNANCE.md

## Scope
- Reuse post-merge verification result as source of truth
- On success: mark linked orchestrator issue complete, close it, and allow queue advancement
- On failure: mark linked orchestrator issue failed and open/retain recovery path
- Do not duplicate post-merge verifier behavior

## Acceptance Criteria
- Successful post-merge verification closes the current orchestrator issue
- Failed post-merge verification does not advance the queue
- Recovery issue path remains visible
- Existing post-merge workflow remains authoritative

## Risk
Low

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs PR events to the linked orchestrator issue and moves merged PRs into the post-merge verification flow. Also handles post-merge success/failure, supports canonical issue links in the PR body, and ignores closed-but-unmerged PRs.

- **New Features**
  - Adds Orchestrator — PR State Sync workflow that runs on `ready_for_review` and merged PRs; ignores closed-but-unmerged PRs.
  - Introduces `scripts/orchestrator/sync-pr-state.mjs` that finds the linked issue in the PR body (full URL or `#123`) and updates labels/comments via `gh`:
    - ready_for_review: `status:implementation` → `status:review`
    - merged: comment with PR URL; `status:review` → `status:post-merge-verify`
    - post_merge_success: `status:post-merge-verify` → `status:complete`; close the issue with a comment
    - post_merge_failure: `status:post-merge-verify` → `status:failed`

<sup>Written for commit dec7fcf1a739920032f259a0364f16f9b112ebf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

