### PR TITLE
Tighten post-merge detection workflow and add PR validation

### DIFF
--- a/.github/workflows/post-merge-intent-verification.yml
+++ b/.github/workflows/post-merge-intent-verification.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   detect:
-    if: >-
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
     runs-on: ubuntu-latest
 
     steps:
@@ -38,18 +34,29 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_PR_MERGED: ${{ github.event.pull_request.merged }}
+          EVENT_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           PR=""
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
-            PR="$EVENT_PR_NUMBER"
+            if [ "$EVENT_PR_MERGED" = "true" ] && [ "$EVENT_PR_BASE_REF" = "main" ]; then
+              PR="$EVENT_PR_NUMBER"
+            fi
           elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_PR_NUMBER" ]; then
             PR="$INPUT_PR_NUMBER"
           else
             PR=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
               -H 'Accept: application/vnd.github+json' \
-              --jq 'map(select(.state == "closed" and .merged_at != null))[0].number // ""')
+              --jq 'map(select(.state == "closed" and .merged_at != null and .base.ref == "main"))[0].number // ""')
           fi
-          echo "pr=$PR" >> $GITHUB_OUTPUT
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: Validate resolved PR
+        if: steps.pr.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view "${{ steps.pr.outputs.pr }}" --json number,state,isDraft,mergedAt,baseRefName --jq 'if (.state != "CLOSED" or .isDraft == true or .mergedAt == null or .baseRefName != "main") then error("Resolved PR is not a merged PR into main") else .number end' > /dev/null
 
       - name: Skip direct pushes without merged PR context
         if: steps.pr.outputs.pr == ''
@@ -79,7 +86,7 @@ jobs:
             [ -z "$f" ] && continue
             [ -e "$f" ] || failures=$((failures+1))
           done < files.txt
-          echo "failures=$failures" >> $GITHUB_OUTPUT
+          echo "failures=$failures" >> "$GITHUB_OUTPUT"
 
       - name: Comment
         if: always() && steps.pr.outputs.pr != ''

--- a/.github/workflows/post-merge-intent-verification.yml
+++ b/.github/workflows/post-merge-intent-verification.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr view "${{ steps.pr.outputs.pr }}" --json number,state,isDraft,mergedAt,baseRefName --jq 'if (.state != "CLOSED" or .isDraft == true or .mergedAt == null or .baseRefName != "main") then error("Resolved PR is not a merged PR into main") else .number end' > /dev/null
+          gh pr view "${{ steps.pr.outputs.pr }}" --json number,isDraft,mergedAt,baseRefName --jq 'if (.isDraft == true or .mergedAt == null or .baseRefName != "main") then error("Resolved PR is not a merged PR into main") else .number end' > /dev/null
 
       - name: Skip direct pushes without merged PR context
         if: steps.pr.outputs.pr == ''


### PR DESCRIPTION
- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/967
- **Supersedes draft PR:** https://github.com/wdhunter645/next-starter-template/pull/968

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Repository operations / post-merge validation
- Task: Repair post-merge detection trigger/reporting after PR #955 did not visibly report on PRs
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: Reviewer dispositions and gate checks still pending

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `.github/workflows/post-merge-intent-verification.yml`
- `docs/ops/ai/CORE-RULES.md`
- Issue #967

## DIATAXIS GAP (REQUIRED IF LEGACY_FALLBACK)
- [ ] Gap Identified
- Link to issue:
- Description:

## LABEL
- Intent label for this PR: infra

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical AI governance reference: `/docs/ops/ai/CORE-RULES.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `.github/workflows/post-merge-intent-verification.yml`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## CHANGE SUMMARY
- Tightens post-merge detection so it only resolves bona fide merged PRs into `main`.
- Moves merged-PR filtering into the Resolve PR step.
- Validates the resolved PR is closed, merged, not draft, and targets `main` before continuing.
- Tightens commit-to-PR lookup to require `.base.ref == "main"`.
- Fixes `$GITHUB_OUTPUT` quoting in shell snippets.

## BUILD / TEST / VERIFICATION
- Codex reports `yamllint` passed for the modified workflow.
- Codex reports `shellcheck` passed for embedded shell snippets.
- Codex reports simulated `act` runs passed for merged `pull_request_target` and `workflow_dispatch` with `pr_number`.
- Repository gate checks still pending in GitHub.

## DOCUMENTATION UPDATES
- [ ] Documentation updated in this PR
- [x] No documentation updates required — this is a narrow workflow reliability repair; Issue #967 and the workflow file are the implementation record.
- Files:
  - N/A

## ACCEPTANCE CRITERIA
- A merged PR into `main` reliably resolves to a PR number.
- Direct pushes or incomplete PR context do not create false-positive PR validation.
- Resolved PRs are verified as closed, merged, non-draft, and targeting `main` before post-merge logic proceeds.
- Post-merge detection continues to comment/sync only after a valid merged PR is resolved.
- PR #968 can be closed as superseded without closing Issue #967.

## REVIEWER RESPONSE ACCOUNTING
- [x] Gemini disposition received: unable to review workflow file type.
- [ ] Copilot disposition received: pending requested review.
- [ ] Cubic disposition received: pending.
- [x] Reviewed reviewer comments present before this PR body update.
- [x] No actionable inline reviewer comments existed at this update time.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] No website implementation files changed
- [x] No production secrets or credentials touched
- [x] No merge attempted

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe818f33483299a005e43f69484d7)