### PR TITLE
Ops: validate OPS tracker issue URLs before use

### DIFF
--- a/.github/workflows/ops-pr-issue-accounting.yml
+++ b/.github/workflows/ops-pr-issue-accounting.yml
@@ -46,10 +46,55 @@ jobs:
               return m ? m[1] : null;
             }
 
+            function issueUrlBelongsToCurrentRepo(issueUrl) {
+              try {
+                const url = new URL(issueUrl);
+                const parts = url.pathname.split('/').filter(Boolean);
+                return url.hostname.toLowerCase() === 'github.com'
+                  && parts.length === 4
+                  && parts[0].toLowerCase() === owner.toLowerCase()
+                  && parts[1].toLowerCase() === repo.toLowerCase()
+                  && parts[2] === 'issues'
+                  && /^\d+$/.test(parts[3]);
+              } catch (e) {
+                return false;
+              }
+            }
+
+            function issueMatchesPrTracker(issue) {
+              const body = issue.body || '';
+              const title = issue.title || '';
+              const labels = (issue.labels || []).map(label => label.name || label);
+              return title.includes(`[Work][PR #${prNumber}]`)
+                && body.includes(`Tracker Issue for PR #${prNumber}.`)
+                && body.includes(pr.data.html_url)
+                && labels.includes('work-accounting');
+            }
+
+            async function validTrackerFromUrl(issueUrl) {
+              if (!issueUrl || !issueUrlBelongsToCurrentRepo(issueUrl)) return null;
+              const issueNumber = parseInt(issueUrl.split('/').pop(), 10);
+              try {
+                const issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+                if (!issueMatchesPrTracker(issue.data)) return null;
+                return { issueNumber, issueUrl, issueTitle: issue.data.title || '' };
+              } catch (e) {
+                return null;
+              }
+            }
+
             async function findIssueByTitle() {
               const q = `repo:${owner}/${repo} is:issue in:title "[Work][PR #${prNumber}]"`;
               const res = await github.rest.search.issuesAndPullRequests({ q, per_page: 5 });
               return (res.data.items || []).find(i => !i.pull_request) || null;
+            }
+
+            async function findValidatedIssueByTitle() {
+              const found = await findIssueByTitle();
+              if (!found) return null;
+              const issue = await github.rest.issues.get({ owner, repo, issue_number: found.number });
+              if (!issueMatchesPrTracker(issue.data)) return null;
+              return { issueNumber: issue.data.number, issueUrl: issue.data.html_url, issueTitle: issue.data.title || '' };
             }
 
             async function tryAddLabels(issueNumber, labels) {
@@ -66,23 +111,14 @@ jobs:
             }
 
             async function ensureIssue() {
-              // 1) If PR body already references an OPS tracker Issue, use it.
+              // 1) If PR body already references a valid OPS tracker Issue for this PR, use it.
               const existingUrl = extractTrackerIssueUrl(prBody);
-              if (existingUrl) {
-                const issueNumber = parseInt(existingUrl.split('/').pop(), 10);
-                try {
-                  const issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
-                  return { issueNumber, issueUrl: existingUrl, issueTitle: issue.data.title || '' };
-                } catch (e) {
-                  // reference is stale; continue
-                }
-              }
+              const validExisting = await validTrackerFromUrl(existingUrl);
+              if (validExisting) return validExisting;
 
-              // 2) Search by deterministic title pattern.
-              const found = await findIssueByTitle();
-              if (found) {
-                return { issueNumber: found.number, issueUrl: found.html_url, issueTitle: found.title || '' };
-              }
+              // 2) Search by deterministic title pattern and validate tracker identity.
+              const validFound = await findValidatedIssueByTitle();
+              if (validFound) return validFound;
 
               // 3) Create new tracker Issue for PR-first work.
               const body = [
@@ -183,10 +219,55 @@ jobs:
               return m ? m[1] : null;
             }
 
+            function issueUrlBelongsToCurrentRepo(issueUrl) {
+              try {
+                const url = new URL(issueUrl);
+                const parts = url.pathname.split('/').filter(Boolean);
+                return url.hostname.toLowerCase() === 'github.com'
+                  && parts.length === 4
+                  && parts[0].toLowerCase() === owner.toLowerCase()
+                  && parts[1].toLowerCase() === repo.toLowerCase()
+                  && parts[2] === 'issues'
+                  && /^\d+$/.test(parts[3]);
+              } catch (e) {
+                return false;
+              }
+            }
+
+            function issueMatchesPrTracker(issue) {
+              const body = issue.body || '';
+              const title = issue.title || '';
+              const labels = (issue.labels || []).map(label => label.name || label);
+              return title.includes(`[Work][PR #${prNumber}]`)
+                && body.includes(`Tracker Issue for PR #${prNumber}.`)
+                && body.includes(pr.data.html_url)
+                && labels.includes('work-accounting');
+            }
+
+            async function validTrackerFromUrl(issueUrl) {
+              if (!issueUrl || !issueUrlBelongsToCurrentRepo(issueUrl)) return null;
+              const issueNumber = parseInt(issueUrl.split('/').pop(), 10);
+              try {
+                const issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+                if (!issueMatchesPrTracker(issue.data)) return null;
+                return { issueNumber, issueUrl, issueTitle: issue.data.title || '' };
+              } catch (e) {
+                return null;
+              }
+            }
+
             async function findIssueByTitle() {
               const q = `repo:${owner}/${repo} is:issue in:title "[Work][PR #${prNumber}]"`;
               const res = await github.rest.search.issuesAndPullRequests({ q, per_page: 5 });
               return (res.data.items || []).find(i => !i.pull_request) || null;
+            }
+
+            async function findValidatedIssueByTitle() {
+              const found = await findIssueByTitle();
+              if (!found) return null;
+              const issue = await github.rest.issues.get({ owner, repo, issue_number: found.number });
+              if (!issueMatchesPrTracker(issue.data)) return null;
+              return { issueNumber: issue.data.number, issueUrl: issue.data.html_url, issueTitle: issue.data.title || '' };
             }
 
             if (hasOrchestratorSourceIssue(prBody)) {
@@ -194,30 +275,18 @@ jobs:
               return;
             }
 
-            let issueNumber = null;
-            let issueUrl = null;
+            let tracker = await validTrackerFromUrl(extractTrackerIssueUrl(prBody));
+            if (!tracker) tracker = await findValidatedIssueByTitle();
 
-            const url = extractTrackerIssueUrl(prBody);
-            if (url) {
-              issueNumber = parseInt(url.split('/').pop(), 10);
-              issueUrl = url;
-            } else {
-              const found = await findIssueByTitle();
-              if (found) {
-                issueNumber = found.number;
-                issueUrl = found.html_url;
-              }
-            }
-
-            if (!issueNumber) {
+            if (!tracker) {
               // Nothing to close; log only.
-              console.log(`No OPS tracker Issue found for PR #${prNumber}`);
+              console.log(`No valid OPS tracker Issue found for PR #${prNumber}`);
               return;
             }
 
             // Keep title aligned (best-effort)
             try {
-              await github.rest.issues.update({ owner, repo, issue_number: issueNumber, title: desiredTitle });
+              await github.rest.issues.update({ owner, repo, issue_number: tracker.issueNumber, title: desiredTitle });
             } catch (e) {}
 
             const msg = merged
@@ -225,11 +294,11 @@ jobs:
               : `PR #${prNumber} closed without merge. Closing OPS tracker Issue.\n\n- PR: ${pr.data.html_url}`;
 
             try {
-              await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body: msg });
+              await github.rest.issues.createComment({ owner, repo, issue_number: tracker.issueNumber, body: msg });
             } catch (e) {}
 
             try {
-              await github.rest.issues.update({ owner, repo, issue_number: issueNumber, state: 'closed' });
+              await github.rest.issues.update({ owner, repo, issue_number: tracker.issueNumber, state: 'closed' });
             } catch (e) {}
 
             // Optional: comment on PR to confirm closure (best-effort)
