### PR TITLE
docs(ci): add post-merge operational review architecture guidance (#1058)

### DIFF
--- a/docs/explanation/ci-governance-and-workflow-architecture.md
+++ b/docs/explanation/ci-governance-and-workflow-architecture.md
@@ -185,6 +185,90 @@ These workflows provide operational guidance only.
 
 ---
 
+# Post-Merge Operational Review Layer
+
+## Purpose
+
+The repository requires operational validation after merge events complete.
+
+Traditional PR gates validate pre-merge safety.
+
+LGFC additionally requires:
+- post-merge operational assurance
+- automation ecosystem validation
+- orchestration regression detection
+- governance synchronization verification
+
+This layer exists because:
+- workflows may pass individually
+- but repository automation may still enter degraded states after merge
+
+---
+
+## Responsibilities
+
+The post-merge operational review layer should:
+- detect automation regressions
+- detect workflow sequencing failures
+- detect governance synchronization drift
+- detect stale workflow references
+- detect broken orchestration assumptions
+- detect documentation synchronization failures
+- validate workflow ownership consistency
+- validate workflow naming consistency
+
+---
+
+## Design Constraints
+
+The post-merge operational review layer must NOT:
+- duplicate all PR gates
+- rerun unnecessary build/test/security suites
+- create contributor deadlocks
+- punish low-signal operational anomalies
+
+This layer exists for:
+- asynchronous operational validation
+- repository health assurance
+- orchestration monitoring
+- governance integrity validation
+
+---
+
+## Severity Model
+
+Default behavior:
+- advisory-first
+- opens Issues automatically when operational anomalies are detected
+- escalates only severe operational regressions
+
+Potential severe conditions:
+- broken governance references
+- broken workflow ownership mappings
+- failed orchestration chains
+- inconsistent workflow naming after normalization rollout
+- governance drift after merge
+
+---
+
+## Operational Separation
+
+### Pre-Merge CI
+Purpose:
+- prevent unsafe merges
+- validate implementation safety
+- validate governance compliance
+
+### Post-Merge Operational Review
+Purpose:
+- validate repository operational integrity
+- validate automation ecosystem health
+- detect orchestration regressions
+- validate governance synchronization
+- ensure long-term repository stability
+
+---
+
 # Workflow Inventory Standard
 
 Every workflow must define:
@@ -234,6 +318,7 @@ This naming alignment becomes repository standard unless technically impractical
 6. Reviewer analysis
 7. Merge-readiness assessment
 8. Human merge approval
+9. Post-merge operational review and governance validation
 
 CI should support this lifecycle without introducing unnecessary deadlocks.
 
@@ -277,5 +362,6 @@ Target state:
 - clear workflow ownership
 - simplified CI troubleshooting
 - scalable governance architecture
+- validated post-merge operational integrity
 
 The CI system should protect repository integrity while preserving operational momentum.


### PR DESCRIPTION
- **Issue:** #1058

- **Issue:** #1058

## Summary
- extend CI governance architecture documentation
- document post-merge operational review layer
- define operational assurance responsibilities
- define post-merge governance validation model
- document separation between pre-merge and post-merge CI responsibilities

## Source Issue
- Closes #1058

## Files
- docs/explanation/ci-governance-and-workflow-architecture.md

## Governance
- docs-only PR
- no workflow execution changes
- no CI behavior changes
- architecture/reference documentation only

## Acceptance Criteria
- post-merge operational review architecture documented
- governance rationale documented
- orchestration validation model documented
- CI lifecycle updated to include post-merge operational review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the post-merge operational review layer in our CI governance architecture. Covers responsibilities, design constraints, and severity; clarifies separation from pre-merge CI; and adds a lifecycle step for post-merge governance validation—docs only, no workflow changes.

<sup>Written for commit 0920e0dced1b5dd5922f8e416b9c9527c6387395. Summary will update on new commits. <a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1062?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->