### PR TITLE
fix(home): T33 Social Wall production-safe integration

### DIFF
--- a/src/components/SocialWall.tsx
+++ b/src/components/SocialWall.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import styles from './social-wall.module.css';
 
 const PLATFORM_SRC = 'https://elfsightcdn.com/platform.js';
@@ -15,13 +15,27 @@ declare global {
 }
 
 export default function SocialWall() {
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
   useEffect(() => {
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     const existingScript = document.querySelector<HTMLScriptElement>(
       `script[src="${PLATFORM_SRC}"]`
     );
 
     const init = () => {
+      if (cancelled) return;
+      if (timeoutId) clearTimeout(timeoutId);
       window.elfsight?.reload?.();
+      setStatus('ready');
+    };
+
+    const fail = () => {
+      if (cancelled) return;
+      if (timeoutId) clearTimeout(timeoutId);
+      setStatus('error');
     };
 
     if (!existingScript) {
@@ -29,10 +43,23 @@ export default function SocialWall() {
       script.src = PLATFORM_SRC;
       script.async = true;
       script.onload = init;
+      script.onerror = fail;
       document.body.appendChild(script);
     } else {
-      init();
+      if (window.elfsight) {
+        init();
+      } else {
+        existingScript.addEventListener('load', init, { once: true });
+        existingScript.addEventListener('error', fail, { once: true });
+      }
     }
+
+    timeoutId = setTimeout(fail, 8000);
+
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
   }, []);
 
   return (
@@ -41,7 +68,14 @@ export default function SocialWall() {
         <h2 className={styles.sectionTitle}>Social Wall</h2>
         <p className={styles.subtitle}>Live fan posts from Facebook.</p>
         <div className={styles.embed}>
-          <p className={styles.fallback}>Loading social wall content...</p>
+          {status === 'loading' ? (
+            <p className={styles.fallback}>Loading social wall content...</p>
+          ) : null}
+          {status === 'error' ? (
+            <p className={styles.fallback}>
+              Social wall is temporarily unavailable. Please check back soon.
+            </p>
+          ) : null}
           <div className={WIDGET_ID} data-elfsight-app-lazy />
         </div>
       </div>


### PR DESCRIPTION
- **Issue:** #1016

## Documentation source classification
- Type: Website implementation task (T33)
- Task authority: Issue #1016

## Design source of truth
- docs/reference/design/LGFC-Production-Design-and-Standards.md

## FILE-TOUCH ALLOWLIST
- src/components/SocialWall*
- src/app/page*

## Change summary
- Hardened Social Wall production integration script lifecycle.
- Added explicit timeout and error-state fallback messaging so embed failure does not break homepage render.
- Preserved canonical homepage section order and Social Wall placement.

## Build/test/verification evidence
- npm run lint: pass (existing repository warnings only)
- npm run build: pass
- git diff --name-only HEAD~1: src/components/SocialWall.tsx

## Acceptance criteria
- [x] Social Wall renders consistently in production-safe flow
- [x] Failed embeds do not break homepage rendering
- [x] Homepage section order remains canonical

## Required pre-review self-check
- [x] Exactly one primary issue linked
- [x] Scope limited to issue allowlist
- [x] No unrelated homepage/footer/header changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Social Wall embed production-safe by adding resilient script loading with an 8s timeout and error fallback, so failures don’t block the homepage. Addresses #1016 (T33) and keeps the canonical section order.

- **Bug Fixes**
  - Added loading/error UI state to show fallback messages.
  - Wired `platform.js` with `onload`/`onerror` and listeners when the script already exists.
  - Set an 8s timeout to fail gracefully if the script doesn’t load.
  - Reloads the widget when ready via `window.elfsight.reload()`.

<sup>Written for commit 4239b1b5bd5adabc8cbfefb9ce241aea22b9f812. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1097?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->