### PR TITLE
docs: normalize website implementation queue

### DIFF
--- a/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
+++ b/docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
@@ -342,6 +342,37 @@ Issue/PR trace:
 Notes:
 - Historical task alias: T23 (Events) is preserved as T23-E to avoid collision with T23 FAQ CMS moderation.
 
+## T25 — Search experience completion and validation
+Status: IN REVIEW (PR #1130)
+Issue: #1108
+Owner: Cursor
+Scope: `/search`, search input UX, result rendering, empty states, mobile behavior, and fail-closed behavior.
+Exit: public search is launch-safe, responsive, and preserves canonical navigation.
+Progress:
+- Implementation PR opened: #1130
+- Branch: `feat/t25-search-1108`
+
+## T26 — Mobile navigation and responsive validation suite
+Status: QUEUED
+Issue: #1109
+Owner: Cursor
+Scope: mobile hamburger behavior, Store link behavior, responsive layouts, header/footer invariants, breakpoints, and touch usability.
+Exit: mobile navigation and responsive rendering comply with locked design invariants without viewport overflow.
+
+## T28 — Join/Login UX completion and auth-state validation
+Status: QUEUED
+Issue: #1110
+Owner: Cursor
+Scope: `/join`, `/login` redirect handling, auth-state transitions, logged-in header invariants, logout behavior, and fail-closed behavior.
+Exit: Join/Login behavior is stable, avoids redirect loops, and preserves mobile/header auth-state invariants.
+
+## T29 — D1/B2 integration verification and fail-closed testing
+Status: QUEUED
+Issue: #1111
+Owner: Cursor
+Scope: active D1 queries, B2 image rendering, fallback handling, missing-content behavior, homepage media validation, and runtime error validation.
+Exit: active D1/B2 integrations fail closed without uncaught runtime failures.
+
 ---
 
 # Phase 4 — Fan Club Core (QUEUED)
@@ -406,15 +437,92 @@ Issue/PR trace:
 - Tracker sync PR: #1103
 
 ## T35 — FanClub home composition pass
-Status: IN REVIEW (PR #1114)
+Status: CLOSED
+Date Closed: 2026-05-28
 Issue: #1113
 Scope: `/fanclub` canonical section composition only.
 Exit: FanClub home renders locked section order with D1-backed discussions/milestones and safe empty/error states.
-Progress:
-- Implementation PR opened: #1114
-- Branch: `feat/t35-fanclub-composition-1113`
+Summary:
+FanClub home composition is merged with canonical section stack, archive tile links, D1-backed discussions/milestones, and safe empty/error handling.
+Issue/PR trace:
+- Implementation PR: #1114
+- Tracker sync PR: #1115
 Notes:
 - Completes the dedicated FanClub formatting/design pass called out during T30 closeout.
+
+---
+
+# Phase 5 — Website Operational Systems (QUEUED)
+
+Normalization reference:
+`/docs/ops/trackers/LGFC-WEBSITE-IMPLEMENTATION-QUEUE-NORMALIZATION.md`
+
+## T40 — Fan Club operational workflows
+Status: QUEUED
+Issue: #1118
+Scope: `/fanclub/photo`, `/fanclub/submit`, `/fanclub/chat`, Fan Club APIs, member-only operational states.
+Exit: member-facing Fan Club operational workflows render safely, stay auth-gated, and preserve canonical Fan Club navigation.
+
+## T41 — Admin operating shell and member operations
+Status: QUEUED
+Issue: #1119
+Scope: `/admin`, `/admin/join-requests`, admin stats/worklist/member-operation surfaces.
+Exit: admin operations have launch-safe navigation, member queue visibility, and stable empty/error states.
+
+## T42 — Moderation and review workflows
+Status: QUEUED
+Issue: #1120
+Scope: `/admin/moderation`, reports APIs, ask/FAQ moderation state transitions, review queues.
+Exit: moderation/review workflows expose actionable queues and preserve auditable approval, rejection, archive, and close states.
+
+## T43 — Content management workflows
+Status: QUEUED
+Issue: #1121
+Scope: `/admin/cms`, `/admin/content`, content save/publish/list APIs.
+Exit: admin content management supports safe draft/list/publish operations without bypassing content authority.
+
+## T44 — Media management workflows
+Status: QUEUED
+Issue: #1122
+Scope: `/admin/media-assets`, B2 sync, photo/media list and get APIs.
+Exit: media management supports safe B2-backed inventory review, sync feedback, and fail-closed asset handling.
+
+## T45 — Editorial/archive systems
+Status: QUEUED
+Issue: #1123
+Scope: content inventory, library submissions, archive publication/review state, editorial metadata.
+Exit: editorial/archive workflows preserve `content_inventory` authority and provide a launch-safe submission-to-publication path.
+
+## T46 — Event/calendar administration
+Status: QUEUED
+Issue: #1124
+Scope: `/admin/events`, event create/update/seed APIs, public event read-path validation.
+Exit: event administration can create and update calendar entries while preserving homepage and `/events` read behavior.
+
+## T47 — Charity/fundraiser administration
+Status: QUEUED
+Issue: #1125
+Scope: `/admin/fundraiser-preview`, campaign spotlight/fundraiser data operations.
+Exit: charity/fundraiser administration safely previews and validates campaign content before public exposure.
+
+## T48 — Matchup administration
+Status: QUEUED
+Issue: #1126
+Scope: weekly matchup current/vote/results APIs and operational rotation controls.
+Exit: weekly matchup operations can review or prepare active matchups without breaking public voting behavior.
+
+## T49 — Audit/reporting systems
+Status: QUEUED
+Issue: #1127
+Scope: reports create/list/close APIs, admin export/stats surfaces, operational evidence flows.
+Exit: reporting and audit surfaces expose launch-safe operational evidence without leaking protected data.
+
+## T50 — Launch readiness QA and production validation suite
+Status: QUEUED
+Issue: #1112
+Owner: Cursor
+Scope: cross-route QA, navigation validation, responsive validation, runtime validation, visual QA, invariant verification, and launch-readiness reporting.
+Exit: public, Fan Club, admin, D1/B2, responsive, and production-readiness checks are complete with no critical runtime defects.
 
 ---
 

--- a/docs/ops/trackers/LGFC-WEBSITE-IMPLEMENTATION-QUEUE-NORMALIZATION.md
+++ b/docs/ops/trackers/LGFC-WEBSITE-IMPLEMENTATION-QUEUE-NORMALIZATION.md
@@ -1,0 +1,194 @@
+---
+Doc Type: Operations
+Audience: Human + AI
+Authority Level: Operational Authority
+Owns: Website implementation queue normalization, issue lifecycle map, implementation gap analysis
+Does Not Own: Runtime implementation, production UI, CI/orchestration systems, design authority
+Canonical Reference: /docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md
+Last Reviewed: 2026-05-28
+---
+
+# LGFC Website Implementation Queue Normalization
+
+## Purpose
+
+This tracker normalizes the LGFC website implementation issue queue against the
+current repository design authority, implementation worklist, and as-built route
+and API surfaces.
+
+Repository state is authoritative. This document does not authorize runtime
+implementation changes.
+
+## Scope
+
+- Website implementation issues under parent coordination issue #1053
+- Worklist tracker alignment for T21–T50 and Phase 5 operational systems
+- GitHub issue title, label, and lifecycle metadata normalization map
+- Gap analysis against design authority and as-built routes/APIs
+
+Does not cover runtime code changes, CI workflow edits, or legacy doc migration.
+
+## Current known truth
+
+- T21–T35 website core tasks are merged or closed in the worklist; T35 closed via #1114/#1115.
+- T25 search implementation is in review on PR #1130 (issue #1108).
+- T26–T29 and T40–T50 remain backlog; orchestrator serial queue advances one active website task at a time.
+- Several older issues (#943, #946, #947, #1013–#1017) remain open with stale lifecycle labels despite worklist CLOSED status.
+- Issue #1112 is assigned launch-readiness task **T50** (not T30).
+
+## Intended final state (if evolving)
+
+- One authoritative issue map with standard `[T##] Website — {scope} — Child #1053` titles
+- Lifecycle labels match orchestrator serial-queue contract and accepted post-merge evidence
+- Worklist and coverage map reflect T25 as current implementation focus after T35 closeout
+- Phase 5 operational-system issues (#1118–#1127, #1112) remain `status:queued` until the serial queue authorizes each task
+
+## Source Inputs
+
+- `docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
+- `docs/reference/design/LGFC-Production-Design-and-Standards.md`
+- `docs/reference/design/fanclub.md`
+- `docs/reference/design/fanclub-home.md`
+- `docs/explanation/lgfc-content-implementation-plan.md`
+- `docs/how-to/ci/lgfc-ci-implementation-plan.md`
+- `docs/explanation/ci/lgfc-ci-production-design.md`
+- `docs/reference/lgfc-implementation-coverage-map.md`
+- `active_tasklist.md`
+- Current repository route/API inventory under `src/app/**` and `functions/api/**`
+- Open GitHub website implementation issues under project issue #1053
+
+## Queue Standards
+
+Every active or queued website implementation issue must use:
+
+- title format: `[T##] Website — {scope} — Child #1053`
+- lifecycle label: exactly one current lifecycle label from the website lane
+- ownership labels: `agent:cursor` and `owner:cursor`
+- type labels: `orchestrator`, `type:website`, and `website`
+- parent reference: `#1053 PROJECT: LGFC Website Implementation Coordination`
+- scope boundary: explicit route/API/component scope
+- acceptance criteria: checkbox list with deterministic completion checks
+- validation: repository checks plus targeted route/manual validation
+
+Lifecycle labels:
+
+- `status:active` for the single Cursor task currently authorized for execution
+- `status:queued` for backlog tasks authorized by the worklist but not yet the active serial-queue head
+- `status:pr-draft` only when a task is the current authorized Cursor implementation head and a PR is being drafted
+- `status:post-merge-verify` for merged tasks awaiting post-merge validation
+- `status:complete` only after post-merge validation has been accepted
+- `status:blocked` for later generated orchestrator tasks waiting behind the active pipeline (serial queue), and additionally when a named non-queue dependency prevents execution
+
+## Audit Findings
+
+| Finding | Evidence | Normalization |
+|---|---|---|
+| Completed implementation issues remain open with inconsistent lifecycle state | #943, #946, #947, #1013, #1014, #1015, #1016, #1017 are represented as completed in the worklist but still carry mixed open-issue lifecycle labels | Keep traceability; normalize to post-merge verification or completion state according to accepted verification record |
+| Future website issues were marked active while a single serial-queue head should be authorized | #1108–#1112 were open with overlapping active-style labels | Hold non-head backlog at `status:queued` (or orchestrator `status:blocked` per serial generation); only the current head may use `status:pr-draft` / active implementation labels |
+| Duplicate task number exists | #1112 used `[T30]`, while T30 is already FanClub shell issue #1013 and is merged | Rename #1112 to launch-readiness task after the operational implementation sequence |
+| Several future issues lacked the full standard label set | #1108 through #1112 omitted some of `orchestrator`, `type:website`, `agent:cursor`, or `owner:cursor` | Apply full website queue label set |
+| Fan Club operational systems were underrepresented | Repository has `/fanclub/photo`, `/fanclub/submit`, `/fanclub/chat`, and Fan Club APIs not fully represented after T35 | Add queued Fan Club operations task |
+| Admin operational systems were underrepresented | Repository has admin dashboard, join requests, stats, worklist, export, and admin layout surfaces | Add queued admin operations task |
+| Moderation/review workflows were underrepresented | Repository has `/admin/moderation`, reports APIs, FAQ/ask approval flows | Add queued moderation/review task |
+| Content management and editorial archive workflows were split across partial surfaces | Repository has `/admin/cms`, `/admin/content`, content APIs, library submission, and content-inventory docs | Add queued CMS and editorial/archive tasks |
+| Media management was underrepresented | Repository has `/admin/media-assets`, B2 sync API, photo APIs, and B2-dependent rendering | Add queued media management task |
+| Calendar, charity, matchup, audit/reporting administration were not fully represented as implementation tasks | Repository has admin events, fundraiser preview, matchup APIs, stats/export/report APIs | Add queued operational admin tasks for each system |
+
+## Normalized Existing Issue Map
+
+| Task | Issue | Lifecycle | Required title |
+|---|---:|---|---|
+| T21 FAQ page functionality | #943 | post-merge verify or complete | `[T21] Website — FAQ page functionality — Child #1053` |
+| T22 Ask-a-question intake | #946 | post-merge verify or complete | `[T22] Website — Ask-a-question intake — Child #1053` |
+| T23 FAQ CMS moderation | #1053 trace / PR #1072 | complete | `[T23] Website — FAQ CMS moderation — Child #1053` |
+| T23-E Events page | #947 | post-merge verify or complete | `[T23-E] Website — Events page — Child #1053` |
+| T25 Search experience completion and validation | #1108 | in review (PR #1130) | `[T25] Website — Search experience completion and validation — Child #1053` |
+| T26 Mobile navigation and responsive validation suite | #1109 | queued | `[T26] Website — Mobile navigation and responsive validation suite — Child #1053` |
+| T28 Join/Login UX completion and auth-state validation | #1110 | queued | `[T28] Website — Join/Login UX completion and auth-state validation — Child #1053` |
+| T29 D1/B2 integration verification and fail-closed testing | #1111 | queued | `[T29] Website — D1/B2 integration verification and fail-closed testing — Child #1053` |
+| T30 FanClub shell and authenticated navigation | #1013 | post-merge verify or complete | `[T30] Website — FanClub shell and authenticated navigation — Child #1053` |
+| T31 FanClub profile and member card pages | #1014 | post-merge verify or complete | `[T31] Website — FanClub profile and member card pages — Child #1053` |
+| T32 FanClub library and memorabilia pages | #1015 | post-merge verify or complete | `[T32] Website — FanClub library and memorabilia pages — Child #1053` |
+| T33 Social Wall production integration | #1016 | post-merge verify or complete | `[T33] Website — Social Wall production integration — Child #1053` |
+| T34 Homepage dynamic D1 content wiring | #1017 | post-merge verify or complete | `[T34] Website — Homepage dynamic D1 content wiring — Child #1053` |
+| T35 FanClub home composition pass | #1113 | complete | `[T35] Website — FanClub home composition pass — Child #1053` |
+| T50 Launch readiness QA and production validation suite | #1112 | queued | `[T50] Website — Launch readiness QA and production validation suite — Child #1053` |
+
+## Expanded Implementation Roadmap
+
+The remaining implementation queue must include these operational systems before
+launch readiness can be treated as complete.
+
+| Task | Issue | System | Scope | Lifecycle |
+|---|---:|---|---|---|
+| T40 | #1118 | Fan Club operational workflows | `/fanclub/photo`, `/fanclub/submit`, `/fanclub/chat`, Fan Club APIs | queued |
+| T41 | #1119 | Admin operating shell and member operations | `/admin`, `/admin/join-requests`, stats/worklist/member operations | queued |
+| T42 | #1120 | Moderation and review workflows | `/admin/moderation`, reports APIs, ask/FAQ moderation transitions | queued |
+| T43 | #1121 | Content management workflows | `/admin/cms`, `/admin/content`, content publish/save APIs | queued |
+| T44 | #1122 | Media management workflows | `/admin/media-assets`, B2 sync, photo/media APIs | queued |
+| T45 | #1123 | Editorial/archive systems | content inventory, library submissions, archive publication and review state | queued |
+| T46 | #1124 | Event/calendar administration | `/admin/events`, event create/update/seed APIs, public event read paths | queued |
+| T47 | #1125 | Charity/fundraiser administration | `/admin/fundraiser-preview`, campaign spotlight/fundraiser data operations | queued |
+| T48 | #1126 | Matchup administration | matchup current/vote/results APIs and weekly operational rotation controls | queued |
+| T49 | #1127 | Audit/reporting systems | reports create/list/close APIs, admin export/stats, operational evidence | queued |
+| T50 | #1112 | Launch readiness QA and production validation suite | cross-route QA, responsive validation, D1/B2 failure checks, launch report | queued |
+
+## Gap Analysis
+
+### Covered by merged or closed work
+
+- FAQ page and Ask intake
+- FAQ CMS moderation
+- public Events page
+- FanClub shell, profile, member card, library, and memorabilia pages
+- Social Wall production integration
+- homepage dynamic D1 sections
+- T35 FanClub home composition pass (#1114)
+
+### Remaining public-core gaps
+
+- Search completion and validation
+- Mobile navigation and responsive validation
+- Join/Login auth-state validation
+- D1/B2 fail-closed verification
+
+### Remaining Fan Club gaps
+
+- member photo/archive browsing completion
+- submission intake flow completion
+- member discussion/chat operational behavior
+- member-only route validation across all Fan Club surfaces
+
+### Remaining Admin and Operations gaps
+
+- admin IA and operational dashboard completeness
+- join-request and member operations
+- moderation/review queue behavior
+- content CMS publishing workflow
+- media asset/B2 operational workflow
+- archive/editorial workflow state model
+- event/calendar administration
+- charity/fundraiser administration
+- weekly matchup administration
+- audit/reporting/export operations
+
+## Issue Lifecycle Actions Required
+
+Apply these GitHub issue metadata changes before or with the normalization PR:
+
+- #1108: full website label set; current serial-queue implementation head while PR #1130 is open (`status:pr-draft` or review-state labels per automation)
+- #1109–#1111: full website label set; lifecycle `status:queued` until T25 completes
+- #1112: full website label set; title `[T50] Website — Launch readiness QA and production validation suite — Child #1053`; lifecycle `status:queued`
+- #1113: close or mark `status:complete` after accepted T35 post-merge evidence
+- #1118–#1127: operational-system child issues under #1053; lifecycle `status:queued` until authorized by serial queue
+- #943, #946, #947, #1013, #1014, #1015, #1016, #1017: remove stale blocked/queued labels where present; retain post-merge verification or completion status according to accepted post-merge evidence
+- #1053: update the master coordination body with this normalized issue map
+
+## Governance Constraints
+
+- Do not implement website runtime changes in queue normalization PRs.
+- Do not modify production UI.
+- Do not modify CI or orchestration systems.
+- Do not migrate legacy docs as part of this queue normalization.
+- Do not close valid active implementation issues.
+- Future implementation issues must remain one task per Cursor run.

--- a/docs/reference/lgfc-implementation-coverage-map.md
+++ b/docs/reference/lgfc-implementation-coverage-map.md
@@ -33,6 +33,7 @@ Operational implementation tracking:
 - PR bodies
 - implementation worklists
 - post-merge validation records
+- `/docs/ops/trackers/LGFC-WEBSITE-IMPLEMENTATION-QUEUE-NORMALIZATION.md`
 
 ## Issue 173 Closeout Mapping
 
@@ -89,12 +90,16 @@ Authority:
 
 - Production design standards canonical FanClub routes
 - production auth/session model
+- `/docs/reference/design/fanclub.md`
+- `/docs/reference/design/fanclub-home.md`
 
 Tracking:
 
 - Issue #1013
 - Issue #1014
 - Issue #1015
+- Issue #1113
+- T40 / Issue #1118 in the normalized website implementation queue
 
 Implementation readiness:
 
@@ -103,6 +108,104 @@ Implementation readiness:
 - preserve canonical navigation
 - keep membership card behavior aligned to `/fanclub/myprofile`
 - keep memorabilia as a tagged or filtered photo/library experience, not a standalone table unless design authority changes
+- complete member photo/archive, submission, and discussion/chat surfaces through queued Fan Club operations work
+
+### Admin Operational Surfaces
+
+Authority:
+
+- Production design standards canonical Admin route family
+- production auth/session model
+- active repository route/API inventory
+
+Tracking:
+
+- T41 / Issue #1119 in the normalized website implementation queue
+
+Implementation readiness:
+
+- preserve `/admin/**` as an admin-only surface
+- keep admin navigation separate from public and FanClub hamburger navigation
+- validate join-request, stats, worklist, export, and member-operation surfaces with safe empty and failure states
+- avoid exposing admin affordances in public footer or mobile public navigation
+
+### Moderation and Review Workflows
+
+Authority:
+
+- production auth/session model
+- FAQ/Ask moderation implementation trace
+- reports API surfaces
+
+Tracking:
+
+- T23 FAQ CMS moderation closeout
+- T42 / Issue #1120 in the normalized website implementation queue
+
+Implementation readiness:
+
+- preserve auditable approval, rejection, archive, and close transitions
+- keep moderation queues admin-only
+- provide safe empty/error states for review queues
+- avoid bypassing existing FAQ, Ask, or report workflow boundaries
+
+### Content Management and Editorial Archive
+
+Authority:
+
+- content inventory design spec
+- content inventory D1 schema reference
+- content archive implementation plan
+
+Tracking:
+
+- T43 / Issue #1121 and T45 / Issue #1123 in the normalized website implementation queue
+
+Implementation readiness:
+
+- preserve `content_inventory` as the canonical archive/content authority
+- route admin CMS/content operations through existing save, publish, and list API boundaries
+- keep library submissions and archive editorial review distinct from public read paths
+- avoid parallel page-specific content stores unless new authority explicitly permits them
+
+### Media Management
+
+Authority:
+
+- content inventory design spec
+- content inventory D1 schema reference
+- active B2/media route and API inventory
+
+Tracking:
+
+- T44 / Issue #1122 in the normalized website implementation queue
+
+Implementation readiness:
+
+- preserve B2-backed media assumptions
+- validate media-assets listing and sync behavior with safe failure states
+- avoid changing public image rendering contracts outside the media management task scope
+
+### Events, Charity, Matchup, and Reporting Operations
+
+Authority:
+
+- production design standards homepage section order
+- active admin event, fundraiser, matchup, reports, stats, and export surfaces
+
+Tracking:
+
+- T46 / Issue #1124 Event/calendar administration
+- T47 / Issue #1125 Charity/fundraiser administration
+- T48 / Issue #1126 Matchup administration
+- T49 / Issue #1127 Audit/reporting systems
+
+Implementation readiness:
+
+- preserve public homepage and `/events` read behavior when admin event tools change
+- keep campaign/fundraiser preview workflows admin-only until public exposure is intentionally enabled
+- keep matchup operations aligned to current weekly voting behavior
+- preserve protected-data boundaries for audit, reporting, stats, and export flows
 
 ### Dynamic D1 Homepage Integrations
 
@@ -151,6 +254,30 @@ A topic is implementation-ready when all of the following exist:
 4. acceptance criteria
 5. validation expectations
 6. no conflict with existing navigation, auth, D1, B2, or content inventory authority
+
+## Normalized Queue Coverage
+
+| Surface | Current coverage | Remaining queue coverage |
+|---|---|---|
+| Public FAQ and Ask | T21, T22, T23 | post-merge verification or accepted completion record |
+| Public Events | T23-E | post-merge verification or accepted completion record |
+| Public Search | Issue #1108 | T25 queued |
+| Mobile/responsive navigation | Issue #1109 | T26 queued |
+| Join/Login auth UX | Issue #1110 | T28 queued |
+| D1/B2 fail-closed validation | Issue #1111 | T29 queued |
+| FanClub shell/profile/library/memorabilia | Issues #1013-#1015 | post-merge verification or accepted completion record |
+| FanClub home composition | Issue #1113 | T35 active |
+| FanClub operations | Issue #1118 | T40 queued |
+| Admin operations | Issue #1119 | T41 queued |
+| Moderation/review | Issue #1120 | T42 queued |
+| CMS/content management | Issue #1121 | T43 queued |
+| Media management | Issue #1122 | T44 queued |
+| Editorial/archive | Issue #1123 | T45 queued |
+| Event/calendar admin | Issue #1124 | T46 queued |
+| Charity/fundraiser admin | Issue #1125 | T47 queued |
+| Matchup admin | Issue #1126 | T48 queued |
+| Audit/reporting | Issue #1127 | T49 queued |
+| Launch readiness | Issue #1112 duplicate task-number repaired | T50 queued |
 
 ## Closed Historical Issues
 


### PR DESCRIPTION
## Summary
- add a website implementation queue normalization tracker with audit findings, lifecycle standards, live issue normalization results, and gap analysis
- align the implementation worklist with T35 closed, T25 in review on PR #1130, queued public-core work, and expanded T40-T50 operational systems
- expand the implementation coverage map for Fan Club, admin, moderation, CMS/content, media, editorial/archive, event, charity, matchup, and audit/reporting surfaces

## GitHub Issue Normalization
- normalized #1053, #943, #946, #947, #1013-#1017, #1108-#1113
- created operational child issues #1118-#1127
- repaired #1112 from duplicate T30 to T50
- moved T35 #1113 out of active after PR #1114/#1115 merged

## Verification
- npm run check:structure
- git diff --check

## Scope
- docs/tracker-only PR
- no runtime, UI, CI, or orchestration files changed