### PR TITLE
feat(auth): T28 join/login UX and auth-state validation (#1110)

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -16,8 +16,11 @@
 /library        /library/               308
 /library/       /library/index.html     200
 
-/login          /login/               308
-/login/         /login/index.html     200
+/login          /                     302
+/login/         /                     302
+
+/auth           /join/                302
+/auth/          /join/                302
 
 /logout         /logout/               308
 /logout/        /logout/index.html     200

--- a/scripts/ci/verify_lgfc_invariants.mjs
+++ b/scripts/ci/verify_lgfc_invariants.mjs
@@ -14,12 +14,12 @@ const header = fs.readFileSync('src/components/Header.tsx', 'utf8');
 const idxJoin = header.indexOf('href="/join"');
 const idxSearch = header.indexOf('href="/search"');
 const idxStore = header.indexOf('bonfire.com/store/lou-gehrig-fan-club');
-const idxLogin = header.indexOf('LOGIN_TAB_ROUTE');
+const idxLogin = header.indexOf('href="/login"');
 
 must(idxJoin !== -1, 'Header missing Join link to /join');
 must(idxSearch !== -1, 'Header missing Search link to /search');
 must(idxStore !== -1, 'Header missing Store external link');
-must(idxLogin !== -1, 'Header missing Login link to canonical /join login tab route');
+must(idxLogin !== -1, 'Header missing Login link to /login');
 must(idxJoin < idxSearch && idxSearch < idxStore && idxStore < idxLogin, 'Header public button order must be Join, Search, Store, Login');
 
 const fanClubHeader = fs.readFileSync('src/components/FanClubHeader.tsx', 'utf8');

--- a/scripts/ci/verify_lgfc_invariants.mjs
+++ b/scripts/ci/verify_lgfc_invariants.mjs
@@ -14,12 +14,12 @@ const header = fs.readFileSync('src/components/Header.tsx', 'utf8');
 const idxJoin = header.indexOf('href="/join"');
 const idxSearch = header.indexOf('href="/search"');
 const idxStore = header.indexOf('bonfire.com/store/lou-gehrig-fan-club');
-const idxLogin = header.indexOf('href="/login"');
+const idxLogin = header.indexOf('LOGIN_TAB_ROUTE');
 
 must(idxJoin !== -1, 'Header missing Join link to /join');
 must(idxSearch !== -1, 'Header missing Search link to /search');
 must(idxStore !== -1, 'Header missing Store external link');
-must(idxLogin !== -1, 'Header missing Login link to /login');
+must(idxLogin !== -1, 'Header missing Login link to canonical /join login tab route');
 must(idxJoin < idxSearch && idxSearch < idxStore && idxStore < idxLogin, 'Header public button order must be Join, Search, Store, Login');
 
 const fanClubHeader = fs.readFileSync('src/components/FanClubHeader.tsx', 'utf8');

--- a/scripts/ci/verify_lgfc_invariants.mjs
+++ b/scripts/ci/verify_lgfc_invariants.mjs
@@ -14,7 +14,7 @@ const header = fs.readFileSync('src/components/Header.tsx', 'utf8');
 const idxJoin = header.indexOf('href="/join"');
 const idxSearch = header.indexOf('href="/search"');
 const idxStore = header.indexOf('bonfire.com/store/lou-gehrig-fan-club');
-const idxLogin = header.indexOf('LOGIN_TAB_ROUTE');
+const idxLogin = header.indexOf('href={LOGIN_TAB_ROUTE}');
 
 must(idxJoin !== -1, 'Header missing Join link to /join');
 must(idxSearch !== -1, 'Header missing Search link to /search');

--- a/src/app/auth/AuthClient.tsx
+++ b/src/app/auth/AuthClient.tsx
@@ -36,9 +36,10 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
   const [checkingSession, setCheckingSession] = useState(true);
 
   const initialMode = useMemo<Mode>(() => {
-    if (defaultMode) return defaultMode;
-    const mode = (sp.get('mode') || '').toLowerCase();
-    return mode === 'login' ? 'login' : 'join';
+    const queryMode = (sp.get('mode') || '').toLowerCase();
+    if (queryMode === 'login') return 'login';
+    if (queryMode === 'join') return 'join';
+    return defaultMode ?? 'join';
   }, [sp, defaultMode]);
 
   const [mode, setMode] = useState<Mode>(initialMode);
@@ -59,12 +60,15 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
 
   useEffect(() => {
     let cancelled = false;
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), 10_000);
 
     async function redirectIfAuthenticated() {
       try {
         const res = await fetch('/api/session/me', {
           credentials: 'include',
           cache: 'no-store',
+          signal: controller.signal,
           headers: { accept: 'application/json' },
         });
         const json: unknown = await res.json().catch(() => null);
@@ -85,6 +89,8 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
     redirectIfAuthenticated();
     return () => {
       cancelled = true;
+      window.clearTimeout(timeoutId);
+      controller.abort();
     };
   }, []);
 
@@ -94,6 +100,11 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
 
     if (!screenName.trim()) {
       setMsg('Screen name is required.');
+      return;
+    }
+
+    if (!fullName.trim()) {
+      setMsg('Full name is required.');
       return;
     }
 
@@ -202,6 +213,7 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
           type="button"
           role="tab"
           aria-selected={mode === 'join'}
+          tabIndex={mode === 'join' ? 0 : -1}
           onClick={() => {
             setMode('join');
             setMsg(null);
@@ -215,6 +227,7 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
           type="button"
           role="tab"
           aria-selected={mode === 'login'}
+          tabIndex={mode === 'login' ? 0 : -1}
           onClick={() => {
             setMode('login');
             setMsg(null);

--- a/src/app/auth/AuthClient.tsx
+++ b/src/app/auth/AuthClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Suspense, useMemo, useState, type FormEvent } from 'react';
+import { Suspense, useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { isValidEmail, JOIN_ROUTE, POST_LOGIN_ROUTE } from '@/lib/auth-routes';
 
 type Mode = 'login' | 'join';
 
@@ -32,11 +33,12 @@ function pickErrMsg(err: unknown, fallback: string): string {
 
 function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
   const sp = useSearchParams();
+  const [checkingSession, setCheckingSession] = useState(true);
 
   const initialMode = useMemo<Mode>(() => {
     if (defaultMode) return defaultMode;
-    const m = (sp.get('mode') || '').toLowerCase();
-    return m === 'join' ? 'join' : 'login';
+    const mode = (sp.get('mode') || '').toLowerCase();
+    return mode === 'login' ? 'login' : 'join';
   }, [sp, defaultMode]);
 
   const [mode, setMode] = useState<Mode>(initialMode);
@@ -51,15 +53,62 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
 
+  useEffect(() => {
+    setMode(initialMode);
+  }, [initialMode]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function redirectIfAuthenticated() {
+      try {
+        const res = await fetch('/api/session/me', {
+          credentials: 'include',
+          cache: 'no-store',
+          headers: { accept: 'application/json' },
+        });
+        const json: unknown = await res.json().catch(() => null);
+        const ok = isRecord(json) && json.ok === true;
+        const email = isRecord(json) && typeof json.email === 'string' ? json.email.trim() : '';
+
+        if (!cancelled && ok && email) {
+          window.location.replace(POST_LOGIN_ROUTE);
+          return;
+        }
+      } catch {
+        // Fail closed to guest join/login surface.
+      }
+
+      if (!cancelled) setCheckingSession(false);
+    }
+
+    redirectIfAuthenticated();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   async function doJoin(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setMsg(null);
+
+    if (!screenName.trim()) {
+      setMsg('Screen name is required.');
+      return;
+    }
+
+    if (!isValidEmail(emailJoin)) {
+      setMsg('Enter a valid email address.');
+      return;
+    }
+
     setBusy(true);
     try {
       const { first, last } = splitName(fullName);
 
       const res = await fetch('/api/join', {
         method: 'POST',
+        credentials: 'include',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           first_name: first,
@@ -81,6 +130,7 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
 
       const res2 = await fetch('/api/login', {
         method: 'POST',
+        credentials: 'include',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ email: emailJoin }),
       });
@@ -94,7 +144,7 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
         return;
       }
 
-      window.location.href = '/fanclub';
+      window.location.href = POST_LOGIN_ROUTE;
     } catch (err: unknown) {
       setMsg(pickErrMsg(err, 'Join failed.'));
     } finally {
@@ -105,10 +155,17 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
   async function doLogin(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setMsg(null);
+
+    if (!isValidEmail(emailLogin)) {
+      setMsg('Enter a valid email address.');
+      return;
+    }
+
     setBusy(true);
     try {
       const res = await fetch('/api/login', {
         method: 'POST',
+        credentials: 'include',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ email: emailLogin }),
       });
@@ -120,7 +177,7 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
         return;
       }
 
-      window.location.href = '/fanclub';
+      window.location.href = POST_LOGIN_ROUTE;
     } catch (err: unknown) {
       setMsg(pickErrMsg(err, 'Login failed.'));
     } finally {
@@ -128,29 +185,60 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
     }
   }
 
+  if (checkingSession) {
+    return (
+      <main style={{ maxWidth: 560, margin: '40px auto', padding: 20 }}>
+        Checking session…
+      </main>
+    );
+  }
+
   return (
     <main style={{ maxWidth: 560, margin: '40px auto', padding: 20 }}>
       <h1 style={{ textAlign: 'center', marginBottom: 16 }}>Join / Login</h1>
 
-      <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
-        <button type="button" onClick={() => { setMode('login'); setMsg(null); }} style={{ flex: 1 }}>
-          Login
-        </button>
-        <button type="button" onClick={() => { setMode('join'); setMsg(null); }} style={{ flex: 1 }}>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 16 }} role="tablist" aria-label="Join or Login">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'join'}
+          onClick={() => {
+            setMode('join');
+            setMsg(null);
+            window.history.replaceState(null, '', JOIN_ROUTE);
+          }}
+          style={{ flex: 1 }}
+        >
           Join
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'login'}
+          onClick={() => {
+            setMode('login');
+            setMsg(null);
+            window.history.replaceState(null, '', `${JOIN_ROUTE}?mode=login`);
+          }}
+          style={{ flex: 1 }}
+        >
+          Login
         </button>
       </div>
 
       {msg && (
-        <div style={{ marginBottom: 14, padding: 10, border: '1px solid #ccc', borderRadius: 8 }}>
+        <div role="alert" style={{ marginBottom: 14, padding: 10, border: '1px solid #ccc', borderRadius: 8 }}>
           {msg}
         </div>
       )}
 
       {mode === 'login' && (
-        <form onSubmit={doLogin}>
-          <label style={{ display: 'block', marginBottom: 6 }}>Email</label>
+        <form onSubmit={doLogin} noValidate>
+          <label style={{ display: 'block', marginBottom: 6 }} htmlFor="login-email">
+            Email
+          </label>
           <input
+            id="login-email"
             value={emailLogin}
             onChange={(e) => setEmailLogin(e.target.value)}
             placeholder="you@example.com"
@@ -158,6 +246,7 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
             style={{ width: '100%', marginBottom: 12, padding: 10 }}
             autoComplete="email"
             inputMode="email"
+            type="email"
           />
           <button type="submit" disabled={busy} style={{ width: '100%', padding: 10 }}>
             {busy ? 'Working…' : 'Login'}
@@ -166,9 +255,12 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
       )}
 
       {mode === 'join' && (
-        <form onSubmit={doJoin}>
-          <label style={{ display: 'block', marginBottom: 6 }}>Screen name / alias</label>
+        <form onSubmit={doJoin} noValidate>
+          <label style={{ display: 'block', marginBottom: 6 }} htmlFor="join-screen-name">
+            Screen name / alias
+          </label>
           <input
+            id="join-screen-name"
             value={screenName}
             onChange={(e) => setScreenName(e.target.value)}
             placeholder="Your public name"
@@ -177,8 +269,11 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
             autoComplete="nickname"
           />
 
-          <label style={{ display: 'block', marginBottom: 6 }}>Full name</label>
+          <label style={{ display: 'block', marginBottom: 6 }} htmlFor="join-full-name">
+            Full name
+          </label>
           <input
+            id="join-full-name"
             value={fullName}
             onChange={(e) => setFullName(e.target.value)}
             placeholder="First Last"
@@ -187,8 +282,11 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
             autoComplete="name"
           />
 
-          <label style={{ display: 'block', marginBottom: 6 }}>Email</label>
+          <label style={{ display: 'block', marginBottom: 6 }} htmlFor="join-email">
+            Email
+          </label>
           <input
+            id="join-email"
             value={emailJoin}
             onChange={(e) => setEmailJoin(e.target.value)}
             placeholder="you@example.com"
@@ -196,6 +294,7 @@ function InnerAuthClient({ defaultMode }: { defaultMode?: Mode }) {
             style={{ width: '100%', marginBottom: 10, padding: 10 }}
             autoComplete="email"
             inputMode="email"
+            type="email"
           />
 
           <label style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,5 +1,16 @@
-import AuthClient from './AuthClient';
+'use client';
 
-export default function AuthPage() {
-  return <AuthClient />;
+import { useEffect } from 'react';
+import { JOIN_ROUTE } from '@/lib/auth-routes';
+
+export default function AuthLegacyRedirectPage() {
+  useEffect(() => {
+    window.location.replace(JOIN_ROUTE);
+  }, []);
+
+  return (
+    <main style={{ padding: 24, maxWidth: 900, margin: '0 auto' }}>
+      Redirecting…
+    </main>
+  );
 }

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -10,7 +10,9 @@ export default function AuthLegacyRedirectPage() {
 
   return (
     <main style={{ padding: 24, maxWidth: 900, margin: '0 auto' }}>
-      Redirecting…
+      <p>
+        Redirecting… <a href={JOIN_ROUTE}>Continue to join</a>
+      </p>
     </main>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,7 +10,9 @@ export default function LoginLegacyRedirectPage() {
 
   return (
     <main style={{ padding: 24, maxWidth: 900, margin: '0 auto' }}>
-      Redirecting…
+      <p>
+        Redirecting… <a href={POST_LOGOUT_ROUTE}>Continue to home</a>
+      </p>
     </main>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,16 @@
-import AuthClient from '../auth/AuthClient';
+'use client';
 
-export default function LoginPage(){
-  return <AuthClient defaultMode="login" />;
+import { useEffect } from 'react';
+import { POST_LOGOUT_ROUTE } from '@/lib/auth-routes';
+
+export default function LoginLegacyRedirectPage() {
+  useEffect(() => {
+    window.location.replace(POST_LOGOUT_ROUTE);
+  }, []);
+
+  return (
+    <main style={{ padding: 24, maxWidth: 900, margin: '0 auto' }}>
+      Redirecting…
+    </main>
+  );
 }

--- a/src/components/HamburgerMenu.tsx
+++ b/src/components/HamburgerMenu.tsx
@@ -4,8 +4,7 @@ import Link from 'next/link';
 import { useRef, RefObject } from 'react';
 import { useClickAway } from '@/hooks/useClickAway';
 import styles from './HamburgerMenu.module.css';
-
-export const STORE_URL = 'https://www.bonfire.com/store/lou-gehrig-fan-club/';
+import { LOGIN_TAB_ROUTE, STORE_URL } from '@/lib/auth-routes';
 
 export type HamburgerMenuVariant = 'public-guest' | 'public-member' | 'fanclub';
 
@@ -18,7 +17,7 @@ export const HAMBURGER_MENU_ITEMS: Record<HamburgerMenuVariant, MenuItem[]> = {
     { kind: 'link', label: 'Join', href: '/join' },
     { kind: 'link', label: 'Search', href: '/search' },
     { kind: 'external', label: 'Store', href: STORE_URL },
-    { kind: 'link', label: 'Login', href: '/join' },
+    { kind: 'link', label: 'Login', href: LOGIN_TAB_ROUTE },
     { kind: 'link', label: 'About', href: '/about' },
     { kind: 'link', label: 'Contact', href: '/contact' },
   ],

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
+import { LOGIN_TAB_ROUTE } from '@/lib/auth-routes';
 import styles from './Header.module.css';
 import HamburgerMenu from './HamburgerMenu';
 
@@ -106,7 +107,7 @@ export default function Header({ showLogo = true }: HeaderProps = {}) {
           </a>
 
           {!isLoggedIn ? (
-            <Link className={styles.btn} href="/login">Login</Link>
+            <Link className={styles.btn} href={LOGIN_TAB_ROUTE}>Login</Link>
           ) : (
             <>
               <Link className={styles.btn} href="/logout">Logout</Link>

--- a/src/components/JoinCTA.tsx
+++ b/src/components/JoinCTA.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { LOGIN_TAB_ROUTE } from '@/lib/auth-routes';
 
 export default function JoinCTA() {
   return (
@@ -8,7 +9,7 @@ export default function JoinCTA() {
         <p className="join-banner__text">Become a member. Get access to the Gehrig library, media archive, memorabilia archive, group discussions, and more.</p>
         <div className="join-banner__actions">
           <Link className="join-banner__btn" href="/join">Join</Link>
-          <Link className="join-banner__btn" href="/login">Login</Link>
+          <Link className="join-banner__btn" href={LOGIN_TAB_ROUTE}>Login</Link>
         </div>
       </div>
     </div>

--- a/src/lib/auth-routes.ts
+++ b/src/lib/auth-routes.ts
@@ -1,0 +1,12 @@
+export const JOIN_ROUTE = '/join';
+export const LOGIN_LEGACY_ROUTE = '/login';
+export const AUTH_LEGACY_ROUTE = '/auth';
+export const POST_LOGIN_ROUTE = '/fanclub';
+export const POST_LOGOUT_ROUTE = '/';
+export const LOGIN_TAB_ROUTE = '/join?mode=login';
+export const STORE_URL = 'https://www.bonfire.com/store/lou-gehrig-fan-club/';
+
+export function isValidEmail(value: string): boolean {
+  const email = value.trim();
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}

--- a/tests/join-login-auth.test.tsx
+++ b/tests/join-login-auth.test.tsx
@@ -10,6 +10,12 @@ import Header from '@/components/Header';
 import JoinCTA from '@/components/JoinCTA';
 import { isValidEmail, LOGIN_TAB_ROUTE, POST_LOGOUT_ROUTE } from '@/lib/auth-routes';
 
+const mockSearchParams = vi.hoisted(() => vi.fn(() => new URLSearchParams('')));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams(),
+}));
+
 describe('auth route helpers', () => {
   it('validates email format', () => {
     expect(isValidEmail('fan@example.com')).toBe(true);
@@ -67,7 +73,21 @@ describe('AuthClient auth-state behavior', () => {
     });
   });
 
+  it('opens login tab when /join?mode=login even with join defaultMode', async () => {
+    mockSearchParams.mockReturnValue(new URLSearchParams('mode=login'));
+
+    render(<AuthClient defaultMode="join" />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Checking session/i)).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('tab', { name: 'Login' })).toHaveAttribute('aria-selected', 'true');
+  });
+
   it('shows inline validation before login submit', async () => {
+    mockSearchParams.mockReturnValue(new URLSearchParams('mode=login'));
+
     render(<AuthClient defaultMode="login" />);
 
     await waitFor(() => {
@@ -113,7 +133,7 @@ describe('LGFC header auth invariants', () => {
     const idxJoin = header.indexOf('href="/join"');
     const idxSearch = header.indexOf('href="/search"');
     const idxStore = header.indexOf('bonfire.com/store/lou-gehrig-fan-club');
-    const idxLogin = header.indexOf('LOGIN_TAB_ROUTE');
+    const idxLogin = header.indexOf('href={LOGIN_TAB_ROUTE}');
 
     expect(idxJoin).toBeGreaterThan(-1);
     expect(idxSearch).toBeGreaterThan(-1);

--- a/tests/join-login-auth.test.tsx
+++ b/tests/join-login-auth.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
 
 import AuthClient from '@/app/auth/AuthClient';
 import AuthLegacyRedirectPage from '@/app/auth/page';
@@ -103,5 +104,23 @@ describe('navigation auth links', () => {
   it('routes homepage CTA Login to canonical join login tab', () => {
     render(<JoinCTA />);
     expect(screen.getByRole('link', { name: 'Login' })).toHaveAttribute('href', LOGIN_TAB_ROUTE);
+  });
+});
+
+describe('LGFC header auth invariants', () => {
+  it('keeps public header button order and canonical login route', () => {
+    const header = fs.readFileSync('src/components/Header.tsx', 'utf8');
+    const idxJoin = header.indexOf('href="/join"');
+    const idxSearch = header.indexOf('href="/search"');
+    const idxStore = header.indexOf('bonfire.com/store/lou-gehrig-fan-club');
+    const idxLogin = header.indexOf('LOGIN_TAB_ROUTE');
+
+    expect(idxJoin).toBeGreaterThan(-1);
+    expect(idxSearch).toBeGreaterThan(-1);
+    expect(idxStore).toBeGreaterThan(-1);
+    expect(idxLogin).toBeGreaterThan(-1);
+    expect(idxJoin).toBeLessThan(idxSearch);
+    expect(idxSearch).toBeLessThan(idxStore);
+    expect(idxStore).toBeLessThan(idxLogin);
   });
 });

--- a/tests/join-login-auth.test.tsx
+++ b/tests/join-login-auth.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AuthClient from '@/app/auth/AuthClient';
+import AuthLegacyRedirectPage from '@/app/auth/page';
+import LoginLegacyRedirectPage from '@/app/login/page';
+import Header from '@/components/Header';
+import JoinCTA from '@/components/JoinCTA';
+import { isValidEmail, LOGIN_TAB_ROUTE, POST_LOGOUT_ROUTE } from '@/lib/auth-routes';
+
+describe('auth route helpers', () => {
+  it('validates email format', () => {
+    expect(isValidEmail('fan@example.com')).toBe(true);
+    expect(isValidEmail('not-an-email')).toBe(false);
+  });
+});
+
+describe('legacy auth redirects', () => {
+  beforeEach(() => {
+    vi.stubGlobal('location', { replace: vi.fn(), href: '' });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('redirects /login to public home', () => {
+    render(<LoginLegacyRedirectPage />);
+    expect(window.location.replace).toHaveBeenCalledWith(POST_LOGOUT_ROUTE);
+  });
+
+  it('redirects /auth to canonical /join', () => {
+    render(<AuthLegacyRedirectPage />);
+    expect(window.location.replace).toHaveBeenCalledWith('/join');
+  });
+});
+
+describe('AuthClient auth-state behavior', () => {
+  beforeEach(() => {
+    vi.stubGlobal('location', { replace: vi.fn(), href: '' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: async () => ({ ok: false }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('redirects authenticated users to /fanclub', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: async () => ({ ok: true, email: 'fan@example.com', role: 'member' }),
+      }),
+    );
+
+    render(<AuthClient defaultMode="join" />);
+
+    await waitFor(() => {
+      expect(window.location.replace).toHaveBeenCalledWith('/fanclub');
+    });
+  });
+
+  it('shows inline validation before login submit', async () => {
+    render(<AuthClient defaultMode="login" />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Checking session/i)).not.toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Login' }));
+    await userEvent.type(screen.getByLabelText(/^Email/i), 'bad-email');
+    await userEvent.click(screen.getByRole('button', { name: 'Login' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/valid email/i);
+  });
+});
+
+describe('navigation auth links', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: async () => ({ ok: false }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('routes header Login to canonical join login tab', () => {
+    render(<Header showLogo={false} />);
+    expect(screen.getByRole('link', { name: 'Login' })).toHaveAttribute('href', LOGIN_TAB_ROUTE);
+  });
+
+  it('routes homepage CTA Login to canonical join login tab', () => {
+    render(<JoinCTA />);
+    expect(screen.getByRole('link', { name: 'Login' })).toHaveAttribute('href', LOGIN_TAB_ROUTE);
+  });
+});

--- a/tests/mobile-navigation.test.tsx
+++ b/tests/mobile-navigation.test.tsx
@@ -6,8 +6,8 @@ import Header from '@/components/Header';
 import FanClubHeader from '@/components/FanClubHeader';
 import HamburgerMenu, {
   HAMBURGER_MENU_ITEMS,
-  STORE_URL,
 } from '@/components/HamburgerMenu';
+import { STORE_URL } from '@/lib/auth-routes';
 import Footer from '@/components/Footer';
 import { createRef } from 'react';
 
@@ -41,7 +41,7 @@ describe('HamburgerMenu variants', () => {
     const links = screen.getAllByRole('link').map((node) => node.textContent?.trim());
     expect(links).toEqual(labels);
     expect(screen.getByRole('link', { name: 'Store' })).toHaveAttribute('href', STORE_URL);
-    expect(screen.getByRole('link', { name: 'Login' })).toHaveAttribute('href', '/join');
+    expect(screen.getByRole('link', { name: 'Login' })).toHaveAttribute('href', '/join?mode=login');
   });
 
   it('renders public member drawer items in canonical order', () => {


### PR DESCRIPTION
- **Issue:** #1110

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- `/docs/reference/design/auth-model.md`
- `/docs/reference/design/join-login.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `src/lib/auth-routes.ts`
- `src/app/login/page.tsx`
- `src/app/auth/page.tsx`
- `src/app/auth/AuthClient.tsx`
- `src/components/Header.tsx`
- `src/components/JoinCTA.tsx`
- `src/components/HamburgerMenu.tsx`
- `public/_redirects`
- `scripts/ci/verify_lgfc_invariants.mjs`
- `tests/join-login-auth.test.tsx`
- `tests/mobile-navigation.test.tsx`

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header auth-state invariants preserved
- [x] Canonical `/join` combined Join/Login surface retained
- [x] Legacy `/login` redirect policy enforced

## CHANGE SUMMARY
- Shared auth route constants; legacy `/login` → `/` and `/auth` → `/join` via `_redirects` plus client fallback.
- AuthClient session guard, email/full-name validation, login-tab query support, session timeout, tab keyboard a11y.
- Header/CTA/hamburger Login links to `/join?mode=login`.
- Drift invariant anchored to `href={LOGIN_TAB_ROUTE}`; auth regression tests added.

## BUILD / TEST / VERIFICATION
- `npm run typecheck` — pass
- `npm test -- tests/join-login-auth.test.tsx tests/mobile-navigation.test.tsx` — pass (17 tests)
- `node scripts/ci/verify_lgfc_invariants.mjs` — pass

## DOCUMENTATION UPDATES
- [x] No documentation updates required — matches existing auth-model and join-login design authority

## REVIEWER RESPONSE ACCOUNTING
- [x] Reviewed all reviewer comments.
- [x] Copilot disposition received.
- [x] Codex disposition received.
- [x] Gemini disposition received.
- [x] Cubic disposition received.
- [x] Every actionable reviewer comment has a PR-body disposition.

Reviewer items:
- review-comment:3328757862 — accepted — Drift invariant now matches `href={LOGIN_TAB_ROUTE}` in Header JSX — thread state: resolved
- review-comment:3328757864 — accepted — Added client-side full-name validation in `doJoin` — thread state: resolved
- review-comment:3328758401 — accepted — `initialMode` honors `?mode=login` before defaultMode — thread state: resolved
- review-comment:3328759592 — accepted — Added 10s AbortController timeout on session preflight — thread state: resolved
- review-comment:3328759595 — accepted — Added full-name validation before join submit — thread state: resolved
- review-comment:3328759604 — accepted — Added roving `tabIndex` on auth tabs — thread state: resolved
- review-comment:3328760181 — accepted — Drift invariant + Header login href alignment — thread state: resolved
- review-comment:3328760182 — accepted — Added `_redirects` `/login` → `/` plus client fallback link — thread state: resolved
- review-comment:3328761689 — accepted — `_redirects` static redirect plus client fallback (static export constraint) — thread state: resolved
- review-comment:3328761692 — accepted — Full-name validation in join flow — thread state: resolved
- review-comment:3328774385 — accepted — Same invariant href-anchor fix — thread state: resolved
- review-comment:3328781718 — accepted — `_redirects` `/auth` → `/join/` plus client fallback — thread state: resolved

## ACCEPTANCE CRITERIA
- [x] `/login` legacy redirect to `/`
- [x] `/join?mode=login` opens Login tab
- [x] Authenticated users redirect to `/fanclub`
- [x] Drift invariant passes for canonical login route
- [x] Join/login validation and tests in place