### PR TITLE
feat(fanclub): T35 FanClub home composition pass

### DIFF
--- a/src/app/fanclub/page.tsx
+++ b/src/app/fanclub/page.tsx
@@ -1,55 +1,33 @@
 'use client';
 
-import Link from 'next/link';
+import { useState } from 'react';
 import FloatingLogo from '@/components/FloatingLogo';
 import AdminLink from '@/components/fanclub/AdminLink';
+import ArchivesTiles from '@/components/fanclub/ArchivesTiles';
+import DiscussionFeed from '@/components/fanclub/DiscussionFeed';
+import GehrigTimeline from '@/components/fanclub/GehrigTimeline';
+import PostCreation from '@/components/fanclub/PostCreation';
+import WelcomeSection from '@/components/fanclub/WelcomeSection';
 import { useMemberSession } from '@/hooks/useMemberSession';
 
-type NavCard = {
-  href: string;
-  title: string;
-  description: string;
+const sectionStackStyle = {
+  maxWidth: 1100,
+  margin: '0 auto',
+  padding: '0 20px 40px',
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: 20,
 };
-
-const FANCLUB_NAV: NavCard[] = [
-  {
-    href: '/fanclub/myprofile',
-    title: 'My Profile',
-    description: 'View and manage your member profile details.',
-  },
-  {
-    href: '/fanclub/library',
-    title: 'Library',
-    description: 'Browse fan club library entries and references.',
-  },
-  {
-    href: '/fanclub/memorabilia',
-    title: 'Memorabilia',
-    description: 'Explore memorabilia highlights curated for members.',
-  },
-  {
-    href: '/fanclub/photo',
-    title: 'Member Photos',
-    description: 'See member photo uploads and visual highlights.',
-  },
-  {
-    href: '/fanclub/submit',
-    title: 'Submit Content',
-    description: 'Send new content for fan club review and publishing.',
-  },
-  {
-    href: '/fanclub/chat',
-    title: 'Member Chat',
-    description: 'Join member discussion threads and ongoing conversation.',
-  },
-];
 
 export default function MemberHomePage() {
   const { isLoading, isAuthenticated, email, role } = useMemberSession({ redirectTo: '/' });
+  const [feedRefresh, setFeedRefresh] = useState(0);
 
   if (isLoading || !isAuthenticated) {
     return null;
   }
+
+  const memberEmail = email || '';
 
   return (
     <main>
@@ -59,57 +37,21 @@ export default function MemberHomePage() {
           fontSize: 32,
           fontWeight: 700,
           textAlign: 'center',
-          margin: '40px 20px 32px 20px',
+          margin: '40px 20px 24px',
           color: 'var(--lgfc-blue)',
         }}
       >
         WELCOME LOU GEHRIG FAN CLUB MEMBERS
       </h1>
 
-      <section
-        aria-label="FanClubMemberShell"
-        style={{
-          maxWidth: 1100,
-          margin: '0 auto',
-          padding: '0 20px',
-        }}
-      >
-        <p style={{ margin: '0 0 20px 0', color: 'rgba(0,0,0,0.72)', lineHeight: 1.55 }}>
-          Signed in as <strong>{email || 'member'}</strong>. Use the member areas below to navigate the
-          Fan Club experience.
-        </p>
-
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
-            gap: 12,
-          }}
-        >
-          {FANCLUB_NAV.map((card) => (
-            <Link
-              key={card.href}
-              href={card.href}
-              style={{
-                display: 'block',
-                textDecoration: 'none',
-                color: 'inherit',
-                border: '1px solid rgba(0,0,0,0.12)',
-                borderRadius: 12,
-                padding: 14,
-                background: '#fff',
-              }}
-            >
-              <div style={{ fontSize: 16, fontWeight: 700 }}>{card.title}</div>
-              <p style={{ margin: '8px 0 0 0', fontSize: 14, color: 'rgba(0,0,0,0.7)', lineHeight: 1.45 }}>
-                {card.description}
-              </p>
-            </Link>
-          ))}
-        </div>
-      </section>
-
-      <AdminLink isAdmin={role === 'admin'} />
+      <div style={sectionStackStyle} aria-label="FanClubHomeSections">
+        <WelcomeSection email={memberEmail} />
+        <ArchivesTiles />
+        <PostCreation email={memberEmail} onPostCreated={() => setFeedRefresh((n) => n + 1)} />
+        <DiscussionFeed refreshTrigger={feedRefresh} />
+        <GehrigTimeline />
+        <AdminLink isAdmin={role === 'admin'} />
+      </div>
     </main>
   );
 }

