### PR TITLE
Ops: preserve task-first PR issue association

### DIFF
--- a/.github/workflows/ops-pr-issue-accounting.yml
+++ b/.github/workflows/ops-pr-issue-accounting.yml
@@ -31,8 +31,16 @@ jobs:
 
             const desiredTitle = `[Work][PR #${prNumber}] ${prTitle}`.trim();
 
-            function extractIssueUrl(body) {
-              const m = body.match(/\*\*Issue:\*\*\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
+            function hasOrchestratorSourceIssue(body) {
+              return /<!--\s*orchestrator-source-issue:\s*\d+\s*-->/i.test(body || '');
+            }
+
+            function extractTrackerIssueUrl(body) {
+              const m = body.match(/\*\*OPS Tracker:\*\*\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
+                     || body.match(/-\s*\*\*OPS Tracker:\*\*\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
+                     || body.match(/OPS Tracker:\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
+                     // Backward compatibility for older accounting PR bodies only.
+                     || body.match(/\*\*Issue:\*\*\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
                      || body.match(/-\s*\*\*Issue:\*\*\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
                      || body.match(/Issue:\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i);
               return m ? m[1] : null;
@@ -52,9 +60,14 @@ jobs:
               }
             }
 
+            if (hasOrchestratorSourceIssue(prBody)) {
+              console.log(`PR #${prNumber} is task-first and already has an orchestrator source issue. Skipping OPS tracker injection.`);
+              return;
+            }
+
             async function ensureIssue() {
-              // 1) If PR body already references an Issue, use it.
-              const existingUrl = extractIssueUrl(prBody);
+              // 1) If PR body already references an OPS tracker Issue, use it.
+              const existingUrl = extractTrackerIssueUrl(prBody);
               if (existingUrl) {
                 const issueNumber = parseInt(existingUrl.split('/').pop(), 10);
                 try {
@@ -71,7 +84,7 @@ jobs:
                 return { issueNumber: found.number, issueUrl: found.html_url, issueTitle: found.title || '' };
               }
 
-              // 3) Create new tracker Issue.
+              // 3) Create new tracker Issue for PR-first work.
               const body = [
                 `Tracker Issue for PR #${prNumber}.`,
                 ``,
@@ -79,7 +92,7 @@ jobs:
                 `- **Status:** open`,
                 `- **Tier:** B (OPS / Overwatch) — support-only`,
                 ``,
-                `This Issue exists to keep the **Issues queue** as the unified work view.`,
+                `This Issue exists to keep the **Issues queue** as the unified work view when a PR is opened before a task Issue exists.`,
               ].join('\n');
 
               const created = await github.rest.issues.create({
@@ -110,10 +123,10 @@ jobs:
               }
             }
 
-            // Ensure PR body includes Issue link (idempotent).
-            const issueLine = `- **Issue:** ${issue.issueUrl}`;
+            // Ensure PR body includes OPS tracker link (idempotent), without becoming the primary implementation Issue.
+            const issueLine = `- **OPS Tracker:** ${issue.issueUrl}`;
             let newBody = prBody || '';
-            if (!extractIssueUrl(newBody)) {
+            if (!extractTrackerIssueUrl(newBody)) {
               newBody = [issueLine, '', newBody].join('\n').trim();
               await github.rest.pulls.update({
                 owner,
@@ -155,8 +168,16 @@ jobs:
             const prBody = pr.data.body || '';
             const desiredTitle = `[Work][PR #${prNumber}] ${prTitle}`.trim();
 
-            function extractIssueUrl(body) {
-              const m = body.match(/\*\*Issue:\*\*\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
+            function hasOrchestratorSourceIssue(body) {
+              return /<!--\s*orchestrator-source-issue:\s*\d+\s*-->/i.test(body || '');
+            }
+
+            function extractTrackerIssueUrl(body) {
+              const m = body.match(/\*\*OPS Tracker:\*\*\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
+                     || body.match(/-\s*\*\*OPS Tracker:\*\*\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
+                     || body.match(/OPS Tracker:\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
+                     // Backward compatibility for older accounting PR bodies only.
+                     || body.match(/\*\*Issue:\*\*\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
                      || body.match(/-\s*\*\*Issue:\*\*\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i)
                      || body.match(/Issue:\s*(https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i);
               return m ? m[1] : null;
@@ -168,10 +189,15 @@ jobs:
               return (res.data.items || []).find(i => !i.pull_request) || null;
             }
 
+            if (hasOrchestratorSourceIssue(prBody)) {
+              console.log(`PR #${prNumber} is task-first and has an orchestrator source issue. No OPS tracker closure needed.`);
+              return;
+            }
+
             let issueNumber = null;
             let issueUrl = null;
 
-            const url = extractIssueUrl(prBody);
+            const url = extractTrackerIssueUrl(prBody);
             if (url) {
               issueNumber = parseInt(url.split('/').pop(), 10);
               issueUrl = url;
@@ -185,7 +211,7 @@ jobs:
 
             if (!issueNumber) {
               // Nothing to close; log only.
-              console.log(`No tracker Issue found for PR #${prNumber}`);
+              console.log(`No OPS tracker Issue found for PR #${prNumber}`);
               return;
             }
 
@@ -195,8 +221,8 @@ jobs:
             } catch (e) {}
 
             const msg = merged
-              ? `PR #${prNumber} merged. Closing tracker Issue.\n\n- PR: ${pr.data.html_url}`
-              : `PR #${prNumber} closed without merge. Closing tracker Issue.\n\n- PR: ${pr.data.html_url}`;
+              ? `PR #${prNumber} merged. Closing OPS tracker Issue.\n\n- PR: ${pr.data.html_url}`
+              : `PR #${prNumber} closed without merge. Closing OPS tracker Issue.\n\n- PR: ${pr.data.html_url}`;
 
             try {
               await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body: msg });

--- a/scripts/orchestrator/create-draft-pr.mjs
+++ b/scripts/orchestrator/create-draft-pr.mjs
@@ -131,6 +131,7 @@ runGit(['commit', '--allow-empty', '-m', `orchestrator: draft PR for issue #${is
 runGit(['push', '-u', 'origin', branchName]);
 
 const prBody = [
+  `<!-- orchestrator-source-issue: ${issue.number} -->`,
   `- **Issue:** #${issue.number}`,
   '',
   '## Orchestrator Draft PR',

--- a/scripts/orchestrator/sync-pr-state.mjs
+++ b/scripts/orchestrator/sync-pr-state.mjs
@@ -28,6 +28,9 @@ function issueLabelNames(issueNumber) {
 }
 
 function linkedIssueNumber(body) {
+  const sourceMarker = body.match(/<!--\s*orchestrator-source-issue:\s*(\d+)\s*-->/i);
+  if (sourceMarker) return sourceMarker[1];
+
   const match = body.match(/(?:\*\*Issue:\*\*|Issue:)\s*(?:https?:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/|#)(\d+)/i);
   return match ? match[1] : '';
 }


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/952

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Repository operations / orchestration
- Task: Preserve source task Issue association for task-first orchestrator PRs
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: None

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `.github/workflows/ops-pr-issue-accounting.yml`
- `scripts/orchestrator/create-draft-pr.mjs`
- `scripts/orchestrator/sync-pr-state.mjs`
- `docs/ops/ai/CORE-RULES.md`

## DIATAXIS GAP (REQUIRED IF LEGACY_FALLBACK)
- [ ] Gap Identified
- Link to issue:
- Description:

## LABEL
- Intent label for this PR: infra

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical AI governance reference: `/docs/ops/ai/CORE-RULES.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `.github/workflows/ops-pr-issue-accounting.yml`
- `scripts/orchestrator/create-draft-pr.mjs`
- `scripts/orchestrator/sync-pr-state.mjs`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## CHANGE SUMMARY
- Adds an explicit `orchestrator-source-issue` marker to orchestrator-created draft PRs.
- Updates post-merge PR state sync to prefer that source-task marker before falling back to generic Issue links.
- Updates OPS PR Issue Accounting so task-first PRs do not receive an OPS tracker Issue link that can hijack task association.
- Keeps OPS tracker Issues available for PR-first work where no source task Issue exists.

## BUILD / TEST / VERIFICATION
- Static workflow/script update.
- Expected validation: GitHub Actions syntax/check gates.
- No application runtime code changed.

## DOCUMENTATION UPDATES
- [ ] Documentation updated in this PR
- [x] No documentation updates required — this PR changes executable orchestration/accounting behavior only; the changed workflow and scripts are the authoritative implementation surface for this bug fix, and existing AI governance docs already define Issue/PR ownership and routing policy.
- Files:
  - N/A

## ACCEPTANCE CRITERIA
- Task-first orchestrator PRs remain associated with their originating task Issue.
- PR-first work may still receive an OPS tracker Issue.
- OPS tracker links use `OPS Tracker`, not primary `Issue`, where injected.
- Post-merge sync closes/completes the source task Issue for orchestrator PRs.
- Existing PR/accounting behavior remains backward-compatible for older PR bodies.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] No website implementation files changed
- [x] No production secrets or credentials touched
- [x] No merge attempted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the original task Issue link for orchestrator-created, task-first PRs. Prevents OPS tracker Issues from replacing the primary Issue, while still supporting trackers for PR‑first work.

- **Bug Fixes**
  - Add a hidden `<!-- orchestrator-source-issue: N -->` marker to draft PRs to lock the source task.
  - Prefer the source marker in `scripts/orchestrator/sync-pr-state.mjs` when syncing and closing the task.
  - Update `.github/workflows/ops-pr-issue-accounting.yml` to:
    - Inject and label links as “OPS Tracker,” not “Issue”.
    - Skip tracker injection when the source marker is present.
    - Close tracker Issues only for PR‑first flows.

<sup>Written for commit 9caf7c9158c04eaece1962fb1a61b04f5d5d8405. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->