### PR TITLE
feat(home): complete T34 D1 dynamic homepage wiring

### DIFF
--- a/src/components/MilestonesSection.tsx
+++ b/src/components/MilestonesSection.tsx
@@ -49,6 +49,7 @@ const compareMilestones = (a: Milestone, b: Milestone): number => {
 export default function MilestonesSection() {
   const [items, setItems] = useState<Milestone[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -63,8 +64,11 @@ export default function MilestonesSection() {
           : [];
 
         setItems([...normalized].sort(compareMilestones));
+        setError(null);
       } catch {
-        if (alive) setItems([]);
+        if (!alive) return;
+        setItems([]);
+        setError('Unable to load milestones right now.');
       } finally {
         if (alive) setLoading(false);
       }
@@ -82,6 +86,8 @@ export default function MilestonesSection() {
 
       {loading ? (
         <p className="sub">Loading milestones…</p>
+      ) : error ? (
+        <p className="sub">{error}</p>
       ) : items.length === 0 ? (
         <p className="sub">No milestones are available yet.</p>
       ) : (

--- a/src/components/RecentDiscussionsTeaser.tsx
+++ b/src/components/RecentDiscussionsTeaser.tsx
@@ -10,18 +10,64 @@ type Discussion = {
   created_at: string;
 };
 
+const safeText = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const normalizeDiscussion = (raw: unknown): Discussion | null => {
+  if (!raw || typeof raw !== 'object') return null;
+  const candidate = raw as Partial<Discussion>;
+  if (typeof candidate.id !== 'number') return null;
+
+  const title = safeText(candidate.title) ?? 'Untitled discussion';
+  const body = safeText(candidate.body) ?? 'No discussion text available.';
+  const createdAt = safeText(candidate.created_at) ?? '';
+
+  return {
+    id: candidate.id,
+    title,
+    body,
+    created_at: createdAt,
+  };
+};
+
+const formatCreatedAt = (raw: string): string => {
+  const parsed = Date.parse(raw);
+  if (Number.isNaN(parsed)) return raw || 'Unknown date';
+
+  return new Date(parsed).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
 export default function RecentDiscussionsTeaser() {
   const [items, setItems] = useState<Discussion[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
     (async () => {
       try {
         const data = await apiGet<{ ok: boolean; items: Discussion[] }>(`/api/discussions/list?limit=5`);
-        if (alive) setItems(data.items || []);
+        if (!alive) return;
+
+        const normalized = Array.isArray(data.items)
+          ? data.items
+              .map((item) => normalizeDiscussion(item))
+              .filter((item): item is Discussion => item !== null)
+          : [];
+
+        setItems(normalized);
+        setError(null);
       } catch {
-        if (alive) setItems([]);
+        if (!alive) return;
+        setItems([]);
+        setError('Unable to load discussions right now.');
       } finally {
         if (alive) setLoading(false);
       }
@@ -40,6 +86,8 @@ export default function RecentDiscussionsTeaser() {
 
       {loading ? (
         <p className="sub" style={{ textAlign: 'center' }}>Loading…</p>
+      ) : error ? (
+        <p className="sub" style={{ textAlign: 'center' }}>{error}</p>
       ) : items.length === 0 ? (
         <p className="sub" style={{ textAlign: 'center' }}>No posts yet (D1 table is empty).</p>
       ) : (
@@ -50,7 +98,9 @@ export default function RecentDiscussionsTeaser() {
               <p className="sub" style={{ marginTop: 10 }}>
                 {p.body.length > 180 ? `${p.body.slice(0, 180)}…` : p.body}
               </p>
-              <div className="sub" style={{ marginTop: 10, opacity: 0.75 }}>Posted: {p.created_at}</div>
+              <div className="sub" style={{ marginTop: 10, opacity: 0.75 }}>
+                Posted: {formatCreatedAt(p.created_at)}
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/RecentDiscussionsTeaser.tsx
+++ b/src/components/RecentDiscussionsTeaser.tsx
@@ -36,12 +36,8 @@ const normalizeDiscussion = (raw: unknown): Discussion | null => {
 const formatCreatedAt = (raw: string): string => {
   const parsed = Date.parse(raw);
   if (Number.isNaN(parsed)) return raw || 'Unknown date';
-
-  return new Date(parsed).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
+  // Keep formatting deterministic across prerender + hydration.
+  return new Date(parsed).toISOString().slice(0, 10);
 };
 
 export default function RecentDiscussionsTeaser() {
@@ -56,11 +52,10 @@ export default function RecentDiscussionsTeaser() {
         const data = await apiGet<{ ok: boolean; items: Discussion[] }>(`/api/discussions/list?limit=5`);
         if (!alive) return;
 
-        const normalized = Array.isArray(data.items)
-          ? data.items
+        const sourceItems = Array.isArray(data?.items) ? data.items : [];
+        const normalized = sourceItems
               .map((item) => normalizeDiscussion(item))
-              .filter((item): item is Discussion => item !== null)
-          : [];
+              .filter((item): item is Discussion => item !== null);
 
         setItems(normalized);
         setError(null);


### PR DESCRIPTION
- **Issue:** #1017

## Documentation source classification
- Type: website implementation (homepage dynamic wiring hardening)
- Scope: T34 milestones + discussions preview sections

## Design source of truth
- /docs/reference/design/LGFC-Production-Design-and-Standards.md

## FILE-TOUCH ALLOWLIST
- src/components/MilestonesSection.tsx
- src/components/RecentDiscussionsTeaser.tsx

## Change summary
- Added strict normalization for discussion payload rows before render to avoid malformed data breaking the homepage section.
- Added explicit error states for milestones and discussions sections while preserving existing empty/loading states.
- Improved discussion timestamp rendering with safe date formatting fallback.

## Build/test/verification evidence
- `npm run typecheck` ✅ pass
- `npm run lint` ✅ pass with existing repository warnings only (no new errors introduced)
- `npm run test:homepage-structure` ⚠️ local environment issue: missing `/home/billhunter71/next-starter-template/vitest.setup.ts` (known nested-workspace path issue, not caused by this diff)

## Acceptance criteria
- [x] Homepage dynamic sections load from D1-backed data paths (`/api/milestones/list`, `/api/discussions/list`)
- [x] Safe empty/error states exist for both sections
- [x] Homepage section order remains canonical

## Required pre-review self-check
- [x] Single task scope (T34)
- [x] One primary source issue
- [x] No unrelated runtime/config/docs changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the T34 dynamic homepage by normalizing D1 data and adding clear error states. Uses deterministic UTC date formatting to prevent hydration drift in discussions while continuing to load from `/api/milestones/list` and `/api/discussions/list?limit=5`.

- **Bug Fixes**
  - Normalize discussion payload with optional-chaining guards and safe defaults for title, body, and date.
  - Add explicit error states to `MilestonesSection` and `RecentDiscussionsTeaser`; keep loading/empty states.

<sup>Written for commit 32d555d6756412533e2ffcde87beb2f25f0449aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1101?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->