--- a/src/components/fanclub/ArchivesTiles.tsx
+++ b/src/components/fanclub/ArchivesTiles.tsx
@@ -1,8 +1,55 @@
+import Link from 'next/link';
+
+const ARCHIVE_LINKS = [
+  {
+    href: '/fanclub/photo',
+    title: 'Member Photos',
+    description: 'Browse member photo uploads and visual highlights.',
+  },
+  {
+    href: '/fanclub/memorabilia',
+    title: 'Memorabilia',
+    description: 'Explore memorabilia entries curated for members.',
+  },
+  {
+    href: '/fanclub/library',
+    title: 'Library',
+    description: 'Read fan club library references and stories.',
+  },
+] as const;
+
 export default function ArchivesTiles() {
   return (
-    <section aria-label="ArchivesTiles" style={{ padding: 16, border: "1px solid rgba(0,0,0,0.12)", borderRadius: 12 }}>
-      <h2 style={{ margin: "0 0 8px 0" }}>ArchivesTiles</h2>
-      <p style={{ margin: 0 }}>Placeholder component. Implement per FanClub design.</p>
+    <section aria-label="Archives tiles">
+      <h2 style={{ margin: '0 0 12px 0', fontSize: 22 }}>Club Archives</h2>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+          gap: 12,
+        }}
+      >
+        {ARCHIVE_LINKS.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            style={{
+              display: 'block',
+              textDecoration: 'none',
+              color: 'inherit',
+              border: '1px solid rgba(0,0,0,0.12)',
+              borderRadius: 12,
+              padding: 14,
+              background: '#fff',
+            }}
+          >
+            <div style={{ fontSize: 16, fontWeight: 700 }}>{item.title}</div>
+            <p style={{ margin: '8px 0 0', fontSize: 14, color: 'rgba(0,0,0,0.7)', lineHeight: 1.45 }}>
+              {item.description}
+            </p>
+          </Link>
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/components/fanclub/DiscussionFeed.tsx
+++ b/src/components/fanclub/DiscussionFeed.tsx
@@ -1,24 +1,100 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiGet } from '@/lib/api';
+
+type Discussion = {
+  id: number;
+  title: string;
+  body: string;
+  created_at: string;
+};
+
 type DiscussionFeedProps = {
   refreshTrigger: number;
 };
 
