### PR TITLE
T20-C: Implement fundraiser leaderboard sorting

### DIFF
--- a/src/lib/fundraiser.ts
+++ b/src/lib/fundraiser.ts
@@ -71,12 +71,30 @@ function normalizeTimestamp(value: unknown, index: number): string {
   return timestamp;
 }
 
+function compareFundraiserLeaderboardEntries(left: FundraiserTeam, right: FundraiserTeam): number {
+  return (
+    right.points - left.points ||
+    right.donorCount - left.donorCount ||
+    right.totalAmount - left.totalAmount
+  );
+}
+
+export function sortFundraiserLeaderboard(teams: FundraiserTeam[]): FundraiserTeam[] {
+  return teams
+    .map((team, index) => ({ team, index }))
+    .sort(
+      (left, right) =>
+        compareFundraiserLeaderboardEntries(left.team, right.team) || left.index - right.index,
+    )
+    .map(({ team }) => team);
+}
+
 export function normalizeFundraiserRecords(records: unknown): FundraiserTeam[] {
   if (!Array.isArray(records)) {
     throw new Error('Fundraiser source must be an array.');
   }
 
-  return records.map((record, index) => {
+  const teams = records.map((record, index) => {
     if (!isRecord(record)) {
       throw new Error(`Fundraiser record ${index} must be an object.`);
     }
@@ -96,6 +114,8 @@ export function normalizeFundraiserRecords(records: unknown): FundraiserTeam[] {
       timestamp,
     };
   });
+
+  return sortFundraiserLeaderboard(teams);
 }
 
 export function getFundraiserTeams(): FundraiserTeam[] {

--- a/src/lib/fundraiser.ts
+++ b/src/lib/fundraiser.ts
@@ -80,13 +80,7 @@ function compareFundraiserLeaderboardEntries(left: FundraiserTeam, right: Fundra
 }
 
 export function sortFundraiserLeaderboard(teams: FundraiserTeam[]): FundraiserTeam[] {
-  return teams
-    .map((team, index) => ({ team, index }))
-    .sort(
-      (left, right) =>
-        compareFundraiserLeaderboardEntries(left.team, right.team) || left.index - right.index,
-    )
-    .map(({ team }) => team);
+  return [...teams].sort((left, right) => compareFundraiserLeaderboardEntries(left, right));
 }
 
 export function normalizeFundraiserRecords(records: unknown): FundraiserTeam[] {

--- a/tests/fundraiser.test.ts
+++ b/tests/fundraiser.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { fundraiserTeams, normalizeFundraiserRecords } from '@/lib/fundraiser';
+import {
+  fundraiserTeams,
+  normalizeFundraiserRecords,
+  sortFundraiserLeaderboard,
+  type FundraiserTeam,
+} from '@/lib/fundraiser';
 
 describe('fundraiser ingest layer', () => {
   it('loads and normalizes the fundraiser JSON seed data', () => {
@@ -53,6 +58,84 @@ describe('fundraiser ingest layer', () => {
         timestamp: '2026-05-01T12:00:00Z',
       },
     ]);
+  });
+
+  it('sorts normalized fundraiser records by leaderboard priority', () => {
+    expect(
+      normalizeFundraiserRecords([
+        {
+          team_id: 'lowest-points',
+          team_name: 'Lowest Points',
+          total_amount: 75,
+          donor_count: 1,
+          timestamp: '2026-05-01T12:00:00Z',
+        },
+        {
+          team_id: 'most-donors',
+          team_name: 'Most Donors',
+          total_amount: 50,
+          donor_count: 4,
+          timestamp: '2026-05-01T12:00:00Z',
+        },
+        {
+          team_id: 'most-points',
+          team_name: 'Most Points',
+          total_amount: 100,
+          donor_count: 3,
+          timestamp: '2026-05-01T12:00:00Z',
+        },
+        {
+          team_id: 'fewer-donors',
+          team_name: 'Fewer Donors',
+          total_amount: 100,
+          donor_count: 2,
+          timestamp: '2026-05-01T12:00:00Z',
+        },
+      ]).map((team) => team.teamId),
+    ).toEqual(['most-points', 'most-donors', 'fewer-donors', 'lowest-points']);
+  });
+
+  it('uses total amount and stable source order for remaining leaderboard ties', () => {
+    const teams: FundraiserTeam[] = [
+      {
+        teamId: 'stable-first',
+        teamName: 'Stable First',
+        totalAmount: 10,
+        donorCount: 0,
+        points: 0,
+        timestamp: '2026-05-01T12:00:00Z',
+      },
+      {
+        teamId: 'most-funds',
+        teamName: 'Most Funds',
+        totalAmount: 100,
+        donorCount: 0,
+        points: 0,
+        timestamp: '2026-05-01T12:00:00Z',
+      },
+      {
+        teamId: 'stable-second',
+        teamName: 'Stable Second',
+        totalAmount: 10,
+        donorCount: 0,
+        points: 0,
+        timestamp: '2026-05-01T12:00:00Z',
+      },
+      {
+        teamId: 'fewest-funds',
+        teamName: 'Fewest Funds',
+        totalAmount: 5,
+        donorCount: 0,
+        points: 0,
+        timestamp: '2026-05-01T12:00:00Z',
+      },
+    ];
+
+    const sortedOnce = sortFundraiserLeaderboard(teams).map((team) => team.teamId);
+    const sortedAgain = sortFundraiserLeaderboard(teams).map((team) => team.teamId);
+
+    expect(sortedOnce).toEqual(['most-funds', 'stable-first', 'stable-second', 'fewest-funds']);
+    expect(sortedAgain).toEqual(sortedOnce);
   });
 
   it('rejects malformed records', () => {


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/918

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### PR Template

#### Reference
Refer to `/.github/pull_request_template.md` for required structure and change conventions.

#### Governance Reference
Follow operational, rollback, and testing standards in `/docs/governance/PR_GOVERNANCE.md`.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [ ] OR any ZIP file that was present in the repo root was deleted before any other change
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Phase 2 — Website Implementation
- Task: T20-C — Leaderboard sorting
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: None
- Notes: Implemented deterministic sorting in the existing fundraiser data layer. Complete metric ties use an explicit source-index fallback so identical inputs produce identical ordering across environments without entering T20-D winner-resolution scope.

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `/docs/ops/tasks/T20-C.md`
- `/docs/reference/architecture/temporary-campaign-spotlight-data-contract.md`
- `/docs/reference/design/als-fundraiser-2026-campaign-spotlight.md`
- `/.github/pull_request_template.md`

## DIATAXIS GAP (REQUIRED IF LEGACY_FALLBACK)
- [ ] Gap Identified
- Link to issue: N/A
- Description: N/A — LEGACY_FALLBACK was not used.

## LABEL
- Intent label for this PR: change-website

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical design reference: `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- Additional design/reference docs used for this PR:
  - `/docs/reference/architecture/temporary-campaign-spotlight-data-contract.md`
  - `/docs/reference/design/als-fundraiser-2026-campaign-spotlight.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `src/lib/fundraiser.ts`
- `tests/fundraiser.test.ts`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [ ] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## DOCS-ONLY ASSERTION (REQUIRED FOR change-ops)
- [ ] This PR contains documentation-only changes
- [x] No documentation updates required because this is a scoped website data-layer change, not change-ops

## CHANGE SUMMARY
- Add deterministic fundraiser leaderboard sorting by points descending, donor count descending, then total amount descending.
- Preserve stable source order as an explicit final fallback for complete metric ties.
- Return normalized fundraiser records in leaderboard order.
- Add focused tests for leaderboard priority and deterministic tie handling.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `npm run test -- tests/fundraiser.test.ts`
  - `npm test`
  - `npm run typecheck`
  - `npm run build`
- Result summary:
  - PASS — focused fundraiser suite passed (5 tests).
  - PASS — full Vitest suite passed (3 files, 17 tests).
  - PASS — `tsc --noEmit` completed successfully.
  - PASS — production build completed successfully.
  - NOTE — build emitted pre-existing `<img>` optimization warnings in unrelated UI files.
- If FAIL, explain: N/A

## DOCUMENTATION UPDATES
- [ ] Documentation updated in this PR
- [x] No documentation updates required
- Files:
  - N/A

## ACCEPTANCE CRITERIA
- [x] Leaderboard sorts by points descending
- [x] Equal points sort by donor_count descending
- [x] Equal points and donor_count sort by total_amount descending
- [x] Complete metric ties retain deterministic stable ordering
- [x] Targeted and relevant full validation passes

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [ ] Intent label correct and singular
- [x] Local checks executed and passed
- [x] Commit message aligns with scope
- [x] No secrets or forbidden artifacts introduced
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41ce6501-a476-40c6-8e42-6c1444c92b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41ce6501-a476-40c6-8e42-6c1444c92b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deterministic sorting for the fundraiser leaderboard. Teams are ordered by points, then donor count, then total amount, with stable source order for full ties.

- **New Features**
  - Exported `sortFundraiserLeaderboard` and used it in `normalizeFundraiserRecords` to return teams in leaderboard order.
  - Simplified comparator; relies on stable sort to preserve source order on complete ties.
  - Added tests for priority order, stable tie handling, and direct use of `sortFundraiserLeaderboard`.

<sup>Written for commit 6967c14884fb2b68799eeb3fbd12b87f55d4a99c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

