### PR TITLE
Docs: clarify AI agent routing and ChatGPT PR authority

### DIFF
--- a/.github/orchestrator-routing.json
+++ b/.github/orchestrator-routing.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "defaultConcurrency": "serial",
   "concurrencyPolicy": {
     "mode": "serial",
@@ -8,27 +8,32 @@
   "taskTypes": {
     "repository": {
       "defaultAgent": "codex",
-      "allowedAgents": ["codex"],
+      "allowedAgents": ["codex", "cursor", "copilot", "atlas"],
+      "priorityOrder": ["codex", "cursor", "copilot", "atlas"],
       "prIntents": ["infra", "platform", "change-ops", "codex"]
     },
     "website": {
       "defaultAgent": "cursor",
-      "allowedAgents": ["cursor"],
-      "prIntents": ["feature"]
+      "allowedAgents": ["cursor", "codex", "copilot", "atlas"],
+      "priorityOrder": ["cursor", "codex", "copilot", "atlas"],
+      "prIntents": ["feature", "codex"]
     },
     "governance": {
       "defaultAgent": "copilot",
-      "allowedAgents": ["copilot", "atlas"],
+      "allowedAgents": ["copilot", "atlas", "codex", "cursor"],
+      "priorityOrder": ["copilot", "atlas", "codex", "cursor"],
       "prIntents": ["infra", "change-ops"]
     },
     "docs": {
       "defaultAgent": "atlas",
-      "allowedAgents": ["atlas", "copilot"],
+      "allowedAgents": ["atlas", "copilot", "codex", "cursor"],
+      "priorityOrder": ["atlas", "copilot", "codex", "cursor"],
       "prIntents": ["docs-only"]
     },
     "recovery": {
       "defaultAgent": "atlas",
       "allowedAgents": ["atlas", "copilot", "codex", "cursor"],
+      "priorityOrder": ["atlas", "copilot", "codex", "cursor"],
       "prIntents": ["recovery"]
     }
   },

--- a/docs/ops/ai/CHATGPT-RULES.md
+++ b/docs/ops/ai/CHATGPT-RULES.md
@@ -12,7 +12,7 @@ Does Not Own: Shared rules, design authority, governance
 
 Canonical Reference: /docs/ops/ai/CORE-RULES.md
 
-Last Reviewed: 2026-05-02
+Last Reviewed: 2026-05-06
 
 ---
 # CHATGPT-RULES.md
@@ -34,17 +34,20 @@ Modes must NOT be mixed.
 
 # ALIGNMENT GATE (MANDATORY)
 
-Before execution:
+Before high-risk execution:
 
 1. Restate task (1–3 lines)  
 2. Confirm scope  
 3. Identify risks  
-4. WAIT for confirmation  
+4. WAIT for confirmation unless standing repository-action permission applies  
 
-Exception:
+Standing repository-action permission:
 
-- ChatGPT has standing permission to create Issues and Pull Requests without waiting for confirmation when the task scope is clear and low risk.
-- Merge authority remains with the operator.
+- ChatGPT has standing permission to create GitHub Issues without waiting for confirmation when the task scope is clear.
+- ChatGPT has standing permission to create GitHub Pull Requests without waiting for confirmation when the task scope is clear.
+- ChatGPT has standing permission to comment, label, update, and organize Issues and Pull Requests as needed for orchestration and repository execution.
+- ChatGPT must NOT merge Pull Requests without explicit human/operator approval.
+- Human approval is required only for merge, destructive production changes, credential/security-sensitive changes, or unclear/high-risk scope.
 
 ---
 
@@ -71,13 +74,17 @@ Allowed observation format:
 
 ## #website
 
-- Cursor → implementation  
-- ChatGPT → design, validation, PR template, prompt  
+- Cursor → primary implementation agent  
+- Codex → secondary implementation agent when Cursor is unavailable, usage-limited, or unsuitable for the specific task  
+- All other agents → tertiary/support implementation agents only by explicit routing need  
+- ChatGPT → control layer: design, validation, Issue/PR creation, orchestration, PR template, agent prompt  
 
 ## #repository
 
-- Copilot → implementation  
-- ChatGPT → design, validation, PR template  
+- Codex → primary implementation agent  
+- Cursor → secondary implementation agent when Codex is unavailable, usage-limited, or unsuitable for the specific task  
+- All other agents → tertiary/support implementation agents only by explicit routing need  
+- ChatGPT → control layer: design, validation, Issue/PR creation, orchestration, PR template, agent prompt  
 
 ---
 
@@ -87,7 +94,7 @@ ChatGPT must provide:
 
 - complete files (not fragments)  
 - one PR template  
-- one agent prompt (Cursor or Copilot)  
+- one agent prompt matched to the routed implementation agent  
 - concise output  
 
 ---
@@ -100,8 +107,10 @@ Refer to /docs/ops/ai/CORE-RULES.md (REQUIRED VERIFICATION) for all fact and cit
 
 # PR OWNERSHIP
 
-- ChatGPT may create PRs and Issues directly under standing permission
-- Operator reviews and approves merges
+- ChatGPT may create PRs and Issues directly under standing permission.
+- ChatGPT may maintain orchestration metadata on PRs and Issues directly under standing permission.
+- Operator reviews and approves merges.
+- Merge is the approval gate.
 
 ---
 

--- a/docs/ops/ai/CORE-RULES.md
+++ b/docs/ops/ai/CORE-RULES.md
@@ -5,7 +5,7 @@ Authority Level: Core
 Owns: Shared execution rules, enforcement model, PR discipline, stop conditions
 Does Not Own: Design authority, platform configuration, tracker content
 Canonical Reference: /Agent.md
-Last Reviewed: 2026-05-02
+Last Reviewed: 2026-05-06
 ---
 
 # CORE-RULES.md
@@ -114,8 +114,28 @@ Defaults:
 
 # CAPABILITIES
 
-- ChatGPT owns PR creation  
-- PR creation is NOT delegated unless explicitly instructed  
+- ChatGPT owns Issue and PR creation under standing operator permission.
+- ChatGPT may create, comment on, label, update, and organize Issues and Pull Requests when task scope is clear.
+- PR creation is NOT delegated unless explicitly instructed.
+- Merge authority remains human/operator only.
+
+---
+
+# AGENT ROUTING PRIORITY
+
+Website implementation tasks:
+
+1. Cursor = primary implementation agent.
+2. Codex = secondary implementation agent when Cursor is unavailable, usage-limited, or unsuitable for the specific task.
+3. All other agents = tertiary/support agents only by explicit routing need.
+
+Repository implementation tasks:
+
+1. Codex = primary implementation agent.
+2. Cursor = secondary implementation agent when Codex is unavailable, usage-limited, or unsuitable for the specific task.
+3. All other agents = tertiary/support agents only by explicit routing need.
+
+Routing priority controls assignment preference only. It does not override design authority, scope limits, PR discipline, or merge approval.
 
 ---
 


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/949

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: AI governance / orchestration model
- Task: Clarify ChatGPT standing Issue/PR authority and agent routing priority
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: None

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `/docs/ops/ai/CORE-RULES.md`
- `/docs/ops/ai/CHATGPT-RULES.md`
- `.github/orchestrator-routing.json`

## DIATAXIS GAP (REQUIRED IF LEGACY_FALLBACK)
- [ ] Gap Identified
- Link to issue:
- Description:

## LABEL
- Intent label for this PR: infra

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical AI governance reference: `/docs/ops/ai/CORE-RULES.md`
- Additional rules/reference docs used for this PR:
  - `/docs/ops/ai/CHATGPT-RULES.md`
  - `.github/orchestrator-routing.json`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `.github/orchestrator-routing.json`
- `docs/ops/ai/CHATGPT-RULES.md`
- `docs/ops/ai/CORE-RULES.md`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## CHANGE SUMMARY
- Clarifies ChatGPT standing permission to create GitHub Issues and Pull Requests without additional confirmation when scope is clear.
- Preserves human/operator approval as the merge gate.
- Defines agent routing priority:
  - Website implementation: Cursor primary, Codex secondary, all other agents tertiary.
  - Repository implementation: Codex primary, Cursor secondary, all other agents tertiary.
- Updates `.github/orchestrator-routing.json` to permit secondary/tertiary routing while preserving default primary routing.

## BUILD / TEST / VERIFICATION
- Documentation/config-only change.
- GitHub checks are required to validate PR template compliance, drift control, docs guardrails, quality, secret scan, and Cloudflare preview.
- Cloudflare preview reported deploy success.
- No application runtime code changed.

## DOCUMENTATION UPDATES
- [x] Documentation updated in this PR
- [ ] No documentation updates required
- Files:
  - `docs/ops/ai/CHATGPT-RULES.md`
  - `docs/ops/ai/CORE-RULES.md`

## ACCEPTANCE CRITERIA
- ChatGPT no longer waits for confirmation before clear-scope Issue/PR creation.
- Merge remains human-approved only.
- Website and repository implementation routing priority is documented.
- Orchestrator routing config supports the documented fallback agent model.
- Design compliance warnings are resolved before merge.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] No website implementation files changed
- [x] No production secrets or credentials touched
- [x] No merge attempted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies standing permission for ChatGPT to open and organize Issues/PRs without extra confirmation when scope is clear, while keeping merge human-only. Documents and supports agent routing priority (website: `cursor` → `codex`; repository: `codex` → `cursor`) with config updates for fallback routing.

- **Policy**
  - Grants standing permission for Issue/PR creation and maintenance; merge requires human approval.
  - Documents routing priority and control/implementation split in `docs/ops/ai/CHATGPT-RULES.md` and `docs/ops/ai/CORE-RULES.md`.

- **Routing Config**
  - Bumps orchestrator `version` to `2`.
  - Expands `allowedAgents` and adds `priorityOrder` for `repository`, `website`, `governance`, `docs`, `recovery`.
  - Keeps defaults: `repository` → default `codex`; `website` → default `cursor`; adds `codex` to website `prIntents`.

<sup>Written for commit 93c84990b0a8b5beadd033803b4269f79fbbef90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->