### PR TITLE
docs: normalize terminology in ownership map (#1132)

### DIFF
--- a/docs/reference/documentation-ownership-map-1132.md
+++ b/docs/reference/documentation-ownership-map-1132.md
@@ -3,7 +3,7 @@ Doc Type: Reference
 Audience: Human + AI
 Authority Level: Controlled
 Owns: project #1132 documentation ownership map
-Does Not Own: final product design, implementation mechanics, or runtime configuration
+Does Not Own: Final product design, implementation mechanics, or runtime configuration
 Canonical Reference: /docs/README.md
 Related issues: #1132, #1133
 Last Reviewed: 2026-05-29
@@ -31,7 +31,7 @@ This map identifies where LGFC documentation ownership currently lives so produc
 | Historical/legacy material | `docs/archive/` and legacy paths | Migration issues #1019/#1039/#1076 | Reference only unless promoted |
 | AI/agent rules | `docs/ops/ai/`, `.agents/skills/`, `ops/ai/` | Agent.md | Must be normalized to avoid split authority |
 
-## project Package Ownership Targets
+## Package Ownership Targets
 
 | Package | Design document location target | Implementation plan location target | As-built destination |
 |---|---|---|---|

--- a/docs/reference/documentation-ownership-map-1132.md
+++ b/docs/reference/documentation-ownership-map-1132.md
@@ -2,14 +2,14 @@
 Doc Type: Reference
 Audience: Human + AI
 Authority Level: Controlled
-Owns: Project #1132 documentation ownership map
-Does Not Own: Final product design, implementation mechanics, or runtime configuration
+Owns: project #1132 documentation ownership map
+Does Not Own: final product design, implementation mechanics, or runtime configuration
 Canonical Reference: /docs/README.md
-Related Issues: #1132, #1133
+Related issues: #1132, #1133
 Last Reviewed: 2026-05-29
 ---
 
-# Documentation Ownership Map — Project #1132
+# Documentation Ownership Map — project #1132
 
 ## Purpose
 
@@ -24,14 +24,14 @@ This map identifies where LGFC documentation ownership currently lives so produc
 | Runtime website behavior | `docs/reference/design/LGFC-Production-Design-and-Standards.md` | Worklists, issues, as-built logs | Product behavior authority |
 | Access and permissions | `docs/reference/architecture/access-model.md` | Admin/Fan Club design package issues | Used for member/admin boundaries |
 | Content inventory architecture | `docs/reference/content-inventory-design-spec.md` | `docs/reference/content-inventory-d1-schema.md` | Source for content package |
-| CI orchestration design | `docs/explanation/ci/lgfc-ci-production-design.md` | `docs/how-to/ci/`, `docs/reference/ci/`, Issues #1075/#1058/#1096/#1131 | Existing CI package appears mature and needs reconciliation |
-| Implementation sequencing | `docs/how-to/` and `docs/ops/trackers/` | GitHub Issues | How-to docs and trackers should support plans, not override design |
-| Operational state | `docs/ops/` | GitHub Issues and PRs | Live process/status surface |
+| CI orchestration design | `docs/explanation/ci/lgfc-ci-production-design.md` | `docs/how-to/ci/`, `docs/reference/ci/`, issues #1075/#1058/#1096/#1131 | Existing CI package appears mature and needs reconciliation |
+| Implementation sequencing | `docs/how-to/` and `docs/ops/trackers/` | GitHub issues | How-to docs and trackers should support plans, not override design |
+| Operational state | `docs/ops/` | GitHub issues and PRs | Live process/status surface |
 | As-built records | `docs/as-built/` | Closed PRs and deployment records | Receives agent-created operational documentation after implementation |
 | Historical/legacy material | `docs/archive/` and legacy paths | Migration issues #1019/#1039/#1076 | Reference only unless promoted |
 | AI/agent rules | `docs/ops/ai/`, `.agents/skills/`, `ops/ai/` | Agent.md | Must be normalized to avoid split authority |
 
-## Project Package Ownership Targets
+## project Package Ownership Targets
 
 | Package | Design document location target | Implementation plan location target | As-built destination |
 |---|---|---|---|
@@ -39,8 +39,8 @@ This map identifies where LGFC documentation ownership currently lives so produc
 | Admin System | `docs/reference/` | `docs/how-to/` | `docs/as-built/` |
 | Content Collection System | `docs/reference/` | `docs/how-to/` | `docs/as-built/` |
 | CI Orchestration System | `docs/explanation/ci/`, `docs/reference/ci/`, `docs/how-to/ci/` | `docs/how-to/ci/` | `docs/as-built/` |
-| DIATAXIS Migration Project | `docs/reference/` or `docs/governance/standards/` as applicable | `docs/how-to/` | `docs/as-built/` |
-| Legacy Retirement Project | `docs/reference/` | `docs/how-to/` | `docs/as-built/` |
+| DIATAXIS Migration project | `docs/reference/` or `docs/governance/standards/` as applicable | `docs/how-to/` | `docs/as-built/` |
+| Legacy Retirement project | `docs/reference/` | `docs/how-to/` | `docs/as-built/` |
 
 ## Rule
 


### PR DESCRIPTION
- **Issue:** #1132

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized terminology and casing in the Documentation Ownership Map for project #1132 to match our style guide. Improves clarity and search consistency across the doc.

- **Refactors**
  - Lowercased front matter and headings; retitled “Project Package Ownership Targets” → “Package Ownership Targets”.
  - Standardized “issues” phrasing across tables (e.g., “GitHub issues”, “issues #1075/#1058/#1096/#1131”).
  - Updated package names to consistent casing (e.g., `DIATAXIS Migration project`, `Legacy Retirement project`).

<sup>Written for commit cdbb8c08b47993cfd119ee0a1540e67c0343014d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->