### PR TITLE
CI: rerun Reviewer Gate after PR body edits (#1051)

### DIFF
--- a/.github/workflows/gate-reviewer-response.yml
+++ b/.github/workflows/gate-reviewer-response.yml
@@ -1,0 +1,221 @@
+name: GATE — Reviewer Response
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  reviewer-response:
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate reviewer response discipline
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            async function resolvePullRequest() {
+              if (context.payload.pull_request) return context.payload.pull_request;
+              if (context.payload.issue?.pull_request) {
+                const { data } = await github.rest.pulls.get({ owner, repo, pull_number: context.payload.issue.number });
+                return data;
+              }
+              if (context.payload.review?.pull_request_url) {
+                const pull_number = Number(context.payload.review.pull_request_url.split('/').pop());
+                const { data } = await github.rest.pulls.get({ owner, repo, pull_number });
+                return data;
+              }
+              if (context.payload.comment?.pull_request_url) {
+                const pull_number = Number(context.payload.comment.pull_request_url.split('/').pop());
+                const { data } = await github.rest.pulls.get({ owner, repo, pull_number });
+                return data;
+              }
+              throw new Error('Unable to resolve pull request context.');
+            }
+
+            const pr = await resolvePullRequest();
+            const prNumber = pr.number;
+            const prAuthor = pr.user?.login || '';
+            const prBody = pr.body || '';
+
+            const trustedReviewers = new Set([
+              'chatgpt-codex-connector[bot]',
+              'chatgpt-codex-connector',
+              'gemini-code-assist[bot]',
+              'gemini-code-assist',
+              'copilot-pull-request-reviewer[bot]',
+              'copilot-pull-request-reviewer',
+              'cubic-dev-ai[bot]',
+              'cubic-dev-ai',
+            ]);
+
+            const permissionCache = new Map();
+            const highSeverityPattern = /(^|[^A-Za-z0-9])(P0|P1)([^A-Za-z0-9]|$)|high[- ]priority|request changes|requested changes|must fix|blocking/i;
+            const resolvedPattern = /✅\s*Addressed|addressed in|\bresolved\b|all checks passed|no findings|no warnings detected/i;
+            const unresolvedPattern = /\bunresolved\b|\bnot\s+resolved\b|\bstill\s+open\b|\bstill\s+blocking\b/i;
+
+            function loginOf(author) {
+              return typeof author === 'string' ? author : (author?.login || '');
+            }
+
+            function isTrusted(login) {
+              return trustedReviewers.has(loginOf(login));
+            }
+
+            function isResolvedText(body) {
+              const text = body || '';
+              return resolvedPattern.test(text) && !unresolvedPattern.test(text);
+            }
+
+            function hasReviewerAccounting(login, id) {
+              const lowerBody = prBody.toLowerCase();
+              const reviewer = loginOf(login).toLowerCase();
+              if (id && lowerBody.includes(`review-comment:${id}`.toLowerCase())) return true;
+              if (id && lowerBody.includes(String(id))) return true;
+              if (!lowerBody.includes('## reviewer response accounting')) return false;
+              if (!lowerBody.includes('reviewed all reviewer comments')) return false;
+              if (reviewer.includes('copilot') && lowerBody.includes('copilot disposition received')) return true;
+              if (reviewer.includes('cubic') && lowerBody.includes('cubic disposition received')) return true;
+              if (reviewer.includes('gemini') && lowerBody.includes('gemini disposition received')) return true;
+              if (reviewer.includes('codex') && (lowerBody.includes('codex disposition received') || lowerBody.includes('reviewed all reviewer comments'))) return true;
+              return false;
+            }
+
+            async function isAuthorizedResponder(login) {
+              const value = loginOf(login);
+              if (!value || isTrusted(value) || value === 'github-actions[bot]' || value.endsWith('[bot]')) return false;
+              if (value === prAuthor) return true;
+              if (permissionCache.has(value)) return permissionCache.get(value);
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username: value });
+                const allowed = ['admin', 'maintain', 'write'].includes(data.permission);
+                permissionCache.set(value, allowed);
+                return allowed;
+              } catch (_error) {
+                permissionCache.set(value, false);
+                return false;
+              }
+            }
+
+            const issueComments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+
+            const reviewComments = await github.paginate(github.rest.pulls.listReviewComments, {
+              owner,
+              repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+
+            const trustedSignals = [];
+
+            for (const comment of issueComments) {
+              if (isTrusted(comment.user?.login)) trustedSignals.push(`issue-comment:${comment.id}`);
+            }
+            for (const review of reviews) {
+              if (isTrusted(review.user?.login)) trustedSignals.push(`review:${review.id}:${review.state}`);
+            }
+            for (const comment of reviewComments) {
+              if (isTrusted(comment.user?.login)) trustedSignals.push(`review-comment:${comment.id}`);
+            }
+
+            if (trustedSignals.length === 0) {
+              core.setFailed('Reviewer response gate failed: no trusted reviewer signal found.');
+              return;
+            }
+
+            async function laterAuthorizedIssueComment(createdAt) {
+              const created = new Date(createdAt).getTime();
+              for (const comment of issueComments) {
+                if (new Date(comment.created_at).getTime() <= created) continue;
+                if (await isAuthorizedResponder(comment.user?.login)) return true;
+              }
+              return false;
+            }
+
+            async function laterAuthorizedReviewComment(createdAt) {
+              const created = new Date(createdAt).getTime();
+              for (const comment of reviewComments) {
+                if (new Date(comment.created_at).getTime() <= created) continue;
+                if (await isAuthorizedResponder(comment.user?.login)) return true;
+              }
+              return false;
+            }
+
+            async function laterAcknowledgement(createdAt) {
+              return (await laterAuthorizedIssueComment(createdAt)) || (await laterAuthorizedReviewComment(createdAt));
+            }
+
+            const failures = [];
+
+            for (const comment of issueComments) {
+              const login = comment.user?.login || '';
+              const body = comment.body || '';
+              if (!isTrusted(login)) continue;
+              if (!highSeverityPattern.test(body) || isResolvedText(body)) continue;
+              if (hasReviewerAccounting(login, comment.id)) continue;
+              if (!(await laterAuthorizedIssueComment(comment.created_at))) {
+                failures.push(`Trusted reviewer issue comment ${comment.id} has a high-severity finding without a later author/maintainer response.`);
+              }
+            }
+
+            for (const review of reviews) {
+              const login = review.user?.login || '';
+              const body = review.body || '';
+              const state = review.state || '';
+              const submittedAt = review.submitted_at || review.submittedAt || review.created_at;
+              const isFinding = state === 'CHANGES_REQUESTED' || highSeverityPattern.test(body);
+              if (!isTrusted(login) || !isFinding || isResolvedText(body)) continue;
+              if (hasReviewerAccounting(login, review.id)) continue;
+              if (!(await laterAcknowledgement(submittedAt))) {
+                failures.push(`Trusted reviewer review ${review.id} has a high-severity finding without a later author/maintainer response.`);
+              }
+            }
+
+            for (const comment of reviewComments) {
+              const login = comment.user?.login || '';
+              const body = comment.body || '';
+              if (!isTrusted(login)) continue;
+              if (!highSeverityPattern.test(body) || isResolvedText(body)) continue;
+              if (hasReviewerAccounting(login, comment.id)) continue;
+              if (!(await laterAuthorizedReviewComment(comment.created_at))) {
+                failures.push(`Trusted reviewer review comment ${comment.id} has a high-severity finding without a later author/maintainer reply.`);
+              }
+            }
+
+            core.summary
+              .addHeading('Reviewer response gate')
+              .addRaw(`Trusted reviewer signals: ${trustedSignals.length}\n`)
+              .addRaw(`High-severity unacknowledged findings: ${failures.length}\n`)
+              .write();
+
+            if (failures.length > 0) {
+              core.setFailed(`Reviewer response gate failed:\n- ${failures.join('\n- ')}`);
+              return;
+            }
+
+            core.info(`Reviewer response gate passed with ${trustedSignals.length} trusted reviewer signal(s).`);

--- a/.github/workflows/gate-reviewer-response.yml
+++ b/.github/workflows/gate-reviewer-response.yml
@@ -80,6 +80,13 @@ jobs:
               return resolvedPattern.test(text) && !unresolvedPattern.test(text);
             }
 
+            function effectiveCommentTime(comment) {
+              return Math.max(
+                new Date(comment.created_at || 0).getTime(),
+                new Date(comment.updated_at || comment.created_at || 0).getTime(),
+              );
+            }
+
             function hasReviewerAccounting(login, id) {
               const lowerBody = prBody.toLowerCase();
               const reviewer = loginOf(login).toLowerCase();
@@ -90,7 +97,7 @@ jobs:
               if (reviewer.includes('copilot') && lowerBody.includes('copilot disposition received')) return true;
               if (reviewer.includes('cubic') && lowerBody.includes('cubic disposition received')) return true;
               if (reviewer.includes('gemini') && lowerBody.includes('gemini disposition received')) return true;
-              if (reviewer.includes('codex') && (lowerBody.includes('codex disposition received') || lowerBody.includes('reviewed all reviewer comments'))) return true;
+              if (reviewer.includes('codex') && lowerBody.includes('codex disposition received')) return true;
               return false;
             }
 
@@ -144,14 +151,14 @@ jobs:
             }
 
             if (trustedSignals.length === 0) {
-              core.setFailed('Reviewer response gate failed: no trusted reviewer signal found.');
+              core.info('Reviewer response gate passed: no trusted reviewer signals found yet.');
               return;
             }
 
             async function laterAuthorizedIssueComment(createdAt) {
               const created = new Date(createdAt).getTime();
               for (const comment of issueComments) {
-                if (new Date(comment.created_at).getTime() <= created) continue;
+                if (effectiveCommentTime(comment) <= created) continue;
                 if (await isAuthorizedResponder(comment.user?.login)) return true;
               }
               return false;
@@ -160,7 +167,7 @@ jobs:
             async function laterAuthorizedReviewComment(createdAt) {
               const created = new Date(createdAt).getTime();
               for (const comment of reviewComments) {
-                if (new Date(comment.created_at).getTime() <= created) continue;
+                if (effectiveCommentTime(comment) <= created) continue;
                 if (await isAuthorizedResponder(comment.user?.login)) return true;
               }
               return false;
@@ -187,6 +194,7 @@ jobs:
               const login = review.user?.login || '';
               const body = review.body || '';
               const state = review.state || '';
+              if (state === 'DISMISSED') continue;
               const submittedAt = review.submitted_at || review.submittedAt || review.created_at;
               const isFinding = state === 'CHANGES_REQUESTED' || highSeverityPattern.test(body);
               if (!isTrusted(login) || !isFinding || isResolvedText(body)) continue;


### PR DESCRIPTION
- **Issue:** #1051

## STATUS
SUPERSEDED / CLOSED WITHOUT MERGE

## SUPERSEDED BY
- Issue #1055 stabilization direction
- Current `main` branch governance state for `.github/workflows/gate-reviewer-response.yml`

## CLOSURE RATIONALE
This PR originally remediated stale reviewer-gate failures by adding `pull_request.edited` triggers and related reviewer-response handling improvements.

Since creation of this PR:
- Main branch governance direction changed under Issue #1055.
- Reviewer gate stabilization/redesign work superseded this implementation path.
- Current repository direction intentionally avoids reintroducing the prior reviewer-gate behavior during stabilization.
- This branch is significantly behind `main` and conflicts with the active governance redesign direction.

Merging this PR would reintroduce workflow behavior intentionally retired pending broader redesign.

## FINAL DISPOSITION
- Scope reviewed
- Prior findings addressed
- No merge recommended
- Closed as superseded by Issue #1055 stabilization work

Closes PR #1052 without merge.
