### PR TITLE
feat(fanclub): T32 library/memorabilia read-only views + tracker alignment

### DIFF
--- a/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
+++ b/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
@@ -352,16 +352,24 @@ Progress:
 - Branch: `feat/t30-fanclub-shell-1013`
 
 ## T31 — Member Profile + membership card panel
-Status: IN REVIEW (PR #1093)
+Status: CLOSED
+Date Closed: 2026-05-27
 Issue: #1014
 Scope: `/fanclub/myprofile` and `/fanclub/membercard` pages only.
 Exit: launch-safe profile/membercard pages with stable cross-page FanClub navigation.
-Progress:
-- Implementation PR opened: #1093
-- Branch: `feat/t31-profile-membercard-1014`
+Summary:
+Profile and membercard pages are merged with dedicated `/fanclub/membercard` presentation and stable cross-page FanClub navigation.
+Issue/PR trace:
+- Implementation PR: #1093
+- Tracker sync PR: #1094
 
-## T32 — Member Chat Day-1 flow
-Status: OPEN
+## T32 — Fan Club library and memorabilia pages
+Status: IN REVIEW
+Issue: #1015
+Scope: `/fanclub/library` and `/fanclub/memorabilia` read-only presentation, plus safe member navigation between FanClub pages.
+Exit: library and memorabilia pages render safely with no admin/upload workflow expansion.
+Progress:
+- Implementation branch: `feat/t32-library-memorabilia-1015`
 
 ---
 

--- a/src/app/fanclub/library/page.tsx
+++ b/src/app/fanclub/library/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useMemberSession } from '@/hooks/useMemberSession';
 
@@ -12,36 +13,43 @@ const styles: Record<string, React.CSSProperties> = {
   p: { fontSize: 16, lineHeight: 1.7, margin: '0 0 14px 0' },
   grid: { display: 'grid', gridTemplateColumns: '1fr', gap: 18 },
   card: { border: '1px solid rgba(0,0,0,0.15)', borderRadius: 16, padding: 16 },
-  form: { display: 'grid', gap: 10 },
   label: { display: 'grid', gap: 6, fontSize: 14 },
   input: { padding: '10px 12px', fontSize: 16, borderRadius: 10, border: '1px solid rgba(0,0,0,0.2)' },
-  textarea: { padding: '10px 12px', fontSize: 16, borderRadius: 10, border: '1px solid rgba(0,0,0,0.2)', minHeight: 120 },
-  btn: { padding: '10px 14px', fontSize: 16, borderRadius: 12, border: '1px solid rgba(0,0,0,0.2)', cursor: 'pointer' },
-  msg: { marginTop: 10, padding: 12, borderRadius: 12, border: '1px solid rgba(0,0,0,0.15)' },
+  btn: { padding: '10px 14px', fontSize: 15, borderRadius: 12, border: '1px solid rgba(0,0,0,0.2)', cursor: 'pointer', textDecoration: 'none' },
   meta: { opacity: 0.75, fontSize: 13, marginTop: 6 },
   hr: { margin: '18px 0', opacity: 0.25 },
 };
 
 export default function LibraryPage() {
-  const { isLoading, isAuthenticated, email } = useMemberSession({ redirectTo: '/' });
+  const { isLoading, isAuthenticated } = useMemberSession({ redirectTo: '/' });
   const [items, setItems] = useState<LibraryItem[]>([]);
   const [loading, setLoading] = useState(false);
-  const [submitBusy, setSubmitBusy] = useState(false);
-  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null);
-  const [name, setName] = useState('');
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
+  const [message, setMessage] = useState('');
+  const [query, setQuery] = useState('');
 
-  const canSubmit = useMemo(() => {
-    return name.trim().length >= 2 && email.includes('@') && title.trim().length >= 3 && content.trim().length >= 10;
-  }, [name, email, title, content]);
+  const filteredItems = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return items;
+    return items.filter((it) => {
+      return it.title.toLowerCase().includes(needle) || it.content.toLowerCase().includes(needle);
+    });
+  }, [items, query]);
 
   async function load() {
     setLoading(true);
+    setMessage('');
     try {
       const res = await fetch('/api/library/list?limit=20', { cache: 'no-store' });
       const data = await res.json().catch(() => ({}));
-      if (res.ok && data?.ok) setItems(Array.isArray(data.items) ? data.items : []);
+      if (res.ok && data?.ok) {
+        setItems(Array.isArray(data.items) ? data.items : []);
+      } else {
+        setItems([]);
+        setMessage(data?.error || 'Unable to load library items right now.');
+      }
+    } catch {
+      setItems([]);
+      setMessage('Unable to load library items right now.');
     } finally {
       setLoading(false);
     }
@@ -53,39 +61,6 @@ export default function LibraryPage() {
     }
   }, [isLoading, isAuthenticated]);
 
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!canSubmit || submitBusy) return;
-
-    setSubmitBusy(true);
-    setResult(null);
-    try {
-      const res = await fetch('/api/library/submit', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: name.trim(),
-          email: email.trim().toLowerCase(),
-          title: title.trim(),
-          content: content.trim(),
-        }),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (res.ok && data?.ok) {
-        setResult({ ok: true, message: 'Submitted. Thank you — entries appear publicly once approved.' });
-        setTitle('');
-        setContent('');
-        await load();
-      } else {
-        setResult({ ok: false, message: data?.error || 'Submission failed.' });
-      }
-    } catch (err: unknown) {
-      setResult({ ok: false, message: String((err as Error)?.message || err) });
-    } finally {
-      setSubmitBusy(false);
-    }
-  }
-
   if (isLoading || !isAuthenticated) {
     return null;
   }
