### PR TITLE
feat(search): T25 search experience completion (#1108)

### DIFF
--- a/functions/api/search.ts
+++ b/functions/api/search.ts
@@ -1,0 +1,272 @@
+import { getSessionEmail, getSessionId } from '../_lib/session';
+import { requireD1 } from '../_lib/d1';
+
+type SearchResult = {
+  type: string;
+  title: string;
+  excerpt: string;
+  url: string;
+  score: number;
+};
+
+function excerpt(value: unknown, max = 120): string {
+  const text = String(value ?? '').trim().replace(/\s+/g, ' ');
+  if (!text) return '';
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}…`;
+}
+
+function scoreForMatch(title: string, body: string, query: string): number {
+  const q = query.toLowerCase();
+  const t = title.toLowerCase();
+  const b = body.toLowerCase();
+  let score = 0;
+  if (t.includes(q)) score += 3;
+  if (b.includes(q)) score += 1;
+  return score;
+}
+
+async function runLikeQuery(
+  db: any,
+  sql: string,
+  args: any[],
+): Promise<any[]> {
+  const rows = await db.prepare(sql).bind(...args).all();
+  return rows.results ?? [];
+}
+
+export const onRequestGet = async (context: any): Promise<Response> => {
+  const { request } = context;
+  const d1 = requireD1(context.env);
+  if (!d1.ok) {
+    return new Response(JSON.stringify(d1.body), {
+      status: d1.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const url = new URL(request.url);
+    const q = (url.searchParams.get('q') || '').trim();
+    const page = Math.max(1, Number(url.searchParams.get('page') || '1') || 1);
+    const pageSize = 20;
+
+    if (q.length < 2) {
+      return new Response(
+        JSON.stringify({ ok: true, query: q, page, pages: 0, total: 0, results: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const like = `%${q.toLowerCase()}%`;
+    const sessionId = getSessionId(request);
+    const memberEmail = await getSessionEmail(d1.db, sessionId);
+    const isMember = Boolean(memberEmail);
+
+    const results: SearchResult[] = [];
+
+    const faqRows = await runLikeQuery(
+      d1.db,
+      `SELECT id, question, answer, view_count
+       FROM faq_entries
+       WHERE status='approved' AND answer IS NOT NULL AND answer != ''
+         AND (lower(question) LIKE ?1 OR lower(answer) LIKE ?1)
+       ORDER BY pinned DESC, view_count DESC, id DESC
+       LIMIT 30`,
+      [like],
+    );
+    for (const row of faqRows) {
+      const title = String(row.question || 'FAQ');
+      results.push({
+        type: 'FAQ',
+        title,
+        excerpt: excerpt(row.answer),
+        url: '/faq',
+        score: scoreForMatch(title, String(row.answer || ''), q),
+      });
+    }
+
+    const eventRows = await runLikeQuery(
+      d1.db,
+      `SELECT id, title, description, start_date
+       FROM events
+       WHERE status='posted'
+         AND (lower(title) LIKE ?1 OR lower(COALESCE(description,'')) LIKE ?1 OR lower(COALESCE(location,'')) LIKE ?1)
+       ORDER BY start_date ASC, id ASC
+       LIMIT 30`,
+      [like],
+    );
+    for (const row of eventRows) {
+      const title = String(row.title || 'Event');
+      const body = String(row.description || row.location || '');
+      results.push({
+        type: 'Event',
+        title,
+        excerpt: excerpt(body || row.start_date),
+        url: '/events',
+        score: scoreForMatch(title, body, q),
+      });
+    }
+
+    const milestoneRows = await runLikeQuery(
+      d1.db,
+      `SELECT id, title, description, year
+       FROM milestones
+       WHERE status='posted'
+         AND (lower(title) LIKE ?1 OR lower(COALESCE(description,'')) LIKE ?1)
+       ORDER BY year DESC, id DESC
+       LIMIT 30`,
+      [like],
+    );
+    for (const row of milestoneRows) {
+      const title = String(row.title || 'Milestone');
+      const body = String(row.description || '');
+      results.push({
+        type: 'Milestone',
+        title: `${row.year ? `${row.year}: ` : ''}${title}`,
+        excerpt: excerpt(body),
+        url: '/',
+        score: scoreForMatch(title, body, q),
+      });
+    }
+
+    const friendRows = await runLikeQuery(
+      d1.db,
+      `SELECT id, name, blurb, url
+       FROM friends
+       WHERE status='posted'
+         AND (lower(name) LIKE ?1 OR lower(COALESCE(blurb,'')) LIKE ?1)
+       ORDER BY name ASC
+       LIMIT 20`,
+      [like],
+    );
+    for (const row of friendRows) {
+      const title = String(row.name || 'Friend');
+      const body = String(row.blurb || '');
+      results.push({
+        type: 'Friend',
+        title,
+        excerpt: excerpt(body),
+        url: String(row.url || '/'),
+        score: scoreForMatch(title, body, q),
+      });
+    }
+
+    if (isMember) {
+      const discussionRows = await runLikeQuery(
+        d1.db,
+        `SELECT id, title, body
+         FROM discussions
+         WHERE status='posted'
+           AND (lower(title) LIKE ?1 OR lower(body) LIKE ?1)
+         ORDER BY created_at DESC, id DESC
+         LIMIT 30`,
+        [like],
+      );
+      for (const row of discussionRows) {
+        const title = String(row.title || 'Discussion');
+        const body = String(row.body || '');
+        results.push({
+          type: 'Discussion',
+          title,
+          excerpt: excerpt(body),
+          url: '/fanclub',
+          score: scoreForMatch(title, body, q),
+        });
+      }
+
+      const libraryRows = await runLikeQuery(
+        d1.db,
+        `SELECT id, title, content
+         FROM library_entries
+         WHERE lower(COALESCE(title,'')) LIKE ?1 OR lower(COALESCE(content,'')) LIKE ?1
+         ORDER BY created_at DESC, id DESC
+         LIMIT 20`,
+        [like],
+      );
+      for (const row of libraryRows) {
+        const title = String(row.title || 'Library item');
+        const body = String(row.content || '');
+        results.push({
+          type: 'Library',
+          title,
+          excerpt: excerpt(body),
+          url: '/fanclub/library',
+          score: scoreForMatch(title, body, q),
+        });
+      }
+
+      const photoRows = await runLikeQuery(
+        d1.db,
+        `SELECT id, title, description
+         FROM photos
+         WHERE (is_memorabilia IS NULL OR is_memorabilia = 0)
+           AND (lower(COALESCE(title,'')) LIKE ?1 OR lower(COALESCE(description,'')) LIKE ?1 OR lower(COALESCE(tags,'')) LIKE ?1)
+         ORDER BY id DESC
+         LIMIT 20`,
+        [like],
+      );
+      for (const row of photoRows) {
+        const title = String(row.title || 'Photo');
+        const body = String(row.description || '');
+        results.push({
+          type: 'Photo',
+          title,
+          excerpt: excerpt(body),
+          url: '/fanclub/photo',
+          score: scoreForMatch(title, body, q),
+        });
+      }
+
+      const memorabiliaRows = await runLikeQuery(
+        d1.db,
+        `SELECT id, title, description
+         FROM photos
+         WHERE is_memorabilia = 1
+           AND (lower(COALESCE(title,'')) LIKE ?1 OR lower(COALESCE(description,'')) LIKE ?1 OR lower(COALESCE(tags,'')) LIKE ?1)
+         ORDER BY id DESC
+         LIMIT 20`,
+        [like],
+      );
+      for (const row of memorabiliaRows) {
+        const title = String(row.title || 'Memorabilia');
+        const body = String(row.description || '');
+        results.push({
+          type: 'Memorabilia',
+          title,
+          excerpt: excerpt(body),
+          url: '/fanclub/memorabilia',
+          score: scoreForMatch(title, body, q),
+        });
+      }
+    }
+
+    const ranked = results
+      .filter((item) => item.score > 0)
+      .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title));
+
+    const total = ranked.length;
+    const pages = Math.max(1, Math.ceil(total / pageSize));
+    const safePage = Math.min(page, pages);
+    const start = (safePage - 1) * pageSize;
+    const pageResults = ranked.slice(start, start + pageSize);
+
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        query: q,
+        page: safePage,
+        pages,
+        total,
+        isMember,
+        results: pageResults,
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err: any) {
+    return new Response(JSON.stringify({ ok: false, error: String(err?.message ?? err) }, null, 2), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,34 +1,212 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { FormEvent, Suspense, useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { apiGet } from '@/lib/api';
 
-export default function SearchPage() {
-  const [q, setQ] = useState('');
+type SearchResult = {
+  type: string;
+  title: string;
+  excerpt: string;
+  url: string;
+};
 
-  const help = useMemo(() => {
-    if (!q.trim()) return 'Search Lou Gehrig Fan Club content, including photos, timeline moments, events, and news.';
-    return 'Search tools are being expanded. For now, use the main navigation to browse sections directly.';
-  }, [q]);
+type SearchResponse = {
+  ok: boolean;
+  query: string;
+  page: number;
+  pages: number;
+  total: number;
+  isMember?: boolean;
+  results: SearchResult[];
+};
+
+function SearchPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const queryFromUrl = searchParams.get('q') || '';
+
+  const [input, setInput] = useState(queryFromUrl);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<SearchResponse | null>(null);
+
+  useEffect(() => {
+    setInput(queryFromUrl);
+  }, [queryFromUrl]);
+
+  useEffect(() => {
+    let alive = true;
+    const q = queryFromUrl.trim();
+
+    if (q.length < 2) {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const page = Number(searchParams.get('page') || '1') || 1;
+        const response = await apiGet<SearchResponse>(`/api/search?q=${encodeURIComponent(q)}&page=${page}`);
+        if (!alive) return;
+        setData(response);
+      } catch {
+        if (!alive) return;
+        setData(null);
+        setError('Search is temporarily unavailable. Please try again.');
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [queryFromUrl, searchParams]);
+
+  const canSubmit = input.trim().length >= 2;
+
+  const onSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const q = input.trim();
+    if (q.length < 2) return;
+    router.push(`/search?q=${encodeURIComponent(q)}`);
+  };
+
+  const statusLine = useMemo(() => {
+    const q = queryFromUrl.trim();
+    if (!q) return 'Enter a keyword to search the fan club.';
+    if (loading) return `Searching for "${q}"…`;
+    if (error) return error;
+    if (!data) return '';
+    if (data.total === 0) return `No results for "${q}".`;
+    return `${data.total} result${data.total === 1 ? '' : 's'} for "${q}"`;
+  }, [queryFromUrl, loading, error, data]);
 
   return (
     <main style={{ padding: '40px 16px', maxWidth: 980, margin: '0 auto' }}>
       <h1 style={{ fontSize: 34, margin: '0 0 12px 0' }}>Search</h1>
-      <p style={{ opacity: 0.85, marginTop: 0 }}>{help}</p>
 
-      <label style={{ display: 'grid', gap: 8, maxWidth: 640, marginTop: 18 }}>
-        <span style={{ fontWeight: 700 }}>Search query</span>
-        <input
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-          placeholder="Try: 'Yankees', '1934', 'Lou Gehrig', 'timeline'"
-          type="search"
-          style={{ padding: '12px 14px', borderRadius: 12, border: '1px solid rgba(0,0,0,0.2)', fontSize: 16 }}
-        />
-      </label>
+      <form onSubmit={onSubmit} style={{ display: 'grid', gap: 10, maxWidth: 720 }}>
+        <label style={{ display: 'grid', gap: 8 }}>
+          <span style={{ fontWeight: 700 }}>Search the Lou Gehrig Fan Club</span>
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Search the Lou Gehrig Fan Club…"
+            type="search"
+            style={{
+              padding: '12px 14px',
+              borderRadius: 12,
+              border: '1px solid #dde3f5',
+              fontSize: 16,
+              minHeight: 48,
+              width: '100%',
+            }}
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={!canSubmit || loading}
+          style={{
+            width: 'fit-content',
+            padding: '10px 16px',
+            borderRadius: 10,
+            border: 'none',
+            background: 'var(--lgfc-blue)',
+            color: '#fff',
+            fontWeight: 700,
+            cursor: canSubmit && !loading ? 'pointer' : 'not-allowed',
+            opacity: canSubmit ? 1 : 0.6,
+          }}
+        >
+          Search
+        </button>
+      </form>
 
-      <div style={{ marginTop: 20, padding: 16, borderRadius: 14, border: '1px solid rgba(0,0,0,0.12)' }}>
-        Search is available for quick keyword entry and will continue improving across public and member sections.
+      <p style={{ marginTop: 18, color: '#666', minHeight: 24 }}>{statusLine}</p>
+
+      {data?.isMember ? (
+        <p style={{ marginTop: 0, color: 'rgba(0,0,0,0.65)', fontSize: 14 }}>
+          Member session detected: results include Fan Club content.
+        </p>
+      ) : null}
+
+      <div style={{ marginTop: 16, display: 'grid', gap: 16 }}>
+        {(data?.results || []).map((result, index) => (
+          <article
+            key={`${result.type}-${result.url}-${index}`}
+            style={{
+              background: '#fff',
+              border: '1px solid #dde3f5',
+              borderRadius: 14,
+              padding: 20,
+              boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+            }}
+          >
+            <div
+              style={{
+                display: 'inline-block',
+                fontSize: 12,
+                textTransform: 'uppercase',
+                letterSpacing: 0.4,
+                padding: '4px 10px',
+                borderRadius: 999,
+                background: '#f8f9ff',
+                color: 'var(--lgfc-blue)',
+                fontWeight: 700,
+                marginBottom: 10,
+              }}
+            >
+              {result.type}
+            </div>
+            <h2 style={{ margin: '0 0 8px 0', fontSize: 18 }}>
+              <Link href={result.url} style={{ color: '#333', textDecoration: 'none' }}>
+                {result.title}
+              </Link>
+            </h2>
+            {result.excerpt ? <p style={{ margin: 0, color: '#666', lineHeight: 1.5 }}>{result.excerpt}</p> : null}
+          </article>
+        ))}
       </div>
+
+      {data && data.pages > 1 ? (
+        <div style={{ marginTop: 20, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          {Array.from({ length: data.pages }, (_, i) => i + 1).map((pageNumber) => {
+            const active = pageNumber === data.page;
+            return (
+              <Link
+                key={pageNumber}
+                href={`/search?q=${encodeURIComponent(queryFromUrl)}&page=${pageNumber}`}
+                style={{
+                  padding: '8px 12px',
+                  borderRadius: 8,
+                  textDecoration: 'none',
+                  fontWeight: 700,
+                  background: active ? 'var(--lgfc-blue)' : '#fff',
+                  color: active ? '#fff' : '#333',
+                  border: '1px solid #dde3f5',
+                }}
+              >
+                {pageNumber}
+              </Link>
+            );
+          })}
+        </div>
+      ) : null}
     </main>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={<main style={{ padding: 40 }}>Loading search…</main>}>
+      <SearchPageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
- **Issue:** #1108

## Design source of truth
- /docs/reference/design/search.md

## FILE-TOUCH ALLOWLIST
- functions/api/search.ts
- src/app/search/page.tsx

## Change summary
- Added GET /api/search with visitor/member permission filtering across FAQ, events, milestones, friends, and member-only content.
- Rebuilt /search page with URL ?q= pattern, submit flow, result cards, pagination, and fail-closed states.

## Build/test/verification evidence
- npm run typecheck ✅ pass

## Acceptance criteria
- [x] Search page operational with URL query pattern
- [x] Empty and error states handled
- [x] Member session expands searchable scope
- [x] Canonical navigation preserved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the T25 search experience by adding a permission-aware `GET /api/search` and rebuilding the `/search` page with URL-driven queries, results, and pagination. Visitors see public results; members also see Fan Club content. Addresses #1108.

- **New Features**
  - API: `GET /api/search?q=&page=` aggregates D1 results across FAQ, events, milestones, friends; includes discussions, library, photos, memorabilia for signed-in members. Returns ranked results with paging and `isMember`.
  - UI: `/search` reads `?q` and `page`, supports submit flow, result cards, pagination, and clear empty/error states. Shows a member-scope notice when applicable.
  - Meets #1108 requirements: URL query pattern, handled empty/error states, member-expanded scope, and links to canonical pages.

<sup>Written for commit 88934698c099410020ee5f4ac6d29b35087d55cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1130?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->