+const formatCreatedAt = (raw: string): string => {
+  const parsed = Date.parse(raw);
+  if (Number.isNaN(parsed)) return raw || 'Unknown date';
+  return new Date(parsed).toISOString().slice(0, 10);
+};
+
 export default function DiscussionFeed({ refreshTrigger }: DiscussionFeedProps) {
+  const [items, setItems] = useState<Discussion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+
+    (async () => {
+      setLoading(true);
+      try {
+        const data = await apiGet<{ ok: boolean; items: Discussion[] }>('/api/discussions/list?limit=10');
+        if (!alive) return;
+
+        const normalized = Array.isArray(data?.items)
+          ? data.items.filter(
+              (item): item is Discussion =>
+                typeof item?.id === 'number' && typeof item?.title === 'string' && typeof item?.body === 'string',
+            )
+          : [];
+
+        setItems(normalized);
+        setError(null);
+      } catch {
+        if (!alive) return;
+        setItems([]);
+        setError('Unable to load club discussions right now.');
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [refreshTrigger]);
+
   return (
     <section
-      aria-label="DiscussionFeed"
+      aria-label="Member discussion feed"
       style={{
         padding: 16,
-        border: "1px solid rgba(0,0,0,0.12)",
+        border: '1px solid rgba(0,0,0,0.12)',
         borderRadius: 12,
+        background: '#fff',
       }}
     >
-      <h2 style={{ margin: "0 0 8px 0" }}>DiscussionFeed</h2>
+      <h2 style={{ margin: '0 0 12px 0', fontSize: 22 }}>Member Discussions</h2>
 
-      <p style={{ margin: "0 0 12px 0" }}>
-        Refresh trigger: <strong>{refreshTrigger}</strong>
-      </p>
-
-      <p style={{ margin: 0 }}>Placeholder component. Implement per FanClub design.</p>
+      {loading ? (
+        <p style={{ margin: 0, color: 'rgba(0,0,0,0.72)' }}>Loading discussions…</p>
+      ) : error ? (
+        <p style={{ margin: 0, color: '#b00020' }}>{error}</p>
+      ) : items.length === 0 ? (
+        <p style={{ margin: 0, color: 'rgba(0,0,0,0.72)' }}>No discussions yet. Be the first to post above.</p>
+      ) : (
+        <div style={{ display: 'grid', gap: 12 }}>
+          {items.map((post) => (
+            <article
+              key={post.id}
+              style={{
+                border: '1px solid rgba(0,0,0,0.08)',
+                borderRadius: 10,
+                padding: 12,
+              }}
+            >
+              <strong>{post.title}</strong>
+              <p style={{ margin: '8px 0', color: 'rgba(0,0,0,0.8)', lineHeight: 1.5 }}>
+                {post.body.length > 280 ? `${post.body.slice(0, 280)}…` : post.body}
+              </p>
+              <div style={{ fontSize: 13, color: 'rgba(0,0,0,0.6)' }}>Posted: {formatCreatedAt(post.created_at)}</div>
+            </article>
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/src/components/fanclub/GehrigTimeline.tsx
+++ b/src/components/fanclub/GehrigTimeline.tsx
@@ -1,8 +1,81 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiGet } from '@/lib/api';
+
+type Milestone = {
+  id: number;
+  year: number | null;
+  title: string;
+  description?: string | null;
+  milestone_date?: string | null;
+};
+
 export default function GehrigTimeline() {
+  const [items, setItems] = useState<Milestone[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+
+    (async () => {
+      try {
+        const data = await apiGet<{ ok: boolean; items: Milestone[] }>('/api/milestones/list?limit=12');
+        if (!alive) return;
+
+        const normalized = Array.isArray(data?.items)
+          ? data.items.filter((m): m is Milestone => typeof m?.id === 'number' && typeof m?.title === 'string')
+          : [];
+
+        setItems(normalized);
+        setError(null);
+      } catch {
+        if (!alive) return;
+        setItems([]);
+        setError('Unable to load Gehrig timeline entries right now.');
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
   return (
-    <section aria-label="GehrigTimeline" style={{ padding: 16, border: "1px solid rgba(0,0,0,0.12)", borderRadius: 12 }}>
-      <h2 style={{ margin: "0 0 8px 0" }}>GehrigTimeline</h2>
-      <p style={{ margin: 0 }}>Placeholder component. Implement per FanClub design.</p>
+    <section
+      aria-label="Gehrig timeline"
+      style={{
+        padding: 16,
+        border: '1px solid rgba(0,0,0,0.12)',
+        borderRadius: 12,
+        background: '#fff',
+      }}
+    >
+      <h2 style={{ margin: '0 0 12px 0', fontSize: 22 }}>Gehrig Timeline</h2>
+
+      {loading ? (
+        <p style={{ margin: 0, color: 'rgba(0,0,0,0.72)' }}>Loading timeline…</p>
+      ) : error ? (
+        <p style={{ margin: 0, color: '#b00020' }}>{error}</p>
+      ) : items.length === 0 ? (
+        <p style={{ margin: 0, color: 'rgba(0,0,0,0.72)' }}>No timeline entries are available yet.</p>
+      ) : (
+        <ol style={{ margin: 0, paddingLeft: 20, display: 'grid', gap: 10 }}>
+          {items.map((entry) => (
+            <li key={entry.id} style={{ lineHeight: 1.5 }}>
+              <strong>
+                {entry.year ?? entry.milestone_date ?? '—'}: {entry.title}
+              </strong>
+              {entry.description ? (
+                <p style={{ margin: '6px 0 0', color: 'rgba(0,0,0,0.75)' }}>{entry.description}</p>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      )}
     </section>
   );
 }

--- a/src/components/fanclub/PostCreation.tsx
+++ b/src/components/fanclub/PostCreation.tsx
@@ -1,41 +1,106 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { apiPost } from '@/lib/api';
+
 type PostCreationProps = {
   email: string;
   onPostCreated: () => void;
 };
 
 export default function PostCreation({ email, onPostCreated }: PostCreationProps) {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    const trimmedTitle = title.trim();
+    const trimmedBody = body.trim();
+    if (!trimmedTitle || !trimmedBody) {
+      setError('Title and message are required.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await apiPost<{ ok: boolean }>('/api/discussions/create', {
+        title: trimmedTitle,
+        body: trimmedBody,
+      });
+      setTitle('');
+      setBody('');
+      setSuccess('Discussion posted.');
+      onPostCreated();
+    } catch {
+      setError('Unable to post discussion right now.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
     <section
-      aria-label="PostCreation"
+      aria-label="Post creation"
       style={{
         padding: 16,
-        border: "1px solid rgba(0,0,0,0.12)",
+        border: '1px solid rgba(0,0,0,0.12)',
         borderRadius: 12,
+        background: '#fff',
       }}
     >
-      <h2 style={{ margin: "0 0 8px 0" }}>PostCreation</h2>
-
-      <p style={{ margin: "0 0 12px 0" }}>
-        Signed in as <strong>{email}</strong>
+      <h2 style={{ margin: '0 0 8px 0', fontSize: 22 }}>Share with the Club</h2>
+      <p style={{ margin: '0 0 12px 0', color: 'rgba(0,0,0,0.72)' }}>
+        Posting as <strong>{email || 'member'}</strong>
       </p>
 
-      <button
-        type="button"
-        onClick={onPostCreated}
-        style={{
-          padding: "10px 14px",
-          borderRadius: 10,
-          border: "1px solid rgba(0,0,0,0.2)",
-          background: "transparent",
-          cursor: "pointer",
-        }}
-      >
-        Refresh Feed
-      </button>
+      <form onSubmit={handleSubmit} style={{ display: 'grid', gap: 10 }}>
+        <label style={{ display: 'grid', gap: 4 }}>
+          <span>Title</span>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={200}
+            disabled={submitting}
+            style={{ padding: 10, borderRadius: 8, border: '1px solid rgba(0,0,0,0.2)' }}
+          />
+        </label>
+        <label style={{ display: 'grid', gap: 4 }}>
+          <span>Message</span>
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            rows={4}
+            maxLength={4000}
+            disabled={submitting}
+            style={{ padding: 10, borderRadius: 8, border: '1px solid rgba(0,0,0,0.2)' }}
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={submitting}
+          style={{
+            width: 'fit-content',
+            padding: '10px 14px',
+            borderRadius: 10,
+            border: '1px solid rgba(0,0,0,0.2)',
+            background: 'var(--lgfc-blue)',
+            color: '#fff',
+            cursor: submitting ? 'not-allowed' : 'pointer',
+          }}
+        >
+          {submitting ? 'Posting…' : 'Post Discussion'}
+        </button>
+      </form>
 
-      <p style={{ margin: "12px 0 0 0" }}>
-        Placeholder component. Implement per FanClub design.
-      </p>
+      {error ? <p style={{ margin: '12px 0 0', color: '#b00020' }}>{error}</p> : null}
+      {success ? <p style={{ margin: '12px 0 0', color: 'rgba(0,0,0,0.72)' }}>{success}</p> : null}
     </section>
   );
 }

--- a/src/components/fanclub/WelcomeSection.tsx
+++ b/src/components/fanclub/WelcomeSection.tsx
@@ -1,22 +1,30 @@
-import React from "react";
+import Link from 'next/link';
 
 type WelcomeSectionProps = {
   email?: string | null;
 };
 
 export default function WelcomeSection({ email }: WelcomeSectionProps) {
-  // Use email safely (no full email exposure). This also satisfies eslint no-unused-vars.
-  const emailHint =
-    typeof email === "string" && email.includes("@")
-      ? email.split("@")[0]
-      : "";
+  const emailHint = typeof email === 'string' && email.includes('@') ? email.split('@')[0] : '';
 
   return (
-    <section aria-label="Welcome section">
-      <h2>Welcome back{emailHint ? `, ${emailHint}` : ""}.</h2>
-      <p>
-        This is your FanClub home. New features will appear here as they go live.
+    <section
+      aria-label="Welcome section"
+      style={{
+        padding: 16,
+        border: '1px solid rgba(0,0,0,0.12)',
+        borderRadius: 12,
+        background: '#fff',
+      }}
+    >
+      <h2 style={{ margin: '0 0 8px 0', fontSize: 22 }}>Welcome back{emailHint ? `, ${emailHint}` : ''}.</h2>
+      <p style={{ margin: '0 0 10px 0', color: 'rgba(0,0,0,0.75)', lineHeight: 1.55 }}>
+        This is your FanClub home. Use the sections below to browse archives, join discussions, and explore club
+        milestones.
       </p>
+      <Link href="/fanclub/myprofile" style={{ fontWeight: 600 }}>
+        Go to My Profile
+      </Link>
     </section>
   );
 }


### PR DESCRIPTION
- **Issue:** #1113

## Documentation source classification
- Type: website implementation (FanClub home composition)
- Scope: T35 locked section stack on `/fanclub`

## Design source of truth
- /docs/reference/design/fanclub.md
- /docs/reference/design/fanclub-home.md

## FILE-TOUCH ALLOWLIST
- src/app/fanclub/page.tsx
- src/components/fanclub/WelcomeSection.tsx
- src/components/fanclub/ArchivesTiles.tsx
- src/components/fanclub/PostCreation.tsx
- src/components/fanclub/DiscussionFeed.tsx
- src/components/fanclub/GehrigTimeline.tsx
- src/components/fanclub/AdminLink.tsx

## Change summary
- Replaced nav-card-only FanClub shell with canonical section composition order.
- Implemented archive tiles linking to `/fanclub/photo`, `/fanclub/memorabilia`, and `/fanclub/library`.
- Wired member discussion post/create flow to existing D1 APIs with refresh + fail-closed states.
- Added Gehrig timeline section backed by milestones API with safe empty/error handling.

## Build/test/verification evidence
- `npm run typecheck` ✅ pass
- `npm run lint` ✅ pass (existing repository warnings only)

## Acceptance criteria
- [x] FanClub home section order matches design authority
- [x] Archives tiles link to canonical FanClub subpages
- [x] Discussion feed uses `/api/discussions/list` with safe states
- [x] Post creation uses `/api/discussions/create` and refreshes feed
- [x] Auth redirect behavior preserved for logged-out users

## Required pre-review self-check
- [x] Single task scope (T35)
- [x] One primary source issue (#1113)
- [x] No unrelated runtime/config/docs changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compose the FanClub home per T35, replacing the old nav-card shell with the canonical section stack. Addresses #1113 with archives, member discussions, post creation, and a Gehrig timeline, all with safe loading and error states.

- **New Features**
  - Section order matches design refs for `/fanclub`.
  - Archives tiles linking to `/fanclub/photo`, `/fanclub/memorabilia`, and `/fanclub/library`.
  - Post creation form posts to `/api/discussions/create` and refreshes the feed.
  - Discussion feed reads from `/api/discussions/list` with loading/error/empty states.
  - Gehrig timeline reads from `/api/milestones/list` with safe empty/error handling.
  - Auth redirect behavior preserved for logged-out users.

<sup>Written for commit 7141777610658dcea461a1cc95e541e9ce65d88e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1114?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->