@@ -94,42 +69,34 @@ export default function LibraryPage() {
     <main style={styles.main}>
       <h1 style={styles.h1}>Library</h1>
       <p style={styles.lead}>
-        Submit short, source-aware entries about Lou Gehrig and the surrounding history: stories, quotes, timelines, book notes, and links to trustworthy resources.
+        A read-only member view of library entries about Lou Gehrig and related history.
       </p>
       <p style={styles.p}>
-        Guidelines: be respectful, don’t upload copyrighted material you don’t own, cite sources when you can, and keep it focused. Depth comes from cross-referencing, not from a single link.
+        Use search to quickly locate entries by title or body text, then jump to memorabilia or other Fan Club pages from the links below.
       </p>
 
       <div style={styles.grid}>
         <section style={styles.card}>
-          <h2 style={{ margin: 0 }}>Submit an entry</h2>
+          <h2 style={{ margin: 0 }}>Browse entries</h2>
           <hr style={styles.hr} />
-          <form style={styles.form} onSubmit={submit}>
-            <label style={styles.label}>
-              Name
-              <input style={styles.input} value={name} onChange={(e) => setName(e.target.value)} />
-            </label>
-            <label style={styles.label}>
-              Email
-              <input style={{ ...styles.input, background: 'rgba(0,0,0,0.04)' }} value={email} readOnly />
-            </label>
-            <label style={styles.label}>
-              Title
-              <input style={styles.input} value={title} onChange={(e) => setTitle(e.target.value)} />
-            </label>
-            <label style={styles.label}>
-              Entry
-              <textarea style={styles.textarea} value={content} onChange={(e) => setContent(e.target.value)} />
-            </label>
-            <button style={styles.btn} disabled={!canSubmit || submitBusy} type="submit">
-              {submitBusy ? 'Submitting...' : 'Submit'}
-            </button>
-          </form>
-          {result && (
-            <div style={styles.msg}>
-              <strong>{result.ok ? 'Success' : 'Error'}:</strong> {result.message}
-            </div>
-          )}
+          <label style={styles.label}>
+            Search
+            <input
+              style={styles.input}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search titles or entry text"
+            />
+          </label>
+          <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 10 }}>
+            <Link href="/fanclub/memorabilia" style={styles.btn}>
+              View Memorabilia
+            </Link>
+            <Link href="/fanclub" style={styles.btn}>
+              Back to Fan Club Home
+            </Link>
+          </div>
+          {message ? <p style={{ ...styles.p, marginTop: 12 }}>{message}</p> : null}
         </section>
 
         <section style={styles.card}>
