### PR TITLE
Make orchestrator status labels best effort

### DIFF
--- a/scripts/orchestrator/sync-pr-state.mjs
+++ b/scripts/orchestrator/sync-pr-state.mjs
@@ -15,6 +15,16 @@ function runGh(args) {
   return execFileSync('gh', args, { encoding: 'utf8' }).trim();
 }
 
+let repoLabels;
+function repoLabelNames() {
+  if (!repoLabels) {
+    const labelsJson = runGh(['label', 'list', '--repo', repo, '--json', 'name', '--limit', '1000']);
+    const labels = JSON.parse(labelsJson);
+    repoLabels = new Set((labels || []).map((label) => label.name));
+  }
+  return repoLabels;
+}
+
 function issueLabelNames(issueNumber) {
   const issueJson = runGh(['issue', 'view', issueNumber, '--repo', repo, '--json', 'labels']);
   const issue = JSON.parse(issueJson);
@@ -28,9 +38,16 @@ function linkedIssueNumber(body) {
 
 function setStatus(issueNumber, removeLabel, addLabel, comment) {
   const labels = issueLabelNames(issueNumber);
+  const availableLabels = repoLabelNames();
   const args = ['issue', 'edit', issueNumber, '--repo', repo];
   if (removeLabel && labels.has(removeLabel)) args.push('--remove-label', removeLabel);
-  if (addLabel && !labels.has(addLabel)) args.push('--add-label', addLabel);
+  if (addLabel && !labels.has(addLabel)) {
+    if (availableLabels.has(addLabel)) {
+      args.push('--add-label', addLabel);
+    } else {
+      console.warn(`Status label ${addLabel} does not exist; leaving issue #${issueNumber} without that label.`);
+    }
+  }
   if (args.length > 5) runGh(args);
   if (comment) runGh(['issue', 'comment', issueNumber, '--repo', repo, '--body', comment]);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/924

### PR Template

#### Reference
Refer to `/.github/pull_request_template.md` for required structure and change conventions.

#### Governance Reference
Follow operational, rollback, and testing standards in `/docs/governance/PR_GOVERNANCE.md`.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [ ] OR any ZIP file that was present in the repo root was deleted before any other change
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Post-merge operations remediation
- Task: Remediate PR #923 post-merge PR-state sync failure caused by missing repository status labels
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: Repository `status:*` labels are currently absent, so status metadata remains best-effort until labels are provisioned.
- Notes: PR #923 merged successfully and Post-Merge Detection passed, but the merge-triggered orchestrator sync failed when adding missing label `status:post-merge-verify`.

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `/.github/pull_request_template.md`
- `/docs/governance/PR_GOVERNANCE.md`
- `/.github/workflows/orchestrator-pr-state-sync.yml`
- `/scripts/orchestrator/sync-pr-state.mjs`

## DIATAXIS GAP (REQUIRED IF LEGACY_FALLBACK)
- [ ] Gap Identified
- Link to issue: N/A
- Description: N/A because LEGACY_FALLBACK was not used.

## LABEL
- Intent label for this PR: infra

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical design reference: `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- Additional design/reference docs used for this PR:
  - `/.github/pull_request_template.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `scripts/orchestrator/sync-pr-state.mjs`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## DOCS-ONLY ASSERTION (REQUIRED FOR change-ops)
- [ ] This PR contains documentation/workflow changes only
- [x] N/A: PR is labeled `infra` and changes orchestrator script resilience only.

## CHANGE SUMMARY
- Cache repository label names before orchestrator status transitions.
- Add issue status labels only when the target label exists in the repository.
- Warn and continue when a status label is unavailable, while still posting the traceability comment.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `python3` static verification for repository label availability guard
  - `python3` YAML parse check for `.github/workflows/orchestrator-pr-state-sync.yml`
  - `./scripts/ci/docs_check_headers.sh .`
  - `./scripts/ci/docs_check_paths.sh .`
  - `./scripts/ci/docs_canonical_hashes_verify.sh .`
  - `git diff --check origin/main..HEAD`
  - `gh pr checks 927 --watch --interval 10`
- Result summary:
  - PASS: sync script contains repository label availability guard.
  - PASS: orchestrator workflow YAML parses successfully.
  - PASS: docs header, path, and canonical drift checks pass.
  - PASS: diff whitespace check passes.
  - PASS: all PR #927 checks pass.
- If FAIL, explain: N/A

## DOCUMENTATION UPDATES
- [ ] Documentation updated in this PR
- [x] No documentation updates required
- Files:
  - N/A

## ACCEPTANCE CRITERIA
- [x] PR #923 merge verified on `main`.
- [x] PR #923 Post-Merge Detection run verified successful.
- [x] Root cause of merge-triggered sync failure identified as missing repository status label metadata.
- [x] Orchestrator sync no longer fails solely because a target status label is unavailable.
- [x] Local validation passes.
- [x] CI passes.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] Local checks executed and passed
- [x] Commit message aligns with scope
- [x] No secrets or forbidden artifacts introduced
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8bab3aa-4590-4849-992a-9567dbec329a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8bab3aa-4590-4849-992a-9567dbec329a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the PR-state orchestrator resilient to missing repository status labels. Sync now continues with a warning and still posts the trace comment, so post-merge flows don’t fail when `status:*` labels are absent.

- **Bug Fixes**
  - Cache repository label names during the run to reduce lookups.
  - Add a status label only if it exists; otherwise skip and warn.
  - Remove labels only when present and always post the issue comment.

<sup>Written for commit c4e92a76949ebe00560c6e9687a29862d1fec62c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

