### PR TITLE
[CI] Add reviewer gate simulation harness design

### DIFF
--- a/docs/explanation/reviewer-gate-simulation-harness.md
+++ b/docs/explanation/reviewer-gate-simulation-harness.md
@@ -1,0 +1,72 @@
+---
+Doc Type: Explanation
+Audience: CI maintainers, governance operators, AI agents
+Authority Level: Canonical Draft
+Owns: Reviewer gate simulation-harness architecture
+Does Not Own: Production merge enforcement runtime behavior
+Canonical Reference: Issue #1058
+Last Reviewed: 2026-05-19
+---
+
+# Reviewer Gate Simulation Harness
+
+## Purpose
+Create deterministic CI simulations for reviewer-gate governance behavior.
+
+## Problem
+Reviewer workflows are currently validated primarily through live PR execution.
+
+This creates:
+- delayed detection
+- governance regressions
+- circular deadlock recurrence risk
+- inconsistent AI-agent behavior validation
+
+## Design Goal
+Enable repeatable simulation testing for:
+- reviewer workflows
+- governance routing
+- remediation handling
+- advisory/blocking classification
+- protected-file enforcement
+
+## Core Test Categories
+
+### PR Lifecycle Simulation
+Simulate:
+- PR opened
+- synchronize
+- ready-for-review
+- review requested
+- approval submitted
+- changes requested
+- labels applied
+
+### Governance Simulation
+Simulate:
+- governance remediation PRs
+- CI repair PRs
+- malformed PR metadata
+- missing issue mappings
+- allowlist violations
+
+### Protected Scope Simulation
+Validate behavior for:
+- .github/workflows/**
+- scripts/ci/**
+- deployment-sensitive files
+- docs-only PRs
+
+### Advisory vs Blocking Validation
+Assert:
+- advisory workflows never fail merge
+- merge-safety workflows remain deterministic
+- remediation labels downgrade advisory enforcement
+
+## Expected Outcome
+The reviewer gate system becomes:
+- deterministic
+- regression-testable
+- AI-agent-safe
+- remediation-safe
+- easier to troubleshoot

--- a/docs/reference/reviewer-gate-simulation-scenarios.md
+++ b/docs/reference/reviewer-gate-simulation-scenarios.md
@@ -1,0 +1,33 @@
+---
+Doc Type: Reference
+Audience: CI maintainers and governance operators
+Authority Level: Canonical Draft
+Owns: Reviewer gate simulation scenarios and expected outcomes
+Does Not Own: Workflow implementation logic
+Canonical Reference: Issue #1058
+Last Reviewed: 2026-05-19
+---
+
+# Reviewer Gate Simulation Scenarios
+
+| Scenario | Expected Result |
+|---|---|
+| Governance remediation PR | Advisory downgrade active |
+| Missing required approval | Hard blocking failure |
+| Stale review | Warning only |
+| Docs-only PR | Advisory-first routing |
+| Workflow mutation PR | Protected enforcement active |
+| Missing issue mapping | Governance failure |
+| Allowlist violation | Governance failure |
+| Malformed PR body | Non-fatal normalization |
+| Requested changes unresolved | Merge blocked |
+| Security review unresolved | Merge blocked |
+
+## Simulation Objectives
+
+Validate:
+- deterministic governance
+- remediation-safe behavior
+- branch-protection compatibility
+- advisory/blocking separation
+- AI-agent resilience


### PR DESCRIPTION
## Summary

Adds the initial reviewer gate simulation harness design documentation following the merge of PR #1067.

This PR establishes:
- deterministic simulation-test direction
- governance simulation categories
- advisory vs blocking validation scenarios
- remediation-safe simulation requirements
- protected-scope simulation definitions

## Scope

Documentation/design only.

No workflow execution behavior changes in this PR.

## Files

- docs/explanation/reviewer-gate-simulation-harness.md
- docs/reference/reviewer-gate-simulation-scenarios.md

## Purpose

Define the future-state CI simulation infrastructure required to validate reviewer-gate governance behavior safely and deterministically.

## Follow-up Work

Subsequent PRs will:
1. implement simulation fixtures
2. create reusable PR-event payloads
3. build deterministic governance assertions
4. validate remediation downgrade behavior
5. add branch-protection compatibility tests
6. integrate workflow simulation into CI

## Governance

Issue:
- #1058

Related:
- PR #1067


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds design and scenario docs for the reviewer-gate CI simulation harness to enable deterministic, safe validation of governance behavior. No workflow changes; defines simulation coverage for lifecycle events, protected scopes, and advisory vs blocking paths.

- **New Features**
  - Adds docs: docs/explanation/reviewer-gate-simulation-harness.md and docs/reference/reviewer-gate-simulation-scenarios.md
  - Defines simulation categories and expected outcomes (advisory vs blocking, remediation downgrades, branch protection compatibility)
  - Aligns with Issue #1058 by specifying governance rules and protected-scope coverage

<sup>Written for commit c293787082b80d00b6da200fe48d616e77f98892. Summary will update on new commits. <a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1068?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

