### PR TITLE
docs: add gap analysis and migration matrix

### DIFF
--- a/docs/reference/documentation-gap-analysis-1132.md
+++ b/docs/reference/documentation-gap-analysis-1132.md
@@ -1,0 +1,47 @@
+---
+Doc Type: Reference
+Audience: human project owner and AI agents
+Authority Level: supporting
+Owns: project #1132 documentation gap analysis and completion sequencing
+Does Not Own: implementation code, runtime behavior, CI workflow code, or historical as-built records
+Canonical Reference: docs/reference/documentation-ownership-map-1132.md
+Related issues: #1132, #1134
+Last Reviewed: 2026-05-29
+---
+
+# Documentation Gap Analysis — project #1132
+
+## Purpose
+
+This document defines the remaining documentation gaps for the project #1132 documentation completion program. It uses the project inventory and ownership map to identify what must still be written, reconciled, migrated, or retired before the documentation program can close.
+
+## Current baseline
+
+The repository now has starter production definitions and implementation plans for the Fan Club, Admin, and Content Collection areas. It also has an inventory report and an ownership map. These documents establish the baseline, but they do not complete the gap analysis, legacy disposition, or remaining CI and governance package definitions.
+
+## Gap matrix
+
+| Area | Current status | Gap | Required follow-up |
+|---|---|---|---|
+| Fan Club | Starter production definition and implementation plan exist | Needs validation against live route/component state and as-built evidence | Verify against current app structure and update package if drift is found |
+| Admin | Starter production definition and implementation plan exist | Needs deeper permission, workflow, and moderation boundary detail | Add admin workflow and acceptance detail after current implementation state is confirmed |
+| Content Collection | Starter production definition exists | Needs editorial lifecycle, intake, review, approval, rejection, archive, and media linkage detail | Expand content collection package into operational workflow definitions |
+| CI Orchestration | Multiple CI design and workflow docs exist | Needs one reconciled production definition and implementation plan tied to current gates | Produce CI orchestration package and reviewer lifecycle redesign plan |
+| DIATAXIS Migration | Folder structure and guardrails exist | Needs migration map, serial order, duplicate handling, and acceptance criteria | Complete legacy-to-DIATAXIS migration matrix and execution plan |
+| Legacy Retirement | Archive and legacy sources exist | Needs explicit keep, merge, split, archive, or delete decisions | Produce legacy retirement package with closure criteria |
+| Governance | Authority hierarchy exists | Needs conflict map between issues, trackers, docs, and archived material | Add documentation normalization plan after migration matrix is complete |
+| Operations | Trackers and as-built records exist | Needs consistent linkage between PRs, issues, implementation, and as-built docs | Define post-implementation as-built requirements per package |
+
+## Completion sequence
+
+1. Complete the legacy-to-DIATAXIS migration matrix.
+2. Reconcile CI orchestration documentation and reviewer lifecycle rules.
+3. Expand Content Collection operational definitions.
+4. Validate Fan Club and Admin definitions against current implementation state.
+5. Produce legacy retirement package.
+6. Generate remaining child implementation issues from the finalized document set.
+7. Close project #1132 only after all gaps are resolved or explicitly deferred.
+
+## Closure criteria
+
+Project #1132 can close when each major documentation area has a clear owner, current production definition, implementation plan when needed, migration disposition, and no unresolved duplicate or conflicting authority source remains.

--- a/docs/reference/legacy-to-diataxis-migration-matrix-1132.md
+++ b/docs/reference/legacy-to-diataxis-migration-matrix-1132.md
@@ -1,0 +1,39 @@
+---
+Doc Type: Reference
+Audience: human project owner and AI agents
+Authority Level: supporting
+Owns: legacy-to-DIATAXIS migration planning for project #1132
+Does Not Own: implementation code or archival execution
+Canonical Reference: docs/reference/documentation-gap-analysis-1132.md
+Related issues: #1132, #1134
+Last Reviewed: 2026-05-29
+---
+
+# Legacy to DIATAXIS Migration Matrix
+
+## Purpose
+
+Define how legacy documentation is evaluated and migrated into the repository documentation structure.
+
+| Legacy State | Action | Destination |
+|---|---|---|
+| Active authoritative document | Keep | Existing authority location |
+| Duplicate authority | Merge | Canonical authority document |
+| Historical reference | Archive | docs/archive |
+| Mixed design and implementation content | Split | Reference + How-To + As-Built |
+| Obsolete material | Retire | Archive with retirement note |
+
+## Migration order
+
+1. Authority documents
+2. Production definitions
+3. Implementation plans
+4. Operations documents
+5. Historical material
+
+## Acceptance criteria
+
+- One authority source per subject.
+- No duplicate production definitions.
+- Legacy material preserved when historically valuable.
+- Migration decisions documented before execution.


### PR DESCRIPTION
- **Issue:** #1134

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds two reference docs: a documentation gap analysis for project #1132 and a legacy-to-DIATAXIS migration matrix. This defines the remaining work, sequence, and acceptance criteria to close #1132 and guide migration efforts in #1134.

- **New Docs**
  - Documentation Gap Analysis: outlines gaps across Fan Club, Admin, Content Collection, CI, DIATAXIS migration, Legacy, Governance, and Operations; includes completion sequence and closure criteria.
  - Legacy → DIATAXIS Migration Matrix: maps legacy states to actions (keep/merge/archive/split/retire), sets migration order, and lists acceptance criteria.

<sup>Written for commit ba97c40a2c906b77d0320a300781629f567bb039. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

