### PR TITLE
feat(faq): wire FAQ page to live API (T21)

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -19,9 +19,6 @@ function sortFaqItems(items: FAQItem[]): FAQItem[] {
     const pinnedDelta = Number(right.pinned) - Number(left.pinned);
     if (pinnedDelta !== 0) return pinnedDelta;
 
-    const viewDelta = right.view_count - left.view_count;
-    if (viewDelta !== 0) return viewDelta;
-
     return right.updated_at.localeCompare(left.updated_at);
   });
 }
@@ -32,13 +29,22 @@ function FAQContent() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState('');
   const [query, setQuery] = useState(searchParams.get('q') || '');
-  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(() => new Set());
   const [viewCounts, setViewCounts] = useState<Record<number, number>>({});
 
   const q = useMemo(() => query.trim().toLowerCase(), [query]);
 
   useEffect(() => {
     let alive = true;
+    let completed = false;
+
+    const timer = setTimeout(() => {
+      if (!alive || completed) return;
+      setLoading(false);
+      setItems([]);
+      setViewCounts({});
+      setLoadError('Unable to load FAQ entries right now.');
+    }, 10000);
 
     (async () => {
       setLoading(true);
@@ -62,12 +68,16 @@ function FAQContent() {
         setViewCounts({});
         setLoadError('Unable to load FAQ entries right now.');
       } finally {
-        if (alive) setLoading(false);
+        if (alive) {
+          setLoading(false);
+          completed = true;
+        }
       }
     })();
 
     return () => {
       alive = false;
+      clearTimeout(timer);
     };
   }, []);
 
@@ -84,15 +94,19 @@ function FAQContent() {
   }, [items, q]);
 
   const handleItemClick = (id: number) => {
-    const newExpandedId = expandedId === id ? null : id;
-    setExpandedId(newExpandedId);
+    setExpandedIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) {
+        next.delete(id);
+        return next;
+      }
 
-    if (newExpandedId !== id) return;
-
-    setViewCounts((current) => ({ ...current, [id]: (current[id] ?? 0) + 1 }));
-
-    void apiPost('/api/faq/view', { id }).catch(() => {
-      // Fire-and-forget per design; UI already updated optimistically.
+      next.add(id);
+      setViewCounts((counts) => ({ ...counts, [id]: (counts[id] ?? 0) + 1 }));
+      void apiPost('/api/faq/view', { id }).catch(() => {
+        // Fire-and-forget per design; UI already updated optimistically.
+      });
+      return next;
     });
   };
 
