### PR TITLE
ci: fix intent-labeler issues API permissions

### DIFF
--- a/.github/workflows/gate-intent-labeler.yml
+++ b/.github/workflows/gate-intent-labeler.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
   contents: read
 
 jobs:


### PR DESCRIPTION
- **Issue:** #1058

## Documentation source classification
- Type: CI workflow fix
- Scope: intent labeler permission correction

## Design source of truth
- docs/reference/design/LGFC-Production-Design-and-Standards.md

## FILE-TOUCH ALLOWLIST
- .github/workflows/gate-intent-labeler.yml

## Change summary
- Add issues: write permission to gate-intent-labeler workflow.
- Resolve 404 failures against issues label endpoints used by label-intent automation.

## Build/test/verification evidence
- Verification via failing logs showed 404 at /issues/<pr>/labels with missing issue permission.

## Acceptance criteria
- [x] label-intent workflow can read/apply intent labels without API permission failure
- [x] drift-gate can receive required single intent label from labeler

## Required pre-review self-check
- [x] Single-intent CI workflow fix
- [x] One primary issue reference
- [x] No unrelated code/runtime changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant `issues: write` to the intent labeler workflow to fix 404s when applying labels. This unblocks label-intent and lets drift-gate validate a single intent label.

- **Bug Fixes**
  - Added `issues: write` in `.github/workflows/gate-intent-labeler.yml`.
  - Stops 404s on issues label endpoints and restores label application.

<sup>Written for commit 31f67457556e05f3e4e488bdb1aa737c769a4f92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1100?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->