### PR TITLE
Ops: add post-merge audit logging

### DIFF
--- a/.github/workflows/post-merge-intent-verification.yml
+++ b/.github/workflows/post-merge-intent-verification.yml
@@ -27,6 +27,27 @@ jobs:
         with:
           ref: main
 
+      - name: Log trigger context
+        run: |
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          {
+            echo "## Post-merge validation audit"
+            echo ""
+            echo "- Event: ${GITHUB_EVENT_NAME}"
+            echo "- Ref: ${GITHUB_REF}"
+            echo "- SHA: ${GITHUB_SHA}"
+            echo "- Actor: ${GITHUB_ACTOR}"
+            echo "- Run ID: ${GITHUB_RUN_ID}"
+            echo "- Run URL: ${run_url}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Post-merge validation trigger context"
+          echo "event=${GITHUB_EVENT_NAME}"
+          echo "ref=${GITHUB_REF}"
+          echo "sha=${GITHUB_SHA}"
+          echo "actor=${GITHUB_ACTOR}"
+          echo "run_id=${GITHUB_RUN_ID}"
+          echo "run_url=${run_url}"
+
       - name: Resolve PR
         id: pr
         env:
@@ -38,18 +59,46 @@ jobs:
           EVENT_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           PR=""
+          METHOD="none"
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            METHOD="pull_request_target"
             if [ "$EVENT_PR_MERGED" = "true" ] && [ "$EVENT_PR_BASE_REF" = "main" ]; then
               PR="$EVENT_PR_NUMBER"
             fi
           elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_PR_NUMBER" ]; then
+            METHOD="workflow_dispatch"
             PR="$INPUT_PR_NUMBER"
           else
+            METHOD="commit-pulls-api"
             PR=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
               -H 'Accept: application/vnd.github+json' \
               --jq 'map(select(.state == "closed" and .merged_at != null and .base.ref == "main"))[0].number // ""')
           fi
           echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          echo "method=$METHOD" >> "$GITHUB_OUTPUT"
