### PR TITLE
feat(faq): T23 FAQ moderation and CMS controls

### DIFF
--- a/docs/ops/tasks/T23-A.md
+++ b/docs/ops/tasks/T23-A.md
@@ -8,6 +8,10 @@ Canonical Reference: /docs/ops/OPERATING_MANUAL.md
 Last Reviewed: 2026-03-25
 ---
 
+# T23-A — Events page (legacy alias)
+
+> **Renumbered:** Use **T23-E** (`/docs/ops/tasks/T23-E.md`) for Events work. The **T23** label is now assigned to FAQ CMS moderation (PR #1072).
+
 # T23-A — Events page
 
 Objective: create events page backed by data.

--- a/docs/ops/tasks/T23-E.md
+++ b/docs/ops/tasks/T23-E.md
@@ -1,0 +1,26 @@
+---
+Doc Type: Operations
+Audience: Human + AI
+Authority Level: Controlled
+Owns: T23-E Events page task scope (renumbered from legacy T23)
+Does Not Own: FAQ CMS moderation (T23 / PR #1072)
+Canonical Reference: /docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
+Last Reviewed: 2026-05-20
+---
+
+# T23-E — Events page (legacy T23)
+
+Objective: stabilize the public events page backed by existing data APIs.
+
+Scope:
+- `/events` page
+- render list of events from `/api/events/next`
+- no calendar UI required in this track
+
+Exit:
+- page renders events from data source at launch-safe level
+
+Related historical assets:
+- `src/app/events/page.tsx`
+- `functions/api/events/next.ts`
+- admin events routes under `functions/api/admin/events/`

--- a/docs/ops/tasks/T23-M-faq-cms-moderation.md
+++ b/docs/ops/tasks/T23-M-faq-cms-moderation.md
@@ -1,0 +1,25 @@
+---
+Doc Type: Operations
+Audience: Human + AI
+Authority Level: Controlled
+Owns: T23 FAQ CMS moderation task scope
+Does Not Own: Events page (T23-E)
+Canonical Reference: /docs/reference/architecture/faq-system.md
+Last Reviewed: 2026-05-20
+---
+
+# T23 — FAQ CMS moderation
+
+Objective: operational admin layer for ask inbox triage and FAQ publishing.
+
+Scope:
+- `/admin/faq` moderation UI
+- `POST/GET` admin FAQ and ask inbox APIs
+- D1 `ask_inbox` + `faq_entries` moderation workflows
+
+Exit:
+- admins can approve/reject/archive ask submissions
+- admins can create/edit/publish/pin/delete FAQs
+- public `/faq` and homepage FAQ remain stable
+
+Delivery: PR #1072 (`website/t23-faq-moderation-cms`)

--- a/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
+++ b/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
@@ -293,14 +293,24 @@ Scope: FAQ page + supporting data only.
 Exit: search, pinned behavior, view count, and ask flow operate at launch-safe level.
 
 ## T22 — Ask-a-question intake
-Status: OPEN
+Status: MERGED (PR #1070)
 Scope: ask form + persistence only.
 Exit: submission stores correctly with basic validation.
 
-## T23 — Events page
+## T23 — FAQ CMS moderation (intentional task reassignment)
+Status: IN REVIEW (PR #1072)
+Owner: Cursor
+Scope: ask inbox moderation + FAQ admin CRUD/publish controls only.
+Exit: admins can moderate ask submissions and manage FAQs; public FAQ behavior unchanged.
+
+**Task-number note:** Historical worklist entry “T23 — Events page” is renumbered to **T23-E** below. This is an intentional reassignment of the T23 label to FAQ CMS moderation per the assigned Cursor brief—not implementation drift.
+
+## T23-E — Events page (legacy T23; follow-up track)
 Status: OPEN
-Scope: events page only.
-Exit: stable month/list presentation.
+Scope: events page stabilization and calendar alignment only.
+Exit: stable month/list presentation on `/events` using existing APIs.
+
+Notes: `/events`, `/api/events/next`, admin events routes, and calendar infrastructure already exist historically. This track is separate from T23 FAQ CMS moderation.
 
 ---
 

--- a/functions/_lib/faqModeration.ts
+++ b/functions/_lib/faqModeration.ts
@@ -2,6 +2,17 @@ export type FaqStatus = 'pending' | 'approved' | 'denied';
 
 export type AskInboxStatus = 'open' | 'pending' | 'approved' | 'rejected' | 'archived' | 'responded' | 'hidden';
 
+export function parseStrictBoolean(value: unknown): boolean | null {
+  if (value === true || value === 1) return true;
+  if (value === false || value === 0) return false;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1') return true;
+    if (normalized === 'false' || normalized === '0') return false;
+  }
+  return null;
+}
+
 export function parsePositiveInt(value: unknown): number | null {
   const id = Number(value);
   if (!Number.isInteger(id) || id <= 0) return null;

--- a/functions/_lib/faqModeration.ts
+++ b/functions/_lib/faqModeration.ts
@@ -1,0 +1,54 @@
+export type FaqStatus = 'pending' | 'approved' | 'denied';
+
+export type AskInboxStatus = 'open' | 'pending' | 'approved' | 'rejected' | 'archived' | 'responded' | 'hidden';
+
+export function parsePositiveInt(value: unknown): number | null {
+  const id = Number(value);
+  if (!Number.isInteger(id) || id <= 0) return null;
+  return id;
+}
+
+export function parsePinned(value: unknown): 0 | 1 | null {
+  const pinned = Number(value);
+  if (pinned === 0 || pinned === 1) return pinned;
+  return null;
+}
+
+export function validateFaqQuestion(question: string): string | null {
+  const text = question.trim();
+  if (!text) return 'Question is required.';
+  if (text.length > 500) return 'Question must be 500 characters or fewer.';
+  return null;
+}
+
+export function validateFaqAnswer(answer: string, required: boolean): string | null {
+  const text = answer.trim();
+  if (!text && required) return 'Answer is required.';
+  if (text.length > 8000) return 'Answer must be 8000 characters or fewer.';
+  return null;
+}
+
+export function normalizeFaqStatus(value: unknown): FaqStatus | null {
+  const status = String(value ?? '').trim().toLowerCase();
+  if (status === 'pending' || status === 'approved' || status === 'denied') return status;
+  return null;
+}
+
+export function askStatusesForFilter(filter: string): string[] {
+  const key = String(filter || 'pending').trim().toLowerCase();
+  switch (key) {
+    case 'approved':
+      return ['approved'];
+    case 'rejected':
+      return ['rejected', 'hidden'];
+    case 'archived':
+      return ['archived'];
+    case 'pending':
+    default:
+      return ['open', 'pending'];
+  }
+}
+
+export function isPublishedFaqStatus(status: string): boolean {
+  return status === 'approved';
+}

--- a/functions/api/admin/ask/approve.ts
+++ b/functions/api/admin/ask/approve.ts
@@ -1,0 +1,111 @@
+import { requireAdmin } from '../../../_lib/auth';
+import {
+  parsePositiveInt,
+  validateFaqAnswer,
+  validateFaqQuestion,
+} from '../../../_lib/faqModeration';
+
+export const onRequestPost = async (context: { request: Request; env: { DB?: unknown } }): Promise<Response> => {
+  const { request, env } = context;
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const id = parsePositiveInt(body?.id);
+    const answer = String(body?.answer ?? '').trim();
+    const moderationNote = String(body?.moderation_note ?? '').trim() || null;
+    const createFaq = body?.create_faq !== false;
+
+    if (!id) {
+      return new Response(JSON.stringify({ ok: false, error: 'Valid ask inbox ID required.' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const db = env.DB as {
+      prepare: (sql: string) => {
+        bind: (...args: unknown[]) => {
+          first: () => Promise<unknown>;
+          run: () => Promise<{ meta?: { last_row_id?: number } }>;
+        };
+      };
+    };
+
+    const row = (await db
+      .prepare(
+        `SELECT id, first_name, last_name, screen_name, email, question, status, faq_entry_id
+         FROM ask_inbox WHERE id = ?`,
+      )
+      .bind(id)
+      .first()) as Record<string, unknown> | null;
+
+    if (!row) {
+      return new Response(JSON.stringify({ ok: false, error: 'Ask inbox entry not found.' }, null, 2), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const status = String(row.status ?? '');
+    if (!['open', 'pending'].includes(status)) {
+      return new Response(JSON.stringify({ ok: false, error: 'Only pending ask entries can be approved.' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const question = String(row.question ?? '');
+    const publishAnswer = answer || '';
+    let faqEntryId = parsePositiveInt(row.faq_entry_id);
+
+    if (createFaq && !faqEntryId) {
+      const questionError = validateFaqQuestion(question);
+      if (questionError) {
+        return new Response(JSON.stringify({ ok: false, error: questionError }, null, 2), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      const answerError = validateFaqAnswer(publishAnswer, true);
+      if (answerError) {
+        return new Response(JSON.stringify({ ok: false, error: answerError }, null, 2), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      const insert = await db
+        .prepare(
+          `INSERT INTO faq_entries (question, answer, status, submitter_email, pinned, view_count, created_at, updated_at)
+           VALUES (?, ?, 'approved', ?, 0, 0, datetime('now'), datetime('now'))`,
+        )
+        .bind(question.trim(), publishAnswer, String(row.email ?? '').trim().toLowerCase())
+        .run();
+
+      faqEntryId = parsePositiveInt(insert.meta?.last_row_id);
+    }
+
+    await db
+      .prepare(
+        `UPDATE ask_inbox
+         SET status = 'approved', moderation_note = ?, faq_entry_id = ?, created_at = created_at
+         WHERE id = ?`,
+      )
+      .bind(moderationNote, faqEntryId, id)
+      .run();
+
+    return new Response(JSON.stringify({ ok: true, id, faq_entry_id: faqEntryId }, null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    console.error('admin ask/approve error:', err);
+    return new Response(JSON.stringify({ ok: false, error: 'Failed to approve ask entry.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/admin/ask/approve.ts
+++ b/functions/api/admin/ask/approve.ts
@@ -15,7 +15,7 @@ export const onRequestPost = async (context: { request: Request; env: { DB?: unk
     const id = parsePositiveInt(body?.id);
     const answer = String(body?.answer ?? '').trim();
     const moderationNote = String(body?.moderation_note ?? '').trim() || null;
-    const createFaq = body?.create_faq !== false;
+    const createFaq = body?.create_faq === true;
 
     if (!id) {
       return new Response(JSON.stringify({ ok: false, error: 'Valid ask inbox ID required.' }, null, 2), {
@@ -24,14 +24,7 @@ export const onRequestPost = async (context: { request: Request; env: { DB?: unk
       });
     }
 
-    const db = env.DB as {
-      prepare: (sql: string) => {
-        bind: (...args: unknown[]) => {
-          first: () => Promise<unknown>;
-          run: () => Promise<{ meta?: { last_row_id?: number } }>;
-        };
-      };
-    };
+    const db = env.DB as any;
 
     const row = (await db
       .prepare(
@@ -57,7 +50,7 @@ export const onRequestPost = async (context: { request: Request; env: { DB?: unk
     }
 
     const question = String(row.question ?? '');
-    const publishAnswer = answer || '';
+    const publishAnswer = answer;
     let faqEntryId = parsePositiveInt(row.faq_entry_id);
 
     if (createFaq && !faqEntryId) {
@@ -88,14 +81,21 @@ export const onRequestPost = async (context: { request: Request; env: { DB?: unk
       faqEntryId = parsePositiveInt(insert.meta?.last_row_id);
     }
 
-    await db
+    const update = await db
       .prepare(
         `UPDATE ask_inbox
-         SET status = 'approved', moderation_note = ?, faq_entry_id = ?, created_at = created_at
-         WHERE id = ?`,
+         SET status = 'approved', moderation_note = ?, faq_entry_id = ?
+         WHERE id = ? AND status IN ('open', 'pending')`,
       )
       .bind(moderationNote, faqEntryId, id)
       .run();
+
+    if (!update.meta?.changes) {
+      return new Response(JSON.stringify({ ok: false, error: 'Ask entry is no longer pending.' }, null, 2), {
+        status: 409,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
 
     return new Response(JSON.stringify({ ok: true, id, faq_entry_id: faqEntryId }, null, 2), {
       status: 200,

--- a/functions/api/admin/ask/archive.ts
+++ b/functions/api/admin/ask/archive.ts
@@ -1,0 +1,53 @@
+import { requireAdmin } from '../../../_lib/auth';
+import { parsePositiveInt } from '../../../_lib/faqModeration';
+
+export const onRequestPost = async (context: { request: Request; env: { DB?: unknown } }): Promise<Response> => {
+  const { request, env } = context;
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const id = parsePositiveInt(body?.id);
+    const moderationNote = String(body?.moderation_note ?? '').trim() || null;
+
+    if (!id) {
+      return new Response(JSON.stringify({ ok: false, error: 'Valid ask inbox ID required.' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const db = env.DB as {
+      prepare: (sql: string) => { bind: (...args: unknown[]) => { run: () => Promise<unknown> } };
+    };
+
+    const result = await db
+      .prepare(
+        `UPDATE ask_inbox
+         SET status = 'archived', moderation_note = COALESCE(?, moderation_note)
+         WHERE id = ?`,
+      )
+      .bind(moderationNote, id)
+      .run();
+
+    const changes = (result as { meta?: { changes?: number } })?.meta?.changes ?? 0;
+    if (!changes) {
+      return new Response(JSON.stringify({ ok: false, error: 'Ask entry not found.' }, null, 2), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true, id }, null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    console.error('admin ask/archive error:', err);
+    return new Response(JSON.stringify({ ok: false, error: 'Failed to archive ask entry.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/admin/ask/list.ts
+++ b/functions/api/admin/ask/list.ts
@@ -1,0 +1,40 @@
+import { requireAdmin } from '../../../_lib/auth';
+import { askStatusesForFilter } from '../../../_lib/faqModeration';
+
+export const onRequestGet = async (context: { request: Request; env: { DB?: unknown } }): Promise<Response> => {
+  const { request, env } = context;
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  try {
+    const url = new URL(request.url);
+    const statuses = askStatusesForFilter(url.searchParams.get('status') || 'pending');
+    const placeholders = statuses.map(() => '?').join(', ');
+
+    const db = env.DB as {
+      prepare: (sql: string) => { bind: (...args: unknown[]) => { all: () => Promise<{ results?: unknown[] }> } };
+    };
+
+    const result = await db
+      .prepare(
+        `SELECT id, first_name, last_name, screen_name, email, question, status,
+                moderation_note, faq_entry_id, created_at
+         FROM ask_inbox
+         WHERE status IN (${placeholders})
+         ORDER BY created_at DESC`,
+      )
+      .bind(...statuses)
+      .all();
+
+    return new Response(JSON.stringify({ ok: true, items: result.results || [] }, null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    console.error('admin ask/list error:', err);
+    return new Response(JSON.stringify({ ok: false, error: 'Failed to load ask inbox.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/admin/ask/reject.ts
+++ b/functions/api/admin/ask/reject.ts
@@ -1,0 +1,53 @@
+import { requireAdmin } from '../../../_lib/auth';
+import { parsePositiveInt } from '../../../_lib/faqModeration';
+
+export const onRequestPost = async (context: { request: Request; env: { DB?: unknown } }): Promise<Response> => {
+  const { request, env } = context;
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const id = parsePositiveInt(body?.id);
+    const moderationNote = String(body?.moderation_note ?? '').trim() || null;
+
+    if (!id) {
+      return new Response(JSON.stringify({ ok: false, error: 'Valid ask inbox ID required.' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const db = env.DB as {
+      prepare: (sql: string) => { bind: (...args: unknown[]) => { run: () => Promise<unknown> } };
+    };
+
+    const result = await db
+      .prepare(
+        `UPDATE ask_inbox
+         SET status = 'rejected', moderation_note = ?
+         WHERE id = ? AND status IN ('open', 'pending')`,
+      )
+      .bind(moderationNote, id)
+      .run();
+
+    const changes = (result as { meta?: { changes?: number } })?.meta?.changes ?? 0;
+    if (!changes) {
+      return new Response(JSON.stringify({ ok: false, error: 'Ask entry not found or not pending.' }, null, 2), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true, id }, null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    console.error('admin ask/reject error:', err);
+    return new Response(JSON.stringify({ ok: false, error: 'Failed to reject ask entry.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/admin/faq/create.ts
+++ b/functions/api/admin/faq/create.ts
@@ -1,6 +1,7 @@
 import { requireAdmin } from '../../../_lib/auth';
 import {
   parsePinned,
+  parseStrictBoolean,
   validateFaqAnswer,
   validateFaqQuestion,
 } from '../../../_lib/faqModeration';
@@ -14,8 +15,15 @@ export const onRequestPost = async (context: { request: Request; env: { DB?: unk
     const body = await request.json().catch(() => ({}));
     const question = String(body?.question ?? '');
     const answer = String(body?.answer ?? '');
-    const publish = Boolean(body?.published ?? body?.publish ?? false);
-    const pinned = parsePinned(body?.pinned) ?? 0;
+    const publish =
+      parseStrictBoolean(body?.published) ?? parseStrictBoolean(body?.publish) ?? false;
+    const pinned = parsePinned(body?.pinned);
+    if (pinned === null) {
+      return new Response(JSON.stringify({ ok: false, error: 'Pinned must be 0 or 1.' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
 
     const questionError = validateFaqQuestion(question);
     if (questionError) {

--- a/functions/api/admin/faq/create.ts
+++ b/functions/api/admin/faq/create.ts
@@ -1,0 +1,64 @@
+import { requireAdmin } from '../../../_lib/auth';
+import {
+  parsePinned,
+  validateFaqAnswer,
+  validateFaqQuestion,
+} from '../../../_lib/faqModeration';
+
+export const onRequestPost = async (context: { request: Request; env: { DB?: unknown } }): Promise<Response> => {
+  const { request, env } = context;
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const question = String(body?.question ?? '');
+    const answer = String(body?.answer ?? '');
+    const publish = Boolean(body?.published ?? body?.publish ?? false);
+    const pinned = parsePinned(body?.pinned) ?? 0;
+
+    const questionError = validateFaqQuestion(question);
+    if (questionError) {
+      return new Response(JSON.stringify({ ok: false, error: questionError }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const answerError = validateFaqAnswer(answer, publish);
+    if (answerError) {
+      return new Response(JSON.stringify({ ok: false, error: answerError }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const status = publish ? 'approved' : 'pending';
+    const db = env.DB as {
+      prepare: (sql: string) => {
+        bind: (...args: unknown[]) => {
+          run: () => Promise<{ meta?: { last_row_id?: number } }>;
+        };
+      };
+    };
+
+    const result = await db
+      .prepare(
+        `INSERT INTO faq_entries (question, answer, status, pinned, submitter_email, view_count, created_at, updated_at)
+         VALUES (?, ?, ?, ?, NULL, 0, datetime('now'), datetime('now'))`,
+      )
+      .bind(question.trim(), answer.trim(), status, pinned)
+      .run();
+
+    return new Response(
+      JSON.stringify({ ok: true, id: result.meta?.last_row_id ?? null, status }, null, 2),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err: unknown) {
+    console.error('admin faq/create error:', err);
+    return new Response(JSON.stringify({ ok: false, error: 'Failed to create FAQ entry.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/admin/faq/delete.ts
+++ b/functions/api/admin/faq/delete.ts
@@ -16,14 +16,19 @@ export const onRequestPost = async (context: { request: Request; env: { DB?: unk
       });
     }
 
-    const db = env.DB as {
-      prepare: (sql: string) => { bind: (...args: unknown[]) => { run: () => Promise<unknown> } };
-    };
+    const db = env.DB as any;
 
-    await db
+    const result = await db
       .prepare("UPDATE faq_entries SET status = 'denied', updated_at = datetime('now') WHERE id = ?")
       .bind(id)
       .run();
+
+    if (!result.meta?.changes) {
+      return new Response(JSON.stringify({ ok: false, error: 'FAQ entry not found.' }, null, 2), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
 
     return new Response(JSON.stringify({ ok: true, id }, null, 2), {
       status: 200,

--- a/functions/api/admin/faq/delete.ts
+++ b/functions/api/admin/faq/delete.ts
@@ -1,0 +1,39 @@
+import { requireAdmin } from '../../../_lib/auth';
+import { parsePositiveInt } from '../../../_lib/faqModeration';
+
+export const onRequestPost = async (context: { request: Request; env: { DB?: unknown } }): Promise<Response> => {
+  const { request, env } = context;
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const id = parsePositiveInt(body?.id);
+    if (!id) {
+      return new Response(JSON.stringify({ ok: false, error: 'Valid FAQ entry ID required.' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const db = env.DB as {
+      prepare: (sql: string) => { bind: (...args: unknown[]) => { run: () => Promise<unknown> } };
+    };
+
+    await db
+      .prepare("UPDATE faq_entries SET status = 'denied', updated_at = datetime('now') WHERE id = ?")
+      .bind(id)
+      .run();
+
+    return new Response(JSON.stringify({ ok: true, id }, null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    console.error('admin faq/delete error:', err);
+    return new Response(JSON.stringify({ ok: false, error: 'Failed to delete FAQ entry.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/admin/faq/list.ts
+++ b/functions/api/admin/faq/list.ts
@@ -1,0 +1,52 @@
+import { requireAdmin } from '../../../_lib/auth';
+import {
+  isPublishedFaqStatus,
+  normalizeFaqStatus,
+} from '../../../_lib/faqModeration';
+
+export const onRequestGet = async (context: { request: Request; env: { DB?: unknown } }): Promise<Response> => {
+  const { request, env } = context;
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  try {
+    const url = new URL(request.url);
+    const statusFilter = normalizeFaqStatus(url.searchParams.get('status') || '');
+
+    const db = env.DB as any;
+
+    let sql =
+      'SELECT id, question, answer, status, submitter_email, view_count, pinned, created_at, updated_at FROM faq_entries';
+    const args: string[] = [];
+
+    if (statusFilter) {
+      sql += ' WHERE status = ?';
+      args.push(statusFilter);
+    }
+
+    sql += ' ORDER BY pinned DESC, updated_at DESC, id DESC';
+
+    const result = args.length
+      ? await db.prepare(sql).bind(...args).all()
+      : await db.prepare(sql).all();
+    const items = (result.results || []).map((row: Record<string, unknown>) => {
+      const record = row;
+      const status = String(record.status ?? '');
+      return {
+        ...record,
+        published: isPublishedFaqStatus(status),
+      };
+    });
+
+    return new Response(JSON.stringify({ ok: true, items }, null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    console.error('admin faq/list error:', err);
+    return new Response(JSON.stringify({ ok: false, error: 'Failed to load FAQ entries.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/admin/faq/update.ts
+++ b/functions/api/admin/faq/update.ts
@@ -3,6 +3,7 @@ import {
   normalizeFaqStatus,
   parsePinned,
   parsePositiveInt,
+  parseStrictBoolean,
   validateFaqAnswer,
   validateFaqQuestion,
 } from '../../../_lib/faqModeration';
@@ -49,7 +50,14 @@ export const onRequestPost = async (context: { request: Request; env: { DB?: unk
         : normalizeFaqStatus(existing.status);
 
     if (body?.published != null || body?.approved != null) {
-      const published = Boolean(body?.published ?? body?.approved);
+      const published =
+        parseStrictBoolean(body?.published) ?? parseStrictBoolean(body?.approved);
+      if (published === null) {
+        return new Response(JSON.stringify({ ok: false, error: 'Invalid published flag.' }, null, 2), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       status = published ? 'approved' : 'pending';
     }
 

--- a/functions/api/admin/faq/update.ts
+++ b/functions/api/admin/faq/update.ts
@@ -1,0 +1,108 @@
+import { requireAdmin } from '../../../_lib/auth';
+import {
+  normalizeFaqStatus,
+  parsePinned,
+  parsePositiveInt,
+  validateFaqAnswer,
+  validateFaqQuestion,
+} from '../../../_lib/faqModeration';
+
+export const onRequestPost = async (context: { request: Request; env: { DB?: unknown } }): Promise<Response> => {
+  const { request, env } = context;
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const id = parsePositiveInt(body?.id);
+    if (!id) {
+      return new Response(JSON.stringify({ ok: false, error: 'Valid FAQ entry ID required.' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const db = env.DB as {
+      prepare: (sql: string) => {
+        bind: (...args: unknown[]) => { first: () => Promise<unknown>; run: () => Promise<unknown> };
+      };
+    };
+
+    const existing = (await db
+      .prepare('SELECT id, question, answer, status, pinned FROM faq_entries WHERE id = ?')
+      .bind(id)
+      .first()) as Record<string, unknown> | null;
+
+    if (!existing) {
+      return new Response(JSON.stringify({ ok: false, error: 'FAQ entry not found.' }, null, 2), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const question =
+      body?.question != null ? String(body.question) : String(existing.question ?? '');
+    const answer = body?.answer != null ? String(body.answer) : String(existing.answer ?? '');
+    let status =
+      body?.status != null
+        ? normalizeFaqStatus(body.status)
+        : normalizeFaqStatus(existing.status);
+
+    if (body?.published != null || body?.approved != null) {
+      const published = Boolean(body?.published ?? body?.approved);
+      status = published ? 'approved' : 'pending';
+    }
+
+    const pinned = body?.pinned != null ? parsePinned(body.pinned) : parsePinned(existing.pinned);
+
+    if (!status) {
+      return new Response(JSON.stringify({ ok: false, error: 'Invalid FAQ status.' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (pinned === null) {
+      return new Response(JSON.stringify({ ok: false, error: 'Pinned must be 0 or 1.' }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const questionError = validateFaqQuestion(question);
+    if (questionError) {
+      return new Response(JSON.stringify({ ok: false, error: questionError }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const answerError = validateFaqAnswer(answer, status === 'approved');
+    if (answerError) {
+      return new Response(JSON.stringify({ ok: false, error: answerError }, null, 2), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    await db
+      .prepare(
+        `UPDATE faq_entries
+         SET question = ?, answer = ?, status = ?, pinned = ?, updated_at = datetime('now')
+         WHERE id = ?`,
+      )
+      .bind(question.trim(), answer.trim(), status, pinned, id)
+      .run();
+
+    return new Response(JSON.stringify({ ok: true, id, status, pinned }, null, 2), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    console.error('admin faq/update error:', err);
+    return new Response(JSON.stringify({ ok: false, error: 'Failed to update FAQ entry.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/migrations/0034_ask_inbox_moderation.sql
+++ b/migrations/0034_ask_inbox_moderation.sql
@@ -1,0 +1,3 @@
+-- 0034_ask_inbox_moderation.sql — T23 ask inbox moderation fields
+ALTER TABLE ask_inbox ADD COLUMN moderation_note TEXT;
+ALTER TABLE ask_inbox ADD COLUMN faq_entry_id INTEGER;

--- a/src/app/admin/faq/page.tsx
+++ b/src/app/admin/faq/page.tsx
@@ -1,213 +1,508 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import PageShell from '@/components/PageShell';
 import AdminNav from '@/components/admin/AdminNav';
 
-type FaqItem = {
-  id: string;
+type FaqRow = {
+  id: number;
   question: string;
   answer: string;
-  approved: boolean;
+  status: string;
+  published: boolean;
   pinned: boolean;
-  views: number;
+  view_count: number;
+  submitter_email?: string | null;
 };
 
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null;
-}
-
-function asString(v: unknown): string | null {
-  return typeof v === 'string' ? v : null;
-}
-
-function asNumber(v: unknown): number | null {
-  return typeof v === 'number' && Number.isFinite(v) ? v : null;
-}
-
-function asBool(v: unknown): boolean | null {
-  return typeof v === 'boolean' ? v : null;
-}
-
-function normalize(raw: unknown): FaqItem | null {
-  if (!isRecord(raw)) return null;
-  const id = asString(raw.id) ?? asString(raw.uuid) ?? asString(raw.faq_id) ?? null;
-  const question = asString(raw.question) ?? null;
-  const answer = asString(raw.answer) ?? '';
-  if (!id || !question) return null;
-
-  const approved =
-    asBool(raw.approved) ??
-    (asNumber(raw.approved) !== null ? (asNumber(raw.approved) as number) !== 0 : false);
-
-  const pinned =
-    asBool(raw.pinned) ??
-    (asNumber(raw.pinned) !== null ? (asNumber(raw.pinned) as number) !== 0 : false);
-
-  const views = asNumber(raw.views) ?? 0;
-
-  return { id, question, answer, approved, pinned, views };
-}
+type AskRow = {
+  id: number;
+  first_name: string;
+  last_name: string;
+  screen_name?: string | null;
+  email: string;
+  question: string;
+  status: string;
+  moderation_note?: string | null;
+  faq_entry_id?: number | null;
+  created_at?: string;
+};
 
 function getToken(): string {
   if (typeof window === 'undefined') return '';
   return window.localStorage.getItem('lgfc_admin_token') || '';
 }
 
-function persistToken(t: string) {
+function persistToken(value: string) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('lgfc_admin_token', t);
+  window.localStorage.setItem('lgfc_admin_token', value);
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+async function adminFetch(path: string, token: string, init?: RequestInit) {
+  return fetch(path, {
+    ...init,
+    headers: {
+      ...(init?.headers || {}),
+      'x-admin-token': token,
+      ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    cache: 'no-store',
+  });
 }
 
 export default function AdminFaqPage() {
   const [token, setToken] = useState('');
-  const [status, setStatus] = useState<string>('');
-  const [items, setItems] = useState<FaqItem[]>([]);
-  const [filter, setFilter] = useState<'all' | 'approved' | 'pending'>('all');
+  const [status, setStatus] = useState('');
+  const [tab, setTab] = useState<'ask' | 'faq'>('ask');
+
+  const [askFilter, setAskFilter] = useState<'pending' | 'approved' | 'rejected' | 'archived'>('pending');
+  const [askItems, setAskItems] = useState<AskRow[]>([]);
+  const [askAnswers, setAskAnswers] = useState<Record<number, string>>({});
+  const [askNotes, setAskNotes] = useState<Record<number, string>>({});
+
+  const [faqFilter, setFaqFilter] = useState<'all' | 'pending' | 'approved' | 'denied'>('all');
+  const [faqItems, setFaqItems] = useState<FaqRow[]>([]);
+  const [draftQuestion, setDraftQuestion] = useState('');
+  const [draftAnswer, setDraftAnswer] = useState('');
+  const [draftPublish, setDraftPublish] = useState(false);
+  const [draftPinned, setDraftPinned] = useState(false);
 
   useEffect(() => {
     setToken(getToken());
   }, []);
 
-  const filtered = useMemo(() => {
-    if (filter === 'approved') return items.filter((x) => x.approved);
-    if (filter === 'pending') return items.filter((x) => !x.approved);
-    return items;
-  }, [items, filter]);
-
-  async function load() {
+  const loadAsk = useCallback(async () => {
     if (!token) {
-      setStatus('Enter ADMIN_TOKEN to load FAQ.');
+      setStatus('Enter ADMIN_TOKEN to load ask inbox.');
       return;
     }
-    setStatus('Loading…');
-    const res = await fetch('/api/admin/faq/list', {
-      headers: { 'x-admin-token': token },
-      cache: 'no-store',
-    });
-    const data: unknown = await res.json().catch(() => ({}));
+    setStatus('Loading ask inbox…');
+    const res = await adminFetch(`/api/admin/ask/list?status=${askFilter}`, token);
+    const data: unknown = await res.json().catch(() => null);
     if (!isRecord(data) || data.ok !== true) {
       const err = isRecord(data) && typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
-      setStatus(`Error: ${err}`);
-      setItems([]);
+      setStatus(`Ask inbox error: ${err}`);
+      setAskItems([]);
       return;
     }
-    const raw = (data as Record<string, unknown>).items;
-    const arr = Array.isArray(raw) ? raw : [];
-    const normalized = arr.map(normalize).filter((x): x is FaqItem => x !== null);
-    setItems(normalized);
+    const rows = Array.isArray(data.items) ? (data.items as AskRow[]) : [];
+    setAskItems(rows);
     setStatus('');
-  }
+  }, [askFilter, token]);
 
-  async function patch(id: string, changes: Partial<Pick<FaqItem, 'approved' | 'pinned'>>) {
+  const loadFaq = useCallback(async () => {
+    if (!token) {
+      setStatus('Enter ADMIN_TOKEN to load FAQs.');
+      return;
+    }
+    setStatus('Loading FAQs…');
+    const query = faqFilter === 'all' ? '' : `?status=${faqFilter}`;
+    const res = await adminFetch(`/api/admin/faq/list${query}`, token);
+    const data: unknown = await res.json().catch(() => null);
+    if (!isRecord(data) || data.ok !== true) {
+      const err = isRecord(data) && typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
+      setStatus(`FAQ error: ${err}`);
+      setFaqItems([]);
+      return;
+    }
+    const rows = (Array.isArray(data.items) ? data.items : []).map((raw) => {
+      const row = raw as Record<string, unknown>;
+      return {
+        id: Number(row.id),
+        question: String(row.question ?? ''),
+        answer: String(row.answer ?? ''),
+        status: String(row.status ?? ''),
+        published: Boolean(row.published ?? row.status === 'approved'),
+        pinned: Number(row.pinned) === 1,
+        view_count: Number(row.view_count ?? 0),
+        submitter_email: row.submitter_email != null ? String(row.submitter_email) : null,
+      } satisfies FaqRow;
+    });
+    setFaqItems(rows.filter((row) => Number.isFinite(row.id)));
+    setStatus('');
+  }, [faqFilter, token]);
+
+  useEffect(() => {
+    if (!token) return;
+    if (tab === 'ask') void loadAsk();
+    else void loadFaq();
+  }, [tab, token, loadAsk, loadFaq]);
+
+  async function askAction(path: string, id: number, body: Record<string, unknown>) {
     if (!token) return;
     setStatus('Saving…');
-    const res = await fetch('/api/admin/faq/update', {
+    const res = await adminFetch(path, token, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'x-admin-token': token },
-      body: JSON.stringify({ id, ...changes }),
+      body: JSON.stringify({ id, ...body }),
     });
-    const data: unknown = await res.json().catch(() => ({}));
+    const data: unknown = await res.json().catch(() => null);
     if (!isRecord(data) || data.ok !== true) {
       const err = isRecord(data) && typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
       setStatus(`Error: ${err}`);
       return;
     }
-    await load();
+    await loadAsk();
     setStatus('');
   }
 
-  async function bumpView(id: string) {
+  async function saveFaq(row: FaqRow) {
     if (!token) return;
-    await fetch('/api/admin/faq/bump', {
+    setStatus('Saving FAQ…');
+    const res = await adminFetch('/api/admin/faq/update', token, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'x-admin-token': token },
-      body: JSON.stringify({ id }),
-    }).catch(() => {});
-    await load();
+      body: JSON.stringify({
+        id: row.id,
+        question: row.question,
+        answer: row.answer,
+        status: row.status,
+        pinned: row.pinned ? 1 : 0,
+      }),
+    });
+    const data: unknown = await res.json().catch(() => null);
+    if (!isRecord(data) || data.ok !== true) {
+      const err = isRecord(data) && typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
+      setStatus(`Error: ${err}`);
+      return;
+    }
+    await loadFaq();
+    setStatus('');
   }
 
+  async function createFaq() {
+    if (!token) return;
+    setStatus('Creating FAQ…');
+    const res = await adminFetch('/api/admin/faq/create', token, {
+      method: 'POST',
+      body: JSON.stringify({
+        question: draftQuestion,
+        answer: draftAnswer,
+        published: draftPublish,
+        pinned: draftPinned ? 1 : 0,
+      }),
+    });
+    const data: unknown = await res.json().catch(() => null);
+    if (!isRecord(data) || data.ok !== true) {
+      const err = isRecord(data) && typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
+      setStatus(`Error: ${err}`);
+      return;
+    }
+    setDraftQuestion('');
+    setDraftAnswer('');
+    setDraftPublish(false);
+    setDraftPinned(false);
+    await loadFaq();
+    setStatus('');
+  }
+
+  async function deleteFaq(id: number) {
+    if (!token || !window.confirm('Mark this FAQ as denied (removed from public)?')) return;
+    setStatus('Deleting…');
+    const res = await adminFetch('/api/admin/faq/delete', token, {
+      method: 'POST',
+      body: JSON.stringify({ id }),
+    });
+    const data: unknown = await res.json().catch(() => null);
+    if (!isRecord(data) || data.ok !== true) {
+      const err = isRecord(data) && typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
+      setStatus(`Error: ${err}`);
+      return;
+    }
+    await loadFaq();
+    setStatus('');
+  }
+
+  const askCountLabel = useMemo(() => `${askItems.length} item(s)`, [askItems.length]);
+
   return (
-    <PageShell title="Admin • FAQ" subtitle="Approve, pin, and manage FAQ questions">
+    <PageShell title="Admin • FAQ Moderation" subtitle="Ask inbox triage and FAQ publishing">
       <AdminNav />
 
-      <div style={{ display: 'grid', gap: 12, maxWidth: 980 }}>
+      <div style={{ display: 'grid', gap: 12, maxWidth: 1040 }}>
         <label style={{ display: 'grid', gap: 6 }}>
           <span style={{ fontWeight: 600 }}>ADMIN_TOKEN</span>
           <input
             value={token}
             onChange={(e) => {
-              const v = e.target.value;
-              setToken(v);
-              persistToken(v);
+              setToken(e.target.value);
+              persistToken(e.target.value);
             }}
-            placeholder="Paste ADMIN_TOKEN (stored locally in this browser)"
+            placeholder="Paste ADMIN_TOKEN"
             style={{ padding: 10, borderRadius: 8, border: '1px solid #ccc' }}
           />
         </label>
 
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
-          <button
-            onClick={() => void load()}
-            style={{ padding: '10px 14px', borderRadius: 10, border: '1px solid #333', cursor: 'pointer' }}
-          >
-            Load FAQ
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <button type="button" onClick={() => setTab('ask')} style={{ fontWeight: tab === 'ask' ? 700 : 400 }}>
+            Ask Inbox
           </button>
-
-          <select
-            value={filter}
-            onChange={(e) => setFilter(e.target.value as 'all' | 'approved' | 'pending')}
-            style={{ padding: 10, borderRadius: 10 }}
-          >
-            <option value="all">All</option>
-            <option value="approved">Approved</option>
-            <option value="pending">Pending</option>
-          </select>
-
+          <button type="button" onClick={() => setTab('faq')} style={{ fontWeight: tab === 'faq' ? 700 : 400 }}>
+            FAQ CMS
+          </button>
           {status ? <span style={{ opacity: 0.85 }}>{status}</span> : null}
         </div>
 
-        <div style={{ display: 'grid', gap: 10 }}>
-          {filtered.map((f) => (
-            <div key={f.id} style={{ border: '1px solid #ddd', borderRadius: 12, padding: 14 }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, alignItems: 'baseline', flexWrap: 'wrap' }}>
-                <div style={{ fontWeight: 800 }}>{f.question}</div>
-                <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-                  <span style={{ opacity: 0.75, fontSize: 13 }}>Views: {f.views}</span>
-                  <button
-                    onClick={() => void bumpView(f.id)}
-                    style={{ padding: '6px 10px', borderRadius: 10, border: '1px solid #333', cursor: 'pointer' }}
-                  >
-                    +1 View
-                  </button>
-                </div>
-              </div>
-
-              {f.answer ? <div style={{ marginTop: 10, lineHeight: 1.35, opacity: 0.95 }}>{f.answer}</div> : null}
-
-              <div style={{ display: 'flex', gap: 10, marginTop: 12, flexWrap: 'wrap' }}>
+        {tab === 'ask' ? (
+          <>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+              {(['pending', 'approved', 'rejected', 'archived'] as const).map((value) => (
                 <button
-                  onClick={() => void patch(f.id, { approved: !f.approved })}
-                  style={{ padding: '8px 10px', borderRadius: 10, border: '1px solid #333', cursor: 'pointer' }}
+                  key={value}
+                  type="button"
+                  onClick={() => setAskFilter(value)}
+                  style={{ fontWeight: askFilter === value ? 700 : 400 }}
                 >
-                  {f.approved ? 'Unapprove' : 'Approve'}
+                  {value}
                 </button>
-
-                <button
-                  onClick={() => void patch(f.id, { pinned: !f.pinned })}
-                  style={{ padding: '8px 10px', borderRadius: 10, border: '1px solid #333', cursor: 'pointer' }}
-                >
-                  {f.pinned ? 'Unpin' : 'Pin'}
-                </button>
-
-                <span style={{ opacity: 0.75, alignSelf: 'center' }}>
-                  Status: {f.approved ? 'Approved' : 'Pending'} • {f.pinned ? 'Pinned' : 'Not pinned'}
-                </span>
-              </div>
+              ))}
+              <button type="button" onClick={() => void loadAsk()}>
+                Refresh
+              </button>
+              <span style={{ opacity: 0.75 }}>{askCountLabel}</span>
             </div>
-          ))}
-        </div>
+
+            <div style={{ display: 'grid', gap: 10 }}>
+              {askItems.map((item) => (
+                <div key={item.id} style={{ border: '1px solid #ddd', borderRadius: 12, padding: 14 }}>
+                  <div style={{ fontWeight: 800 }}>{item.question}</div>
+                  <div className="sub" style={{ marginTop: 6 }}>
+                    {item.first_name} {item.last_name}
+                    {item.screen_name ? ` (${item.screen_name})` : ''} — {item.email}
+                  </div>
+                  <div className="sub" style={{ marginTop: 4 }}>
+                    Status: {item.status}
+                    {item.faq_entry_id ? ` • FAQ #${item.faq_entry_id}` : ''}
+                  </div>
+                  {item.moderation_note ? (
+                    <div className="sub" style={{ marginTop: 6 }}>
+                      Note: {item.moderation_note}
+                    </div>
+                  ) : null}
+
+                  {askFilter === 'pending' ? (
+                    <>
+                      <label style={{ display: 'block', marginTop: 12 }}>
+                        <strong>Publish answer (creates FAQ when approved)</strong>
+                        <textarea
+                          value={askAnswers[item.id] ?? ''}
+                          onChange={(e) =>
+                            setAskAnswers((current) => ({ ...current, [item.id]: e.target.value }))
+                          }
+                          rows={4}
+                          style={{ width: '100%', marginTop: 6, padding: 8, boxSizing: 'border-box' }}
+                        />
+                      </label>
+                      <label style={{ display: 'block', marginTop: 8 }}>
+                        <strong>Moderation note (optional)</strong>
+                        <input
+                          value={askNotes[item.id] ?? ''}
+                          onChange={(e) =>
+                            setAskNotes((current) => ({ ...current, [item.id]: e.target.value }))
+                          }
+                          style={{ width: '100%', marginTop: 6, padding: 8 }}
+                        />
+                      </label>
+                      <div style={{ display: 'flex', gap: 8, marginTop: 12, flexWrap: 'wrap' }}>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            void askAction('/api/admin/ask/approve', item.id, {
+                              answer: askAnswers[item.id] ?? '',
+                              moderation_note: askNotes[item.id] ?? '',
+                            })
+                          }
+                        >
+                          Approve
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            void askAction('/api/admin/ask/reject', item.id, {
+                              moderation_note: askNotes[item.id] ?? '',
+                            })
+                          }
+                        >
+                          Reject
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            void askAction('/api/admin/ask/archive', item.id, {
+                              moderation_note: askNotes[item.id] ?? '',
+                            })
+                          }
+                        >
+                          Archive
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <button
+                      type="button"
+                      style={{ marginTop: 12 }}
+                      onClick={() =>
+                        void askAction('/api/admin/ask/archive', item.id, {
+                          moderation_note: askNotes[item.id] ?? '',
+                        })
+                      }
+                    >
+                      Archive
+                    </button>
+                  )}
+                </div>
+              ))}
+              {askItems.length === 0 ? <p className="sub">No ask inbox entries in this queue.</p> : null}
+            </div>
+          </>
+        ) : (
+          <>
+            <div style={{ border: '1px solid #ddd', borderRadius: 12, padding: 14 }}>
+              <h2 style={{ margin: '0 0 10px 0', fontSize: 18 }}>Create FAQ</h2>
+              <label style={{ display: 'block' }}>
+                <strong>Question</strong>
+                <input
+                  value={draftQuestion}
+                  onChange={(e) => setDraftQuestion(e.target.value)}
+                  style={{ width: '100%', marginTop: 6, padding: 8 }}
+                />
+              </label>
+              <label style={{ display: 'block', marginTop: 10 }}>
+                <strong>Answer</strong>
+                <textarea
+                  value={draftAnswer}
+                  onChange={(e) => setDraftAnswer(e.target.value)}
+                  rows={4}
+                  style={{ width: '100%', marginTop: 6, padding: 8, boxSizing: 'border-box' }}
+                />
+              </label>
+              <label style={{ display: 'flex', gap: 8, marginTop: 10, alignItems: 'center' }}>
+                <input
+                  type="checkbox"
+                  checked={draftPublish}
+                  onChange={(e) => setDraftPublish(e.target.checked)}
+                />
+                Publish immediately
+              </label>
+              <label style={{ display: 'flex', gap: 8, marginTop: 6, alignItems: 'center' }}>
+                <input
+                  type="checkbox"
+                  checked={draftPinned}
+                  onChange={(e) => setDraftPinned(e.target.checked)}
+                />
+                Pin on publish
+              </label>
+              <button type="button" style={{ marginTop: 12 }} onClick={() => void createFaq()}>
+                Create FAQ
+              </button>
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+              {(['all', 'pending', 'approved', 'denied'] as const).map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setFaqFilter(value)}
+                  style={{ fontWeight: faqFilter === value ? 700 : 400 }}
+                >
+                  {value}
+                </button>
+              ))}
+              <button type="button" onClick={() => void loadFaq()}>
+                Refresh
+              </button>
+            </div>
+
+            <div style={{ display: 'grid', gap: 10 }}>
+              {faqItems.map((item) => (
+                <FaqEditor
+                  key={item.id}
+                  item={item}
+                  onChange={(next) =>
+                    setFaqItems((rows) => rows.map((row) => (row.id === next.id ? next : row)))
+                  }
+                  onSave={() => {
+                    const current = faqItems.find((row) => row.id === item.id) ?? item;
+                    void saveFaq(current);
+                  }}
+                  onDelete={() => void deleteFaq(item.id)}
+                />
+              ))}
+              {faqItems.length === 0 ? <p className="sub">No FAQ entries in this filter.</p> : null}
+            </div>
+          </>
+        )}
       </div>
     </PageShell>
+  );
+}
+
+function FaqEditor({
+  item,
+  onChange,
+  onSave,
+  onDelete,
+}: {
+  item: FaqRow;
+  onChange: (row: FaqRow) => void;
+  onSave: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div style={{ border: '1px solid #ddd', borderRadius: 12, padding: 14 }}>
+      <label style={{ display: 'block' }}>
+        <strong>Question</strong>
+        <input
+          value={item.question}
+          onChange={(e) => onChange({ ...item, question: e.target.value })}
+          style={{ width: '100%', marginTop: 6, padding: 8 }}
+        />
+      </label>
+      <label style={{ display: 'block', marginTop: 10 }}>
+        <strong>Answer</strong>
+        <textarea
+          value={item.answer}
+          onChange={(e) => onChange({ ...item, answer: e.target.value })}
+          rows={5}
+          style={{ width: '100%', marginTop: 6, padding: 8, boxSizing: 'border-box' }}
+        />
+      </label>
+      <div style={{ display: 'flex', gap: 12, marginTop: 10, flexWrap: 'wrap' }}>
+        <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <input
+            type="checkbox"
+            checked={item.published}
+            onChange={(e) =>
+              onChange({
+                ...item,
+                published: e.target.checked,
+                status: e.target.checked ? 'approved' : 'pending',
+              })
+            }
+          />
+          Published
+        </label>
+        <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <input
+            type="checkbox"
+            checked={item.pinned}
+            onChange={(e) => onChange({ ...item, pinned: e.target.checked })}
+          />
+          Pinned
+        </label>
+        <span className="sub">Views: {item.view_count}</span>
+      </div>
+      <div style={{ display: 'flex', gap: 8, marginTop: 12, flexWrap: 'wrap' }}>
+        <button type="button" onClick={onSave}>
+          Save
+        </button>
+        <button type="button" onClick={onDelete}>
+          Delete
+        </button>
+        <span className="sub">Status: {item.status}</span>
+      </div>
+    </div>
   );
 }

--- a/src/app/admin/faq/page.tsx
+++ b/src/app/admin/faq/page.tsx
@@ -130,7 +130,8 @@ export default function AdminFaqPage() {
     if (!token) return;
     if (tab === 'ask') void loadAsk();
     else void loadFaq();
-  }, [tab, token, loadAsk, loadFaq]);
+    // Load on tab change only; use Refresh after updating ADMIN_TOKEN to avoid partial-token 401s.
+  }, [tab, loadAsk, loadFaq]);
 
   async function askAction(path: string, id: number, body: Record<string, unknown>) {
     if (!token) return;
@@ -312,6 +313,7 @@ export default function AdminFaqPage() {
                             void askAction('/api/admin/ask/approve', item.id, {
                               answer: askAnswers[item.id] ?? '',
                               moderation_note: askNotes[item.id] ?? '',
+                              create_faq: Boolean((askAnswers[item.id] ?? '').trim()),
                             })
                           }
                         >

--- a/tests/faq-moderation.test.ts
+++ b/tests/faq-moderation.test.ts
@@ -6,11 +6,18 @@ import {
   normalizeFaqStatus,
   parsePinned,
   parsePositiveInt,
+  parseStrictBoolean,
   validateFaqAnswer,
   validateFaqQuestion,
 } from '../functions/_lib/faqModeration';
 
 describe('faq moderation helpers', () => {
+  it('parses strict boolean flags', () => {
+    expect(parseStrictBoolean(true)).toBe(true);
+    expect(parseStrictBoolean('false')).toBe(false);
+    expect(parseStrictBoolean('falsey')).toBeNull();
+  });
+
   it('parses positive integers fail-closed', () => {
     expect(parsePositiveInt(3)).toBe(3);
     expect(parsePositiveInt('4')).toBe(4);

--- a/tests/faq-moderation.test.ts
+++ b/tests/faq-moderation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  askStatusesForFilter,
+  isPublishedFaqStatus,
+  normalizeFaqStatus,
+  parsePinned,
+  parsePositiveInt,
+  validateFaqAnswer,
+  validateFaqQuestion,
+} from '../functions/_lib/faqModeration';
+
+describe('faq moderation helpers', () => {
+  it('parses positive integers fail-closed', () => {
+    expect(parsePositiveInt(3)).toBe(3);
+    expect(parsePositiveInt('4')).toBe(4);
+    expect(parsePositiveInt(0)).toBeNull();
+    expect(parsePositiveInt('abc')).toBeNull();
+  });
+
+  it('parses pinned values strictly', () => {
+    expect(parsePinned(1)).toBe(1);
+    expect(parsePinned(0)).toBe(0);
+    expect(parsePinned(2)).toBeNull();
+  });
+
+  it('validates FAQ question and answer', () => {
+    expect(validateFaqQuestion('  How do I join?  ')).toBeNull();
+    expect(validateFaqQuestion('   ')).toMatch(/required/i);
+    expect(validateFaqAnswer('Answer text', true)).toBeNull();
+    expect(validateFaqAnswer('', true)).toMatch(/required/i);
+    expect(validateFaqAnswer('', false)).toBeNull();
+  });
+
+  it('normalizes FAQ status values', () => {
+    expect(normalizeFaqStatus('approved')).toBe('approved');
+    expect(normalizeFaqStatus('PENDING')).toBe('pending');
+    expect(normalizeFaqStatus('hidden')).toBeNull();
+  });
+
+  it('maps ask inbox filters to status sets', () => {
+    expect(askStatusesForFilter('pending')).toEqual(['open', 'pending']);
+    expect(askStatusesForFilter('approved')).toEqual(['approved']);
+    expect(askStatusesForFilter('rejected')).toEqual(['rejected', 'hidden']);
+    expect(askStatusesForFilter('archived')).toEqual(['archived']);
+  });
+
+  it('detects published FAQ status', () => {
+    expect(isPublishedFaqStatus('approved')).toBe(true);
+    expect(isPublishedFaqStatus('pending')).toBe(false);
+  });
+});
+
+describe('admin auth fail-closed', () => {
+  it('rejects missing or invalid admin token', async () => {
+    const { requireAdmin } = await import('../functions/_lib/auth');
+
+    const unconfigured = requireAdmin(new Request('https://example.com'), { ADMIN_TOKEN: '' });
+    expect(unconfigured?.status).toBe(503);
+
+    const unauthorized = requireAdmin(new Request('https://example.com'), { ADMIN_TOKEN: 'secret' });
+    expect(unauthorized?.status).toBe(401);
+
+    const ok = requireAdmin(
+      new Request('https://example.com', { headers: { 'x-admin-token': 'secret' } }),
+      { ADMIN_TOKEN: 'secret' },
+    );
+    expect(ok).toBeNull();
+  });
+});


### PR DESCRIPTION
- **Issue**: #1053

## Merge outcome (pre-merge)
- **Intended design:** T23 — FAQ CMS moderation per assigned Cursor brief and `faq-system.md`.
- **Scope delivered:** PASS (pending merge) — ask inbox moderation, FAQ CRUD/publish, admin UI, APIs, tests, task-number documentation.
- **Quality gate:** pending CI on `2643207`

## T23 label conflict acknowledged (intentional reassignment)
- **T23 label conflict acknowledged:** Historical worklist entry “T23 — Events page” collided with this assignment.
- **This PR implements FAQ CMS moderation** per the assigned Cursor brief—not Events, not homepage drift.
- **Events page remains a follow-up task** renumbered to **T23-E** in `IMPLEMENTATION-WORKLIST_Master.md` and `docs/ops/tasks/T23-E.md`.
- `/events`, calendar infrastructure, and events APIs already exist historically; T23-E is stabilization, not greenfield.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [ ] OR any ZIP file that was present in the repo root was deleted before any other change
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Phase 3 — Public Core Features
- Task: T23 — FAQ CMS moderation and management
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: none

## DOCUMENTATION SOURCE (MANDATORY)
- [ ] DIATAXIS_FULL
- [x] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `/docs/reference/design/faq-and-ask.md`
- `/docs/reference/architecture/faq-system.md`
- `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- `/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md` (T23 / T23-E reassignment note)

## LABEL
- Intent label for this PR: `feature`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `migrations/0034_ask_inbox_moderation.sql`
- `functions/_lib/faqModeration.ts`
- `functions/api/admin/faq/list.ts`
- `functions/api/admin/faq/create.ts`
- `functions/api/admin/faq/update.ts`
- `functions/api/admin/faq/delete.ts`
- `functions/api/admin/ask/list.ts`
- `functions/api/admin/ask/approve.ts`
- `functions/api/admin/ask/reject.ts`
- `functions/api/admin/ask/archive.ts`
- `src/app/admin/faq/page.tsx`
- `tests/faq-moderation.test.ts`
- `docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
- `docs/ops/tasks/T23-E.md`
- `docs/ops/tasks/T23-M-faq-cms-moderation.md`
- `docs/ops/tasks/T23-A.md`

All other files are out of scope.

## CHANGE SUMMARY
- Add ask inbox moderation APIs (list/approve/reject/archive) with explicit `create_faq` when publishing an answer.
- Add FAQ admin list/create/update/delete routes with strict validation and fail-closed auth.
- Extend `ask_inbox` with `moderation_note` and `faq_entry_id` (migration `0034`).
- Rebuild `/admin/faq` with Ask Inbox + FAQ CMS tabs (operational UI only).
- Document intentional T23 (FAQ CMS) vs T23-E (Events) task reassignment in worklist/task docs.
- Add `tests/faq-moderation.test.ts`.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `npm run typecheck`
  - `npm run test -- tests/faq-moderation.test.ts`
- Result summary:
  - PASS — typecheck
  - CI pending — moderation tests on GitHub Actions

## REVIEWER RESPONSE ACCOUNTING
- [x] Copilot disposition received: strict publish/pinned parsing and prior findings addressed on `2643207`.
- [x] Reviewed selected reviewer comments.
- [x] Accepted / rejected / ignored each actionable selected-reviewer comment with rationale.
- [x] Reviewed all reviewer comments.
- [x] Gemini disposition received: `any` typing on D1 handle acknowledged; matches existing admin API pattern.
- [x] Codex disposition received: prior-head P1 superseded by guarded approve UPDATE on `2643207`.
- [x] Cubic disposition received: auto-summary only.

Reviewer items:
- review-comment:3273291519 — accepted — `parseStrictBoolean` + require valid `pinned` on create (2643207).
- review-comment:3273291620 — accepted — strict `published`/`approved` parsing on update (2643207).
- review-comment:3273291424 — accepted — `create_faq` only when UI sends `create_faq: true` with answer (2643207).
- review-comment:3273291486 — accepted — approve UPDATE guarded by pending status; removed redundant `created_at` assignment (2643207).
- review-comment:3273291556 — accepted — delete returns 404 when no row updated (2643207).
- review-comment:3273291591 — accepted — load on tab change only; Refresh after token paste (2643207).
- review-comment:3273301907 — ignored — D1 `any` matches existing Pages Functions admin routes; no shared D1 type in repo.
- review-comment:3273285989 — accepted — pending-status guard on approve UPDATE prevents duplicate publish race (2643207).

## ACCEPTANCE CRITERIA
- [x] Admins can moderate ask submissions (pending/approved/rejected/archived)
- [x] Admins can create/edit/delete/pin/publish FAQs
- [x] Public FAQ list behavior unchanged
- [x] Task reassignment documented (T23 FAQ CMS vs T23-E Events)
- [ ] CI passes fully (pending)

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains required sections
- [x] Allowlist matches diff
- [x] No homepage/nav/footer changes
- [x] Local typecheck passed

## D1 OPS AFTER MERGE
- Apply `migrations/0033_ask_inbox.sql` if not already applied.
- Apply `migrations/0034_ask_inbox_moderation.sql`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ask inbox moderation and a simple FAQ CMS (APIs + `/admin/faq` UI) to review asks, publish FAQs, and manage entries. Meets T23 requirements in #1053; hardens admin gating/validation and keeps public FAQ output unchanged (events work tracked under T23-E).

- **New Features**
  - Ask moderation APIs: list, approve (optional FAQ create), reject, archive; pending-only approve guard.
  - FAQ admin APIs: list, create, update (question/answer/status/pinned/published), soft delete.
  - Admin UI: Ask Inbox + FAQ tabs; approve/reject/archive; create/edit/publish/pin; filters and refresh; explicit `create_faq` on approve when an answer is provided.
  - Validation/auth: strict input parsing; admin routes require `x-admin-token` and fail closed.
  - Tests: moderation helpers and admin auth coverage.

- **Migration**
  - Apply `migrations/0034_ask_inbox_moderation.sql` (adds `moderation_note`, `faq_entry_id`).
  - Ensure `ADMIN_TOKEN` is set; send it via the `x-admin-token` header on admin routes.

<sup>Written for commit 8ae47f7d4ae631a8764f97258b204df67407a964. Summary will update on new commits. <a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1072?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

