### PR TITLE
[CI] Make PR issue-accounting parser semantic and format-tolerant

### DIFF
--- a/.github/workflows/ops-pr-issue-accounting.yml
+++ b/.github/workflows/ops-pr-issue-accounting.yml
@@ -16,10 +16,20 @@ jobs:
       group: ops-pr-issue-accounting-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
+      - name: Checkout workflow parser helpers
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
       - name: Normalize and verify Issue-first pull request accounting
         uses: actions/github-script@v7
         with:
           script: |
+            const {
+              issueRefsFromBody,
+              issueRefsFromBranch,
+              normalizeIssueLine,
+            } = require('./scripts/ci/pr-issue-accounting-parser.js');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const prNumber = context.payload.pull_request.number;
@@ -28,98 +38,6 @@ jobs:
             const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
             const prBody = pr.body || '';
             const headRef = pr.head?.ref || '';
-
-            function issueUrlBelongsToCurrentRepo(issueUrl) {
-              try {
-                const url = new URL(issueUrl);
-                const parts = url.pathname.split('/').filter(Boolean);
-                return url.hostname.toLowerCase() === 'github.com'
-                  && parts.length === 4
-                  && parts[0].toLowerCase() === owner.toLowerCase()
-                  && parts[1].toLowerCase() === repo.toLowerCase()
-                  && parts[2] === 'issues'
-                  && /^\d+$/.test(parts[3]);
-              } catch (_error) {
-                return false;
-              }
-            }
-
-            function issueNumberFromRef(ref) {
-              const value = (ref || '').trim().replace(/[).,;]+$/g, '');
-              const local = value.match(/^#(\d+)$/);
-              if (local) return Number(local[1]);
-              if (!issueUrlBelongsToCurrentRepo(value)) return null;
-              const parts = new URL(value).pathname.split('/').filter(Boolean);
-              return Number(parts[3]);
-            }
-
-            function pushUnique(refs, issueNumber, source) {
-              if (!issueNumber || Number.isNaN(issueNumber)) return;
-              refs.push({ issueNumber, source });
-            }
-
-            function issueRefsFromBody(body) {
-              const refs = [];
-              const lines = (body || '').split('\n');
-              for (const line of lines) {
-                if (/OPS\s+Tracker/i.test(line)) continue;
-                if (/Umbrella\s+Tracker/i.test(line)) continue;
-
-                const primary = line.match(/^\s*-?\s*(?:\*\*)?Issue(?::|\*\*\s*:|\*\*:)\s*(#\d+|https:\/\/github\.com\/[^\s)]+\/[^\s)]+\/issues\/\d+\/?)/i);
-                if (primary) {
-                  pushUnique(refs, issueNumberFromRef(primary[1]), 'primary-body-line');
-                  continue;
-                }
-
-                const closing = line.match(/\b(?:closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved)\s+(#\d+|https:\/\/github\.com\/[^\s)]+\/[^\s)]+\/issues\/\d+\/?)/i);
-                if (closing) {
-                  pushUnique(refs, issueNumberFromRef(closing[1]), 'closing-keyword-body-line');
-                }
-              }
-              return refs;
-            }
-
-            function issueRefsFromBranch(ref) {
-              const refs = [];
-              const patterns = [
-                /(?:^|[-_/])issue[-_/]?(\d+)(?:$|[-_/])/i,
-                /(?:^|[-_/])(\d{3,6})(?:[-_/][A-Za-z]|$)/,
-              ];
-              for (const pattern of patterns) {
-                const match = (ref || '').match(pattern);
-                if (match) {
-                  pushUnique(refs, Number(match[1]), 'branch-name');
-                  break;
-                }
-              }
-              return refs;
-            }
-
-            function canonicalIssueLine(issueNumber) {
-              return `- **Issue:** #${issueNumber}`;
-            }
-
-            function normalizeIssueLine(body, issueNumber) {
-              const canonical = canonicalIssueLine(issueNumber);
-              const lines = (body || '').split('\n');
-              let replaced = false;
-              const normalized = lines.map((line) => {
-                if (/OPS\s+Tracker/i.test(line) || /Umbrella\s+Tracker/i.test(line)) return line;
-                if (/^\s*-?\s*(?:\*\*)?Issue(?::|\*\*\s*:|\*\*:)\s*(#\d+|https:\/\/github\.com\/[^\s)]+\/[^\s)]+\/issues\/\d+\/?)/i.test(line)) {
-                  if (!replaced) {
-                    replaced = true;
-                    return canonical;
-                  }
-                  return null;
-                }
-                return line;
-              }).filter((line) => line !== null);
-
-              if (!replaced) {
-                return `${canonical}\n\n${body || ''}`.trimEnd();
-              }
-              return normalized.join('\n').trimEnd();
-            }
 
             async function commentOnce(marker, body) {
               try {
@@ -142,13 +60,15 @@ jobs:
             }
 
             const marker = '<!-- ops-pr-issue-accounting -->';
+            const bodyRefs = issueRefsFromBody(prBody, owner, repo);
             const discoveredRefs = [
-              ...issueRefsFromBody(prBody),
+              ...bodyRefs.refs,
               ...issueRefsFromBranch(headRef),
             ];
+            const invalidRefs = bodyRefs.invalidRefs || [];
             const uniqueSourceIssues = [...new Set(discoveredRefs.map((ref) => ref.issueNumber))];
 
-            if (uniqueSourceIssues.length !== 1) {
+            if (invalidRefs.length > 0 || uniqueSourceIssues.length !== 1) {
               await commentOnce(
                 marker,
                 [
@@ -161,16 +81,18 @@ jobs:
                   'Accepted source surfaces:',
                   '- Existing primary PR body line such as `- **Issue:** #123`',
                   '- Compatible primary PR body variants such as `- **Issue**: #123`',
+                  '- Semantic primary PR body variants such as `Issue #123` or `Related Issue: #123`',
                   '- Same-repository closing keyword references such as `Closes #123`',
                   '- Branch names containing an issue number such as `issue-123-example`',
                   '',
                   `Detected source Issues: ${uniqueSourceIssues.length ? uniqueSourceIssues.map((issue) => `#${issue}`).join(', ') : 'none'}`,
                   `Detected sources: ${discoveredRefs.length ? discoveredRefs.map((ref) => `${ref.source}:#${ref.issueNumber}`).join(', ') : 'none'}`,
+                  `Invalid issue references: ${invalidRefs.length ? invalidRefs.map((ref) => `${ref.source}:${ref.ref}`).join(', ') : 'none'}`,
                   '',
                   'Add or correct the source Issue reference, then edit or synchronize the PR to rerun this workflow.',
                 ].join('\n')
               );
-              core.setFailed(`PR #${prNumber} must resolve to exactly one source Issue. Found unique issues: ${uniqueSourceIssues.length}`);
+              core.setFailed(`PR #${prNumber} must resolve to exactly one valid same-repository source Issue. Found unique issues: ${uniqueSourceIssues.length}; invalid refs: ${invalidRefs.length}`);
               return;
             }
 

--- a/docs/governance/PR_GOVERNANCE.md
+++ b/docs/governance/PR_GOVERNANCE.md
@@ -15,6 +15,18 @@ Last Reviewed: 2026-03-27
 2. Summarize exact edits with file paths (and line-level context when relevant).
 3. Link back to this governance file and the canonical design authority.
 
+## Source Issue Accounting
+The PR issue-accounting gate validates semantic issue linkage rather than a single exact Markdown spelling.
+
+Accepted primary source Issue examples include:
+- `- **Issue:** #123`
+- `- **Issue**: #123`
+- `Issue: #123`
+- `Issue #123`
+- `Related Issue: #123`
+
+The gate must still enforce exactly one source Issue, same-repository issue URLs, open-Issue validation while the PR is open, and rejection of pull request references used as source Issues.
+
 ## Canonical references for UI/layout work
 - `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
 - `/docs/reference/design/home.md`

--- a/scripts/ci/pr-issue-accounting-parser.js
+++ b/scripts/ci/pr-issue-accounting-parser.js
@@ -1,0 +1,146 @@
+function issueUrlBelongsToCurrentRepo(issueUrl, owner, repo) {
+  try {
+    const url = new URL(issueUrl);
+    const parts = url.pathname.split('/').filter(Boolean);
+    return url.hostname.toLowerCase() === 'github.com'
+      && parts.length === 4
+      && parts[0].toLowerCase() === owner.toLowerCase()
+      && parts[1].toLowerCase() === repo.toLowerCase()
+      && parts[2] === 'issues'
+      && /^\d+$/.test(parts[3]);
+  } catch (_error) {
+    return false;
+  }
+}
+
+function issueNumberFromRef(ref, owner, repo) {
+  const value = (ref || '').trim().replace(/[).,;]+$/g, '');
+  const local = value.match(/^#(\d+)$/);
+  if (local) return Number(local[1]);
+  if (!issueUrlBelongsToCurrentRepo(value, owner, repo)) return null;
+  const parts = new URL(value).pathname.split('/').filter(Boolean);
+  return Number(parts[3]);
+}
+
+function normalizeIssueReferenceLine(line) {
+  return (line || '')
+    .trim()
+    .replace(/^[>\s]*[-*+]\s+/, '')
+    .replace(/[`*_]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function pushIssueRef(refs, invalidRefs, ref, source, owner, repo) {
+  const issueNumber = issueNumberFromRef(ref, owner, repo);
+  if (!issueNumber || Number.isNaN(issueNumber)) {
+    invalidRefs.push({ ref, source });
+    return;
+  }
+  refs.push({ issueNumber, source });
+}
+
+function issueRefTokens(value) {
+  const tokenPattern = /#\d+|https:\/\/github\.com\/[^\s)]+\/[^\s)]+\/issues\/\d+\/?/gi;
+  return (value || '').match(tokenPattern) || [];
+}
+
+function semanticIssueRefsFromLine(line, owner, repo) {
+  const refs = [];
+  const invalidRefs = [];
+  const normalizedLine = normalizeIssueReferenceLine(line);
+  const semantic = normalizedLine.match(/^(?:related\s+)?issue\b(?:\s*:)?\s*(.*)$/i);
+  if (!semantic) return { refs, invalidRefs, matched: false };
+
+  const tokens = issueRefTokens(semantic[1]);
+  for (const token of tokens) {
+    pushIssueRef(refs, invalidRefs, token, 'primary-body-line', owner, repo);
+  }
+  return { refs, invalidRefs, matched: true };
+}
+
+function closingIssueRefsFromLine(line, owner, repo) {
+  const refs = [];
+  const invalidRefs = [];
+  const closingPattern = /\b(?:closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved)\s+(#\d+|https:\/\/github\.com\/[^\s)]+\/[^\s)]+\/issues\/\d+\/?)/gi;
+  let closing;
+  while ((closing = closingPattern.exec(line || '')) !== null) {
+    pushIssueRef(refs, invalidRefs, closing[1], 'closing-keyword-body-line', owner, repo);
+  }
+  return { refs, invalidRefs };
+}
+
+function issueRefsFromBody(body, owner, repo) {
+  const refs = [];
+  const invalidRefs = [];
+  const lines = (body || '').split('\n');
+
+  for (const line of lines) {
+    if (/OPS\s+Tracker/i.test(line)) continue;
+    if (/Umbrella\s+Tracker/i.test(line)) continue;
+
+    const semantic = semanticIssueRefsFromLine(line, owner, repo);
+    refs.push(...semantic.refs);
+    invalidRefs.push(...semantic.invalidRefs);
+    if (semantic.matched) continue;
+
+    const closing = closingIssueRefsFromLine(line, owner, repo);
+    refs.push(...closing.refs);
+    invalidRefs.push(...closing.invalidRefs);
+  }
+
+  return { refs, invalidRefs };
+}
+
+function issueRefsFromBranch(ref) {
+  const refs = [];
+  const patterns = [
+    /(?:^|[-_/])issue[-_/]?(\d+)(?:$|[-_/])/i,
+    /(?:^|[-_/])(\d{3,6})(?:[-_/][A-Za-z]|$)/,
+  ];
+  for (const pattern of patterns) {
+    const match = (ref || '').match(pattern);
+    if (match) {
+      refs.push({ issueNumber: Number(match[1]), source: 'branch-name' });
+      break;
+    }
+  }
+  return refs;
+}
+
+function canonicalIssueLine(issueNumber) {
+  return `- **Issue:** #${issueNumber}`;
+}
+
+function normalizeIssueLine(body, issueNumber) {
+  const canonical = canonicalIssueLine(issueNumber);
+  const lines = (body || '').split('\n');
+  let replaced = false;
+  const normalized = lines.map((line) => {
+    if (/OPS\s+Tracker/i.test(line) || /Umbrella\s+Tracker/i.test(line)) return line;
+    const normalizedLine = normalizeIssueReferenceLine(line);
+    if (/^(?:related\s+)?issue\b(?:\s*:)?\s*/i.test(normalizedLine)) {
+      if (!replaced) {
+        replaced = true;
+        return canonical;
+      }
+      return null;
+    }
+    return line;
+  }).filter((line) => line !== null);
+
+  if (!replaced) {
+    return `${canonical}\n\n${body || ''}`.trimEnd();
+  }
+  return normalized.join('\n').trimEnd();
+}
+
+module.exports = {
+  canonicalIssueLine,
+  issueNumberFromRef,
+  issueRefsFromBody,
+  issueRefsFromBranch,
+  issueUrlBelongsToCurrentRepo,
+  normalizeIssueLine,
+  normalizeIssueReferenceLine,
+};

--- a/tests/pr-issue-accounting-parser.test.mjs
+++ b/tests/pr-issue-accounting-parser.test.mjs
@@ -1,0 +1,88 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+  issueRefsFromBody,
+  issueRefsFromBranch,
+  normalizeIssueLine,
+} = require('../scripts/ci/pr-issue-accounting-parser.js');
+
+const owner = 'wdhunter645';
+const repo = 'next-starter-template';
+
+function bodyRefs(body) {
+  return issueRefsFromBody(body, owner, repo);
+}
+
+describe('PR issue-accounting parser', () => {
+  it.each([
+    '- **Issue:** #1053',
+    '- **Issue**: #1053',
+    'Issue: #1053',
+    'Issue #1053',
+    'Related Issue: #1053',
+    'Related Issue https://github.com/wdhunter645/next-starter-template/issues/1053',
+  ])('accepts semantic source issue format: %s', (line) => {
+    const result = bodyRefs(line);
+    expect(result.invalidRefs).toEqual([]);
+    expect(result.refs).toEqual([{ issueNumber: 1053, source: 'primary-body-line' }]);
+  });
+
+  it('normalizes equivalent source issue lines to one canonical line', () => {
+    const result = normalizeIssueLine(
+      [
+        '- **Issue:** #1053',
+        '- **Issue**: #1053',
+        'Related Issue: #1053',
+        '',
+        '## CHANGE SUMMARY',
+      ].join('\n'),
+      1053
+    );
+
+    expect(result).toBe(['- **Issue:** #1053', '', '## CHANGE SUMMARY'].join('\n'));
+  });
+
+  it('continues to detect same-repository closing keyword references', () => {
+    const result = bodyRefs('Closes https://github.com/wdhunter645/next-starter-template/issues/1053');
+    expect(result.invalidRefs).toEqual([]);
+    expect(result.refs).toEqual([{ issueNumber: 1053, source: 'closing-keyword-body-line' }]);
+  });
+
+  it('does not manufacture issue refs from malformed references', () => {
+    const result = bodyRefs('Issue: not-an-issue');
+    expect(result.invalidRefs).toEqual([]);
+    expect(result.refs).toEqual([]);
+  });
+
+  it('preserves multiple-issue violations for enforcement', () => {
+    const result = bodyRefs(['Issue: #1053', 'Related Issue: #1054'].join('\n'));
+    const unique = [...new Set(result.refs.map((ref) => ref.issueNumber))];
+    expect(result.invalidRefs).toEqual([]);
+    expect(unique).toEqual([1053, 1054]);
+  });
+
+  it('rejects cross-repository explicit issue references', () => {
+    const result = bodyRefs('Issue: https://github.com/other/repo/issues/1053');
+    expect(result.refs).toEqual([]);
+    expect(result.invalidRefs).toEqual([
+      {
+        ref: 'https://github.com/other/repo/issues/1053',
+        source: 'primary-body-line',
+      },
+    ]);
+  });
+
+  it('reports missing issue references as no discovered refs', () => {
+    const result = bodyRefs('## CHANGE SUMMARY\nNo source issue here.');
+    expect(result.invalidRefs).toEqual([]);
+    expect(result.refs).toEqual([]);
+  });
+
+  it('keeps branch-name issue discovery available as a fallback surface', () => {
+    expect(issueRefsFromBranch('ci/1058-semantic-issue-parser')).toEqual([
+      { issueNumber: 1058, source: 'branch-name' },
+    ]);
+  });
+});


### PR DESCRIPTION
- **Issue:** #1058

- **Issue:** #1058

## Summary

This PR makes the existing OPS PR Issue Accounting parser validate semantic source-Issue linkage instead of depending on one exact Markdown spelling.

Changed scope is intentionally limited to the issue-accounting gate parser, focused parser regression tests, and a concise governance note.

## Before / After

Before, semantically equivalent source-Issue lines were not handled consistently:

```md
- **Issue:** <source-issue>
- **Issue**: <source-issue>
```

After, the parser accepts these source-Issue forms and normalizes the PR body back to the canonical line:

```md
- **Issue:** <source-issue>
- **Issue**: <source-issue>
Issue: <source-issue>
Issue <source-issue>
Related Issue: <source-issue>
```

## Governance preserved

- Exactly one source Issue is still required.
- Same-repository issue URL validation is preserved.
- Open-Issue validation remains in the workflow.
- Pull request references are still rejected as source Issues.
- Cross-repository explicit issue URLs are rejected.
- No reviewer gate redesign, branch protection change, or unrelated CI edit is included.

## Allowed files:

- `.github/workflows/ops-pr-issue-accounting.yml`
- `scripts/ci/pr-issue-accounting-parser.js`
- `tests/pr-issue-accounting-parser.test.mjs`
- `docs/governance/PR_GOVERNANCE.md`

## REVIEWER RESPONSE ACCOUNTING

- [x] Gemini disposition received: two inline comments reviewed.
- [x] Reviewed selected reviewer comments.
- [x] Accepted / rejected / ignored each actionable selected-reviewer comment with rationale.
- review-comment:3273176145 — rejected — plural `Issues` forms are outside the requested acceptance set for this PR and can imply multiple-source accounting; this parser change stays limited to the approved singular source-Issue variants.
- review-comment:3273176163 — rejected — same scope rationale; normalization follows the supported singular source-Issue surface instead of broadening to plural labels in this PR.

## Validation

- `npm test -- tests/pr-issue-accounting-parser.test.mjs`
- `node -e "const fs=require('fs'); const yaml=require('js-yaml'); yaml.load(fs.readFileSync('.github/workflows/ops-pr-issue-accounting.yml','utf8')); console.log('workflow yaml parse PASSED')"`
- `node -c scripts/ci/pr-issue-accounting-parser.js`
- `node scripts/ci/verify_lgfc_invariants.mjs`
- `git diff --check`
- `./scripts/ci/docs_check_headers.sh .`
- `./scripts/ci/docs_check_paths.sh .`
- `./scripts/ci/docs_canonical_hashes_verify.sh .`
- `node .agents/checks/agent-governance-check.mjs .`
- `bash scripts/ci/no_supabase_guard.sh`