@@ -238,6 +307,6 @@ jobs:
                 owner,
                 repo,
                 issue_number: prNumber,
-                body: `OPS: Tracker Issue closed: ${issueUrl || `(issue #${issueNumber})`}`,
+                body: `OPS: Tracker Issue closed: ${tracker.issueUrl || `(issue #${tracker.issueNumber})`}`,
               });
             } catch (e) {}


### PR DESCRIPTION
- **OPS Tracker:** https://github.com/wdhunter645/next-starter-template/issues/954

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Repository operations / orchestration hardening
- Task: Validate OPS tracker Issue URLs before using PR-body links
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: None

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `.github/workflows/ops-pr-issue-accounting.yml`
- `docs/ops/ai/CORE-RULES.md`

## DIATAXIS GAP (REQUIRED IF LEGACY_FALLBACK)
- [ ] Gap Identified
- Link to issue:
- Description:

## LABEL
- Intent label for this PR: infra

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical AI governance reference: `/docs/ops/ai/CORE-RULES.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `.github/workflows/ops-pr-issue-accounting.yml`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## CHANGE SUMMARY
- Addresses the P1 issue identified by cubic on PR #951.
- Validates that OPS tracker Issue URLs belong to the current repository before use.
- Validates that referenced tracker Issues match the current PR by title, body, PR URL, and `work-accounting` label.
- Applies the same validation before updating, retitling, commenting on, or closing tracker Issues.

## BUILD / TEST / VERIFICATION
- Static workflow update.
- Expected validation: GitHub Actions syntax/check gates.
- No application runtime code changed.

## DOCUMENTATION UPDATES
- [ ] Documentation updated in this PR
- [x] No documentation updates required — this is a narrow security hardening fix to existing OPS workflow behavior, and the workflow itself is the authoritative implementation surface.
- Files:
  - N/A

## ACCEPTANCE CRITERIA
- PR-body tracker URLs from other repositories are ignored.
- PR-body tracker URLs for unrelated local Issues are ignored.
- Existing valid tracker Issues for the same PR are reused.
- Invalid or missing tracker references fall back to deterministic search/create behavior.
- Tracker closure only affects validated tracker Issues for the closing PR.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] No website implementation files changed
- [x] No production secrets or credentials touched
- [x] No merge attempted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the OPS tracker workflow to validate issue URLs so only the correct in-repo tracker for the current PR is used and closed. This prevents cross-repo or unrelated issue references and keeps work accounting consistent.

- **Bug Fixes**
  - Validate PR-body tracker URLs belong to this repo and match the PR by title, body, PR link, and `work-accounting` label.
  - Enforce the same checks before retitling, commenting on, or closing a tracker.
  - If no valid URL is present, search by validated title; otherwise create a new tracker. Reuse existing valid trackers.
  - On close, do nothing if no valid tracker is found. Changes are limited to `.github/workflows/ops-pr-issue-accounting.yml`.

<sup>Written for commit 8a8c321135a19b617005655a2383e0429407c8be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