@@ -137,10 +104,10 @@ export default function LibraryPage() {
           <hr style={styles.hr} />
           {loading ? (
             <p style={styles.p}>Loading…</p>
-          ) : items.length === 0 ? (
+          ) : filteredItems.length === 0 ? (
             <p style={styles.p}>No entries yet.</p>
           ) : (
-            items.map((it) => (
+            filteredItems.map((it) => (
               <article key={it.id} style={{ marginBottom: 14 }}>
                 <h3 style={{ margin: '0 0 6px 0' }}>{it.title}</h3>
                 <div style={styles.meta}>{new Date(it.created_at).toLocaleString()}</div>

--- a/src/app/fanclub/memorabilia/page.tsx
+++ b/src/app/fanclub/memorabilia/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 import { useMemberSession } from '@/hooks/useMemberSession';
 import { buildFanclubPhotoListApiUrl } from '@/lib/fanclubApi';
@@ -23,10 +24,13 @@ export default function MemorabiliaPage() {
   const [items, setItems] = useState<MemorabiliaItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [offset, setOffset] = useState(0);
+  const [message, setMessage] = useState('');
+  const [query, setQuery] = useState('');
   const limit = 24;
 
   async function load(nextOffset: number) {
     setLoading(true);
+    setMessage('');
     try {
       const res = await fetch(buildFanclubPhotoListApiUrl({ limit, offset: nextOffset, memorabilia: true }));
       const data = await res.json().catch(() => ({}));
@@ -34,6 +38,14 @@ export default function MemorabiliaPage() {
         const incoming = Array.isArray(data.items) ? data.items : [];
         if (nextOffset === 0) setItems(incoming);
         else setItems((prev) => [...prev, ...incoming]);
+      } else if (nextOffset === 0) {
+        setItems([]);
+        setMessage(data?.error || 'Unable to load memorabilia items right now.');
+      }
+    } catch {
+      if (nextOffset === 0) {
+        setItems([]);
+        setMessage('Unable to load memorabilia items right now.');
       }
     } finally {
       setLoading(false);
@@ -50,13 +62,32 @@ export default function MemorabiliaPage() {
     return null;
   }
 
+  const filtered = query.trim()
+    ? items.filter((p) => {
+        const title = (p.title || '').toLowerCase();
+        const description = (p.description || '').toLowerCase();
+        const needle = query.trim().toLowerCase();
+        return title.includes(needle) || description.includes(needle);
+      })
+    : items;
+
   return (
     <main style={{ ...styles.main }}>
       <h1 style={{ ...styles.h1 }}>Memorabilia</h1>
-      <p style={{ ...styles.lead }}>A filtered view of memorabilia-tagged records sourced from the photos archive.</p>
+      <p style={{ ...styles.lead }}>A read-only view of memorabilia-tagged records sourced from the photo archive.</p>
+      <label style={{ display: 'grid', gap: 6, fontSize: 14, marginBottom: 14 }}>
+        Search
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search title or description"
+          style={{ padding: '10px 12px', fontSize: 16, borderRadius: 10, border: '1px solid rgba(0,0,0,0.2)' }}
+        />
+      </label>
+      {message ? <p style={{ opacity: 0.85 }}>{message}</p> : null}
 
       <div style={{ ...styles.grid }}>
-        {items.map((p) => (
+        {filtered.map((p) => (
           <div key={p.id} style={{ ...styles.card }}>
             {p.thumbnail_url ? (
               <img src={p.thumbnail_url} alt={p.description || p.title || `Item ${p.id}`} style={{ ...styles.img }} />
@@ -67,6 +98,7 @@ export default function MemorabiliaPage() {
           </div>
         ))}
       </div>
+      {!loading && filtered.length === 0 ? <p style={{ marginTop: 14, opacity: 0.85 }}>No memorabilia items found.</p> : null}
 
       <div style={{ ...styles.btnRow }}>
         <button
@@ -80,9 +112,15 @@ export default function MemorabiliaPage() {
         >
           {loading ? 'Loading...' : 'Load more'}
         </button>
-        <a style={{ ...styles.btn, textDecoration: 'none' }} href="/fanclub/photo">
+        <Link style={{ ...styles.btn }} href="/fanclub/photo">
           View photos
-        </a>
+        </Link>
+        <Link style={{ ...styles.btn }} href="/fanclub/library">
+          View library
+        </Link>
+        <Link style={{ ...styles.btn }} href="/fanclub">
+          Back to Fan Club Home
+        </Link>
       </div>
     </main>
   );


### PR DESCRIPTION
- **Issue:** #1015

## Documentation source classification
- Type: Website implementation (T32) + tracker alignment closeout
- Task authority: Issue #1015

## Design source of truth
- docs/reference/design/LGFC-Production-Design-and-Standards.md

## FILE-TOUCH ALLOWLIST
- src/app/fanclub/library/**
- src/app/fanclub/memorabilia/**
- docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md

## Change summary
- Implemented launch-safe read-only library presentation with search/filter and robust empty/error handling.
- Implemented memorabilia presentation hardening with search/filter, safer loading behavior, and stable FanClub navigation links.
- Updated tracker alignment: T31 moved to CLOSED with merge trace; T32 moved to IN REVIEW with issue/branch scope.

## Build/test/verification evidence
- npm run lint: pass (existing repository warnings only)
- npm run build: pass
- git diff --name-only HEAD~1: docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md, src/app/fanclub/library/page.tsx, src/app/fanclub/memorabilia/page.tsx

## Acceptance criteria
- [x] Library page renders safely as read-only presentation
- [x] Memorabilia page renders safely as read-only presentation
- [x] Fan Club navigation remains stable
- [x] Tracker reflects T31 closeout + T32 active implementation state

## Required pre-review self-check
- [x] Exactly one primary issue linked
- [x] Scope aligned to T32 + tracker alignment request
- [x] No homepage/public header/footer regressions introduced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds launch-safe, read-only views for Fan Club Library and Memorabilia with search/filter, clearer empty/error states, and stable in-app navigation. Updates the tracker to close T31 and move T32 (issue #1015) to In Review.

- New Features
  - Library: read-only view; removed submit form; added client-side search; improved loading/empty/error feedback; links to Memorabilia and Fan Club Home; internal links use `next/link`.
  - Memorabilia: read-only list from the photo archive; added search by title/description; safer first-load and error handling; clear “no results” message; stable links to Photos, Library, and Fan Club Home; “Load more” behavior preserved.

- Tracker Alignment
  - T31 marked Closed with a concise summary and merge trace in the tracker.
  - T32 (issue #1015) marked In Review with scope limited to read-only `/fanclub/library` and `/fanclub/memorabilia` plus stable navigation.

<sup>Written for commit 7f1fa5b8e915e7f56070bc2b6f165f33f9b2efa7. Summary will update on new commits. <a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1095?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->