@@ -143,7 +157,7 @@ function FAQContent() {
                   {item.pinned ? '📌 ' : ''}
                   {item.question}
                 </strong>
-                {expandedId === item.id ? (
+                {expandedIds.has(item.id) ? (
                   <>
                     <br />
                     <span className="sub">{item.answer}</span>

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -54,8 +54,12 @@ function FAQContent() {
         const data = await apiGet<{ ok: boolean; items: FAQItem[] }>('/api/faq/list?limit=50');
         if (!alive) return;
 
+        completed = true;
+        clearTimeout(timer);
+
         const rows = Array.isArray(data.items) ? data.items : [];
         setItems(rows);
+        setLoadError('');
         setViewCounts(
           rows.reduce<Record<number, number>>((acc, item) => {
             acc[item.id] = item.view_count;

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -19,7 +19,7 @@ function sortFaqItems(items: FAQItem[]): FAQItem[] {
     const pinnedDelta = Number(right.pinned) - Number(left.pinned);
     if (pinnedDelta !== 0) return pinnedDelta;
 
-    const viewDelta = (right.view_count ?? 0) - (left.view_count ?? 0);
+    const viewDelta = right.view_count - left.view_count;
     if (viewDelta !== 0) return viewDelta;
 
     return right.updated_at.localeCompare(left.updated_at);
@@ -52,7 +52,7 @@ function FAQContent() {
         setItems(rows);
         setViewCounts(
           rows.reduce<Record<number, number>>((acc, item) => {
-            acc[item.id] = item.view_count ?? 0;
+            acc[item.id] = item.view_count;
             return acc;
           }, {}),
         );

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,89 +1,99 @@
 'use client';
 
-import { useMemo, useState, Suspense } from 'react';
+import { useEffect, useMemo, useState, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
+import { apiGet, apiPost } from '@/lib/api';
 
 type FAQItem = {
   id: number;
   question: string;
   answer: string;
-  pinned?: boolean;
-  view_count?: number;
+  view_count: number;
+  pinned: number;
+  updated_at: string;
 };
 
-const FAQ_ITEMS: FAQItem[] = [
-  {
-    id: 1,
-    question: 'How do I join the fan club?',
-    answer:
-      'Visit the Join Fanclub page, choose your membership tier, and complete checkout. Your benefits unlock immediately after payment confirmation.',
-    pinned: true,
-    view_count: 0,
-  },
-  {
-    id: 2,
-    question: 'Where can I buy official merch?',
-    answer:
-      'Our official merch is available in the store section. New drops are announced first on the homepage and social channels.',
-    pinned: true,
-    view_count: 0,
-  },
-  {
-    id: 3,
-    question: 'How can I submit a question to be answered?',
-    answer:
-      'Use the Ask page to submit your question. Our team reviews submissions and publishes approved answers on this FAQ page.',
-    view_count: 0,
-  },
-  {
-    id: 4,
-    question: 'Do you offer refunds for memberships or tickets?',
-    answer:
-      'Refund terms vary by product. Please review checkout policies and contact support with your order details for case-by-case assistance.',
-    view_count: 0,
-  },
-  {
-    id: 5,
-    question: 'How do I get updates about upcoming events?',
-    answer:
-      'Check the Events page regularly and follow announcements on our social channels for schedule updates and venue details.',
-    view_count: 0,
-  },
-];
+function sortFaqItems(items: FAQItem[]): FAQItem[] {
+  return [...items].sort((left, right) => {
+    const pinnedDelta = Number(right.pinned) - Number(left.pinned);
+    if (pinnedDelta !== 0) return pinnedDelta;
+
+    const viewDelta = (right.view_count ?? 0) - (left.view_count ?? 0);
+    if (viewDelta !== 0) return viewDelta;
+
+    return right.updated_at.localeCompare(left.updated_at);
+  });
+}
 
 function FAQContent() {
   const searchParams = useSearchParams();
+  const [items, setItems] = useState<FAQItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
   const [query, setQuery] = useState(searchParams.get('q') || '');
   const [expandedId, setExpandedId] = useState<number | null>(null);
-  const [viewCounts, setViewCounts] = useState<Record<number, number>>(() =>
-    FAQ_ITEMS.reduce<Record<number, number>>((acc, item) => {
-      acc[item.id] = item.view_count ?? 0;
-      return acc;
-    }, {})
-  );
+  const [viewCounts, setViewCounts] = useState<Record<number, number>>({});
 
   const q = useMemo(() => query.trim().toLowerCase(), [query]);
 
+  useEffect(() => {
+    let alive = true;
+
+    (async () => {
+      setLoading(true);
+      setLoadError('');
+
+      try {
+        const data = await apiGet<{ ok: boolean; items: FAQItem[] }>('/api/faq/list?limit=50');
+        if (!alive) return;
+
+        const rows = Array.isArray(data.items) ? data.items : [];
+        setItems(rows);
+        setViewCounts(
+          rows.reduce<Record<number, number>>((acc, item) => {
+            acc[item.id] = item.view_count ?? 0;
+            return acc;
+          }, {}),
+        );
+      } catch {
+        if (!alive) return;
+        setItems([]);
+        setViewCounts({});
+        setLoadError('Unable to load FAQ entries right now.');
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
   const filteredItems = useMemo(() => {
     const matches = q
-      ? FAQ_ITEMS.filter(
+      ? items.filter(
           (item) =>
             item.question.toLowerCase().includes(q) ||
-            item.answer.toLowerCase().includes(q)
+            item.answer.toLowerCase().includes(q),
         )
-      : FAQ_ITEMS;
+      : items;
 
-    return [...matches].sort((a, b) => Number(Boolean(b.pinned)) - Number(Boolean(a.pinned)));
-  }, [q]);
+    return sortFaqItems(matches);
+  }, [items, q]);
 
   const handleItemClick = (id: number) => {
     const newExpandedId = expandedId === id ? null : id;
     setExpandedId(newExpandedId);
 
-    if (newExpandedId === id) {
-      setViewCounts((current) => ({ ...current, [id]: (current[id] || 0) + 1 }));
-    }
+    if (newExpandedId !== id) return;
+
+    setViewCounts((current) => ({ ...current, [id]: (current[id] ?? 0) + 1 }));
+
+    void apiPost('/api/faq/view', { id }).catch(() => {
+      // Fire-and-forget per design; UI already updated optimistically.
+    });
   };
 
   return (
@@ -103,11 +113,24 @@ function FAQContent() {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
             />
-            <button type="button" onClick={() => setQuery('')}>Clear</button>
+            <button type="button" onClick={() => setQuery('')}>
+              Clear
+            </button>
           </div>
 
-          {filteredItems.length === 0 ? (
-            <p className="sub">No FAQ entries matched your search.</p>
+          {loading ? (
+            <p className="sub">Loading FAQ…</p>
+          ) : loadError ? (
+            <p className="sub">{loadError}</p>
+          ) : filteredItems.length === 0 ? (
+            <p className="sub">
+              {q
+                ? 'No questions match your search.'
+                : 'No FAQ entries are available yet.'}{' '}
+              <Link href="/ask" className="link">
+                Ask a Question
+              </Link>
+            </p>
           ) : (
             filteredItems.map((item) => (
               <div
@@ -134,6 +157,9 @@ function FAQContent() {
         </div>
 
         <div style={{ marginTop: 24 }}>
+          <p className="sub" style={{ marginBottom: 10 }}>
+            Have a question we haven&apos;t answered?
+          </p>
           <Link href="/ask" className="link" style={{ fontSize: 16 }}>
             Ask a Question
           </Link>

--- a/tests/faq-page.test.tsx
+++ b/tests/faq-page.test.tsx
@@ -191,7 +191,7 @@ describe('FAQ page', () => {
 
     render(<FAQPage />);
 
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(10000);
     });
 
@@ -199,11 +199,10 @@ describe('FAQ page', () => {
 
     await act(async () => {
       resolveFaq({ ok: true, items: SAMPLE_ITEMS });
+      await Promise.resolve();
     });
 
-    await waitFor(() => {
-      expect(screen.queryByText(/Unable to load FAQ entries right now/i)).not.toBeInTheDocument();
-      expect(screen.getByText(/How do I join\?/)).toBeInTheDocument();
-    });
+    expect(screen.queryByText(/Unable to load FAQ entries right now/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/How do I join\?/)).toBeInTheDocument();
   });
 });

--- a/tests/faq-page.test.tsx
+++ b/tests/faq-page.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import FAQPage from '@/app/faq/page';
 import { apiGet, apiPost } from '@/lib/api';
@@ -41,6 +41,10 @@ describe('FAQ page', () => {
     mockedApiGet.mockReset();
     mockedApiPost.mockReset();
     mockedApiPost.mockResolvedValue({ ok: true } as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('loads approved FAQ entries from the API', async () => {
@@ -172,6 +176,34 @@ describe('FAQ page', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Unable to load FAQ entries right now/i)).toBeInTheDocument();
+    });
+  });
+
+  it('clears timeout error when a delayed FAQ fetch eventually succeeds', async () => {
+    vi.useFakeTimers();
+
+    let resolveFaq: (value: { ok: boolean; items: typeof SAMPLE_ITEMS }) => void = () => {};
+    mockedApiGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFaq = resolve;
+      }) as never,
+    );
+
+    render(<FAQPage />);
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    expect(screen.getByText(/Unable to load FAQ entries right now/i)).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFaq({ ok: true, items: SAMPLE_ITEMS });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Unable to load FAQ entries right now/i)).not.toBeInTheDocument();
+      expect(screen.getByText(/How do I join\?/)).toBeInTheDocument();
     });
   });
 });

--- a/tests/faq-page.test.tsx
+++ b/tests/faq-page.test.tsx
@@ -71,7 +71,7 @@ describe('FAQ page', () => {
     expect(screen.getByText(/Where are events posted\?/)).toBeInTheDocument();
   });
 
-  it('shows pinned entries before unpinned entries after filtering', async () => {
+  it('shows pinned entries before unpinned entries', async () => {
     mockedApiGet.mockResolvedValue({ ok: true, items: SAMPLE_ITEMS } as never);
 
     render(<FAQPage />);
@@ -82,6 +82,55 @@ describe('FAQ page', () => {
 
     const questions = screen.getAllByText(/How do I join\?|Where are events posted\?/);
     expect(questions[0]).toHaveTextContent(/How do I join\?/);
+  });
+
+  it('orders unpinned entries by updated_at descending', async () => {
+    mockedApiGet.mockResolvedValue({
+      ok: true,
+      items: [
+        {
+          id: 1,
+          question: 'Older entry',
+          answer: 'Older answer.',
+          view_count: 100,
+          pinned: 0,
+          updated_at: '2026-05-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          question: 'Newer entry',
+          answer: 'Newer answer.',
+          view_count: 1,
+          pinned: 0,
+          updated_at: '2026-05-10T00:00:00Z',
+        },
+      ],
+    } as never);
+
+    render(<FAQPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Newer entry/)).toBeInTheDocument();
+    });
+
+    const questions = screen.getAllByText(/Older entry|Newer entry/);
+    expect(questions[0]).toHaveTextContent(/Newer entry/);
+  });
+
+  it('allows multiple FAQ entries to stay expanded at once', async () => {
+    mockedApiGet.mockResolvedValue({ ok: true, items: SAMPLE_ITEMS } as never);
+
+    render(<FAQPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/How do I join\?/)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText(/How do I join\?/));
+    await userEvent.click(screen.getByText(/Where are events posted\?/));
+
+    expect(screen.getByText('Visit the Join page.')).toBeInTheDocument();
+    expect(screen.getByText('Check the Events page.')).toBeInTheDocument();
   });
 
   it('increments view count and posts to the view API when an entry expands', async () => {

--- a/tests/faq-page.test.tsx
+++ b/tests/faq-page.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import FAQPage from '@/app/faq/page';
+import { apiGet, apiPost } from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(''),
+}));
+
+const mockedApiGet = vi.mocked(apiGet);
+const mockedApiPost = vi.mocked(apiPost);
+
+const SAMPLE_ITEMS = [
+  {
+    id: 1,
+    question: 'How do I join?',
+    answer: 'Visit the Join page.',
+    view_count: 2,
+    pinned: 1,
+    updated_at: '2026-05-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    question: 'Where are events posted?',
+    answer: 'Check the Events page.',
+    view_count: 5,
+    pinned: 0,
+    updated_at: '2026-05-02T00:00:00Z',
+  },
+];
+
+describe('FAQ page', () => {
+  beforeEach(() => {
+    mockedApiGet.mockReset();
+    mockedApiPost.mockReset();
+    mockedApiPost.mockResolvedValue({ ok: true } as never);
+  });
+
+  it('loads approved FAQ entries from the API', async () => {
+    mockedApiGet.mockResolvedValue({ ok: true, items: SAMPLE_ITEMS } as never);
+
+    render(<FAQPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/How do I join\?/)).toBeInTheDocument();
+    });
+
+    expect(mockedApiGet).toHaveBeenCalledWith('/api/faq/list?limit=50');
+    expect(screen.getByText(/Where are events posted\?/)).toBeInTheDocument();
+  });
+
+  it('filters loaded entries with client-side search', async () => {
+    mockedApiGet.mockResolvedValue({ ok: true, items: SAMPLE_ITEMS } as never);
+
+    render(<FAQPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/How do I join\?/)).toBeInTheDocument();
+    });
+
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search questions' }), 'events');
+
+    expect(screen.queryByText(/How do I join\?/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Where are events posted\?/)).toBeInTheDocument();
+  });
+
+  it('shows pinned entries before unpinned entries after filtering', async () => {
+    mockedApiGet.mockResolvedValue({ ok: true, items: SAMPLE_ITEMS } as never);
+
+    render(<FAQPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/How do I join\?/)).toBeInTheDocument();
+    });
+
+    const questions = screen.getAllByText(/How do I join\?|Where are events posted\?/);
+    expect(questions[0]).toHaveTextContent(/How do I join\?/);
+  });
+
+  it('increments view count and posts to the view API when an entry expands', async () => {
+    mockedApiGet.mockResolvedValue({ ok: true, items: SAMPLE_ITEMS } as never);
+
+    render(<FAQPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/How do I join\?/)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText(/How do I join\?/));
+
+    expect(screen.getByText('Views: 3')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockedApiPost).toHaveBeenCalledWith('/api/faq/view', { id: 1 });
+    });
+  });
+
+  it('shows a fail-closed empty search state with Ask link', async () => {
+    mockedApiGet.mockResolvedValue({ ok: true, items: SAMPLE_ITEMS } as never);
+
+    render(<FAQPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/How do I join\?/)).toBeInTheDocument();
+    });
+
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search questions' }), 'zzzz');
+
+    expect(screen.getByText(/No questions match your search/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'Ask a Question' }).length).toBeGreaterThan(0);
+  });
+
+  it('shows an error message when FAQ loading fails', async () => {
+    mockedApiGet.mockRejectedValue(new Error('api_error_500'));
+
+    render(<FAQPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Unable to load FAQ entries right now/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
- **Issue:** #1053

## Merge outcome (pre-merge)
- **Intended design:** T21 — FAQ page loads approved entries from D1, supports search, pinning, view counts, and Ask CTA per `faq-and-ask.md`.
- **Scope delivered:** PASS (pending merge) — `/faq` now uses `/api/faq/list` + `/api/faq/view`; homepage FAQ section unchanged.
- **Quality gate:** latest CI rerun pending final confirmation.

## REVIEWER RESPONSE ACCOUNTING
- review-comment:3266929197 — accepted — Added 10s list-fetch timeout matching FAQSection fail-closed pattern (2ba9ae9).
- review-comment:3266929254 — accepted — Renamed pinned-order test; removed misleading wording (2ba9ae9).
- review-comment:3266929283 — accepted — Sort is pinned then updated_at DESC only; removed view_count tie-break (2ba9ae9).
- review-comment:3266929329 — accepted — Replaced single expandedId with expandedIds Set so multiple FAQs can stay open (2ba9ae9).
- review-comment:3266918268 — accepted — Removed redundant `?? 0` usage (1e70c97).
- review-comment:3266918289 — accepted — Removed redundant `?? 0` usage in initialization (1e70c97).
- review-comment:3267370186 — accepted — Cleared stale timeout error after delayed successful fetch and added regression test coverage (350e836, e0d3576).
- Cubic — acknowledged — no actionable inline findings.

## ACCEPTANCE CRITERIA
- [x] `/faq` loads approved FAQ entries from API
- [x] Search, pinning, and view-count behavior operate at launch-safe level
- [x] Ask CTA preserved; homepage section order unchanged
- [ ] CI passes fully on latest rerun