+          {
+            echo ""
+            echo "### PR resolution"
+            echo "- Method: ${METHOD}"
+            echo "- Resolved PR: ${PR:-none}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "post_merge_resolution_method=${METHOD}"
+          echo "post_merge_resolved_pr=${PR:-none}"
+
+      - name: Comment validation started
+        if: steps.pr.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          gh pr comment "${{ steps.pr.outputs.pr }}" --body "Post-merge validation started.
+
+- Event: ${GITHUB_EVENT_NAME}
+- Commit: ${GITHUB_SHA}
+- Resolution method: ${{ steps.pr.outputs.method }}
+- Run ID: ${GITHUB_RUN_ID}
+- Run URL: ${run_url}" || \
+            echo "::warning::Unable to post validation-started comment."
 
       - name: Validate resolved PR
         if: steps.pr.outputs.pr != ''
@@ -57,10 +106,27 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr view "${{ steps.pr.outputs.pr }}" --json number,isDraft,mergedAt,baseRefName --jq 'if (.isDraft == true or .mergedAt == null or .baseRefName != "main") then error("Resolved PR is not a merged PR into main") else .number end' > /dev/null
+          pr_json=$(gh pr view "${{ steps.pr.outputs.pr }}" --json number,isDraft,mergedAt,baseRefName)
+          base_ref=$(echo "$pr_json" | jq -r '.baseRefName')
+          merged_at=$(echo "$pr_json" | jq -r '.mergedAt')
+          is_draft=$(echo "$pr_json" | jq -r '.isDraft')
+          {
+            echo ""
+            echo "### Resolved PR validation"
+            echo "- Base branch: ${base_ref}"
+            echo "- Merged at: ${merged_at}"
+            echo "- Draft: ${is_draft}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Skip direct pushes without merged PR context
         if: steps.pr.outputs.pr == ''
         run: |
+          {
+            echo ""
+            echo "### Skip result"
+            echo "No merged pull request found for commit ${GITHUB_SHA}."
+            echo "Post-merge PR checks skipped for this run."
+          } >> "$GITHUB_STEP_SUMMARY"
           echo "No merged pull request found for ${GITHUB_SHA}; skipping post-merge PR checks."
 
       - name: Collect
@@ -72,21 +138,47 @@ jobs:
           jq -r '.body // ""' pr.json > body.md
           jq -r '.files[].path' pr.json > files.txt
           jq -r '.mergeCommit.oid // ""' pr.json > merge_commit.txt
+          changed_file_count=$(wc -l < files.txt | tr -d ' ')
+          merge_commit="$(cat merge_commit.txt 2>/dev/null || true)"
+          {
+            echo ""
+            echo "### Collection"
+            echo "- Changed files: ${changed_file_count}"
+            echo "- Merge commit: ${merge_commit:-none}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Evaluate
         if: steps.pr.outputs.pr != ''
         id: verify
         run: |
           failures=0
-          grep -Eqi '\b(TODO|TBD|placeholder)\b' body.md && failures=$((failures+1))
+          missing_sections=""
+          if grep -Eqi '\b(TODO|TBD|placeholder)\b' body.md; then
+            failures=$((failures+1))
+            missing_sections="${missing_sections} forbidden-placeholder-token"
+          fi
           for req in '## CHANGE SUMMARY' '## BUILD / TEST / VERIFICATION' '## ACCEPTANCE CRITERIA' '## REQUIRED PRE-REVIEW SELF-CHECK'; do
-            grep -Fq "$req" body.md || failures=$((failures+1))
+            if ! grep -Fq "$req" body.md; then
+              failures=$((failures+1))
+              missing_sections="${missing_sections} ${req}"
+            fi
           done
+          missing_files=0
           while IFS= read -r f; do
             [ -z "$f" ] && continue
-            [ -e "$f" ] || failures=$((failures+1))
+            [ -e "$f" ] || missing_files=$((missing_files+1))
           done < files.txt
+          failures=$((failures+missing_files))
           echo "failures=$failures" >> "$GITHUB_OUTPUT"
+          echo "missing_files=$missing_files" >> "$GITHUB_OUTPUT"
+          echo "missing_sections=${missing_sections}" >> "$GITHUB_OUTPUT"
+          {
+            echo ""
+            echo "### Evaluation"
+            echo "- Failure count: ${failures}"
+            echo "- Missing/degraded sections: ${missing_sections:-none}"
+            echo "- Missing changed files: ${missing_files}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment
         if: always() && steps.pr.outputs.pr != ''
@@ -95,10 +187,24 @@ jobs:
         run: |
           failures="${{ steps.verify.outputs.failures }}"
           [ -n "$failures" ] || failures="unknown"
+          missing_files="${{ steps.verify.outputs.missing_files }}"
+          [ -n "$missing_files" ] || missing_files="unknown"
+          missing_sections="${{ steps.verify.outputs.missing_sections }}"
+          [ -n "$missing_sections" ] || missing_sections="none"
           merge_commit="$(cat merge_commit.txt 2>/dev/null || true)"
-          body="Post-merge detection result: failures=${failures}"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          body="Post-merge validation result: failures=${failures}
+
+- Event: ${GITHUB_EVENT_NAME}
+- Commit: ${GITHUB_SHA}
+- Resolution method: ${{ steps.pr.outputs.method }}
+- Run ID: ${GITHUB_RUN_ID}
+- Run URL: ${run_url}
+- Missing files: ${missing_files}
+- Missing/degraded sections: ${missing_sections}"
           if [ -n "$merge_commit" ]; then
-            body="${body}\n\nMerge commit: ${merge_commit}"
+            body="${body}
+- Merge commit: ${merge_commit}"
           fi
           gh pr comment "${{ steps.pr.outputs.pr }}" --body "$body" || \
             echo "::warning::Unable to post detection comment; continuing because the verification result is enforced separately."

--- a/.github/workflows/post-merge-intent-verification.yml
+++ b/.github/workflows/post-merge-intent-verification.yml
@@ -60,10 +60,13 @@ jobs:
         run: |
           PR=""
           METHOD="none"
+          SKIP_REASON="none"
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
             METHOD="pull_request_target"
             if [ "$EVENT_PR_MERGED" = "true" ] && [ "$EVENT_PR_BASE_REF" = "main" ]; then
               PR="$EVENT_PR_NUMBER"
+            else
+              SKIP_REASON="closed PR was not merged into main"
             fi
           elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_PR_NUMBER" ]; then
             METHOD="workflow_dispatch"
@@ -73,17 +76,23 @@ jobs:
             PR=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
               -H 'Accept: application/vnd.github+json' \
               --jq 'map(select(.state == "closed" and .merged_at != null and .base.ref == "main"))[0].number // ""')
+            if [ -z "$PR" ]; then
+              SKIP_REASON="no merged PR associated with commit"
+            fi
           fi
           echo "pr=$PR" >> "$GITHUB_OUTPUT"
           echo "method=$METHOD" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=$SKIP_REASON" >> "$GITHUB_OUTPUT"
           {
             echo ""
             echo "### PR resolution"
             echo "- Method: ${METHOD}"
             echo "- Resolved PR: ${PR:-none}"
+            echo "- Skip reason: ${SKIP_REASON}"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "post_merge_resolution_method=${METHOD}"
           echo "post_merge_resolved_pr=${PR:-none}"
+          echo "post_merge_skip_reason=${SKIP_REASON}"
 
       - name: Comment validation started
         if: steps.pr.outputs.pr != ''
@@ -105,11 +114,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr view "${{ steps.pr.outputs.pr }}" --json number,isDraft,mergedAt,baseRefName --jq 'if (.isDraft == true or .mergedAt == null or .baseRefName != "main") then error("Resolved PR is not a merged PR into main") else .number end' > /dev/null
           pr_json=$(gh pr view "${{ steps.pr.outputs.pr }}" --json number,isDraft,mergedAt,baseRefName)
           base_ref=$(echo "$pr_json" | jq -r '.baseRefName')
           merged_at=$(echo "$pr_json" | jq -r '.mergedAt')
           is_draft=$(echo "$pr_json" | jq -r '.isDraft')
+          echo "$pr_json" | jq -e 'if (.isDraft == true or .mergedAt == null or .baseRefName != "main") then error("Resolved PR is not a merged PR into main") else .number end' > /dev/null
           {
             echo ""
             echo "### Resolved PR validation"
@@ -118,16 +127,18 @@ jobs:
             echo "- Draft: ${is_draft}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Skip direct pushes without merged PR context
+      - name: Skip run without eligible merged PR
         if: steps.pr.outputs.pr == ''
         run: |
           {
             echo ""
             echo "### Skip result"
-            echo "No merged pull request found for commit ${GITHUB_SHA}."
             echo "Post-merge PR checks skipped for this run."
+            echo "- Method: ${{ steps.pr.outputs.method }}"
+            echo "- Reason: ${{ steps.pr.outputs.skip_reason }}"
+            echo "- Commit: ${GITHUB_SHA}"
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "No merged pull request found for ${GITHUB_SHA}; skipping post-merge PR checks."
+          echo "Post-merge checks skipped: ${{ steps.pr.outputs.skip_reason }}"
 
       - name: Collect
         if: steps.pr.outputs.pr != ''


### PR DESCRIPTION
- **OPS Tracker:** https://github.com/wdhunter645/next-starter-template/issues/990

- **Issue:** https://github.com/wdhunter645/next-starter-template/issues/987

- **Umbrella Tracker:** https://github.com/wdhunter645/next-starter-template/issues/991

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Repository operations / post-merge validation observability
- Task: Add verbose audit logging to post-merge validation workflow
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: Awaiting gate checks on current head `da2074d`

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `.github/workflows/post-merge-intent-verification.yml`
- Issue #987
- Umbrella tracker Issue #991

## LABEL
- Intent label for this PR: infra

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical AI governance reference: `/docs/ops/ai/CORE-RULES.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `.github/workflows/post-merge-intent-verification.yml`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## CHANGE SUMMARY
- Adds explicit trigger-context logging to the post-merge workflow.
- Writes PR resolution details to the GitHub Actions summary.
- Comments on resolved PRs when post-merge validation starts.
- Comments final pass/fail details with run ID, run URL, merge commit, failure count, and degraded/missing items.
- Writes explicit skip summaries when no eligible merged PR is resolved.
- Uses a single PR metadata fetch in resolved-PR validation.
- Emits precise skip reason for non-main/non-merged PR close events versus commit-with-no-PR events.

## BUILD / TEST / VERIFICATION
- Static GitHub Actions workflow update.
- Expected validation: repository gate checks and reviewer-response gate.
- No website/application runtime code changed.
- Cubic reported no issues.
- Copilot findings were accepted and fixed.
- Gemini left visible unsupported-file disposition.

## DOCUMENTATION UPDATES
- [ ] Documentation updated in this PR
- [x] No documentation updates required — Issue #987, umbrella tracker #991, and workflow comments/summaries are the implementation record.

## ACCEPTANCE CRITERIA
- Every post-merge workflow run writes a clear GitHub Actions summary.
- Resolved PR runs leave a PR comment when validation starts.
- Resolved PR runs leave a final PR comment with pass/fail result.
- Skipped push/non-eligible runs explain why no PR was resolved.
- Logs include run ID, run URL, event name, commit SHA, branch/ref, actor, resolved PR, and failure count.
- No website/application code changes.

## REVIEWER RESPONSE ACCOUNTING
- [x] Copilot disposition received: overview plus two actionable findings.
- [x] Cubic disposition received: no issues found.
- [x] Gemini disposition received: unable to generate review for this workflow file type.
- [x] Reviewed all reviewer comments present before this PR body update.
- [x] Accepted / rejected / ignored each actionable comment with rationale.
- review-comment:3202815547 — accepted — Copilot found duplicate `gh pr view` calls in resolved-PR validation; changed validation to fetch PR JSON once and validate/log from that payload.
- review-comment:3202815596 — accepted — Copilot found skip logging could be misleading for closed PR events; added explicit skip_reason output distinguishing non-main/non-merged PR closure from commit-with-no-PR resolution.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] No website implementation files changed
- [x] No production secrets or credentials touched
- [x] No merge attempted