### PR TITLE
OPS — Queue Advance Hotfix (PR 10)

### DIFF
--- a/scripts/orchestrator/advance-queue.mjs
+++ b/scripts/orchestrator/advance-queue.mjs
@@ -3,39 +3,46 @@
 import { execFileSync } from 'node:child_process';
 
 const repo = process.env.GITHUB_REPOSITORY;
-
 if (!repo) {
   console.error('GITHUB_REPOSITORY is required.');
   process.exit(1);
 }
 
-function runGh(args) {
+const ACTIVE = new Set([
+  'status:assigned',
+  'status:pr-draft',
+  'status:implementation',
+  'status:review',
+  'status:post-merge-verify'
+]);
+
+function gh(args) {
   return execFileSync('gh', args, { encoding: 'utf8' }).trim();
 }
 
-function searchIssues(query) {
-  const result = runGh(['issue', 'list', '--repo', repo, '--search', query, '--json', 'number,title,labels', '--limit', '20']);
-  return JSON.parse(result);
+const issues = JSON.parse(
+  gh(['issue','list','--repo',repo,'--search','is:open label:orchestrator','--json','number,title,labels,createdAt','--limit','100'])
+);
+
+function has(issue, name) {
+  return issue.labels.some(l => l.name === name);
 }
 
-const failed = searchIssues('is:open label:orchestrator label:status:failed');
-if (failed.length > 0) {
-  console.log('Queue advance stopped: failed orchestrator issue exists.');
-  process.exit(0);
-}
+// stop if failure exists
+if (issues.some(i => has(i,'status:failed'))) process.exit(0);
 
-const active = searchIssues('is:open label:orchestrator label:status:assigned,label:status:pr-draft,label:status:implementation,label:status:review,label:status:post-merge-verify');
-if (active.length > 0) {
-  console.log('Queue advance stopped: active orchestrator issue exists.');
-  process.exit(0);
-}
+// stop if active work exists
+if (issues.some(i => i.labels.some(l => ACTIVE.has(l.name)))) process.exit(0);
 
-const queued = searchIssues('is:open label:orchestrator label:status:queued');
-if (queued.length === 0) {
-  console.log('Queue complete: no queued orchestrator issues.');
-  process.exit(0);
-}
+// select next blocked task
+const next = issues
+  .filter(i => has(i,'status:blocked'))
+  .sort((a,b)=>new Date(a.createdAt)-new Date(b.createdAt))[0];
 
-const next = queued.sort((a, b) => a.number - b.number)[0];
-runGh(['issue', 'comment', String(next.number), '--repo', repo, '--body', 'Queue advance selected this issue as the next serial task. Draft PR creation will run from status:queued.']);
-console.log(`Queue advance selected issue #${next.number}: ${next.title}`);
+if (!next) process.exit(0);
+
+// trigger next task by relabeling
+gh(['issue','edit',String(next.number),'--repo',repo,'--remove-label','status:blocked','--add-label','status:queued']);
+
+// comment for traceability
+gh(['issue','comment',String(next.number),'--repo',repo,'--body','Queue advance activated: status:blocked → status:queued']);


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/920

## Reference
PR #915

## Change Summary
Fixes queue advancement to enforce true serial orchestration.

## Scope
- Fix active status detection
- Replace broken GitHub search logic
- Enforce blocked → queued model
- Trigger next task via label change (not comment)

## Acceptance Criteria
- Only one task runs at a time
- Next task starts automatically
- Queue halts on failure

## Risk
Low

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the orchestrator queue to run tasks strictly one at a time. Advances the next task by relabeling and halts the queue on failure.

- **Bug Fixes**
  - Use a single `gh issue list` call and filter labels in-memory for reliability.
  - Detect active work via labels: `status:assigned`, `status:pr-draft`, `status:implementation`, `status:review`, `status:post-merge-verify`.
  - Stop advancing if any issue has `status:failed`.
  - Promote the oldest `status:blocked` issue to `status:queued` and add a trace comment.

<sup>Written for commit b5451dcaf10f4e134ecab31cec119342a131ab08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

