### PR TITLE
infra(ci): align header login invariant for T28 (#1110)

### DIFF
--- a/scripts/ci/verify_lgfc_invariants.mjs
+++ b/scripts/ci/verify_lgfc_invariants.mjs
@@ -14,12 +14,12 @@ const header = fs.readFileSync('src/components/Header.tsx', 'utf8');
 const idxJoin = header.indexOf('href="/join"');
 const idxSearch = header.indexOf('href="/search"');
 const idxStore = header.indexOf('bonfire.com/store/lou-gehrig-fan-club');
-const idxLogin = header.indexOf('href="/login"');
+const idxLogin = header.indexOf('LOGIN_TAB_ROUTE');
 
 must(idxJoin !== -1, 'Header missing Join link to /join');
 must(idxSearch !== -1, 'Header missing Search link to /search');
 must(idxStore !== -1, 'Header missing Store external link');
-must(idxLogin !== -1, 'Header missing Login link to /login');
+must(idxLogin !== -1, 'Header missing Login link to canonical /join login tab route');
 must(idxJoin < idxSearch && idxSearch < idxStore && idxStore < idxLogin, 'Header public button order must be Join, Search, Store, Login');
 
 const fanClubHeader = fs.readFileSync('src/components/FanClubHeader.tsx', 'utf8');


### PR DESCRIPTION
- **Issue:** #1110

## FILE-TOUCH ALLOWLIST
- `scripts/ci/verify_lgfc_invariants.mjs`

## CHANGE SUMMARY
- Update drift invariant check so Header Login uses canonical `/join?mode=login` route constant instead of legacy `/login` href.

## BUILD / TEST / VERIFICATION
- `node scripts/ci/verify_lgfc_invariants.mjs` — pass after #1149 Header change lands

## Merge note
Merge before or with #1149 (T28 join/login UX).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `scripts/ci/verify_lgfc_invariants.mjs` to require the Header Login link uses the canonical `/join` login tab route via `LOGIN_TAB_ROUTE` instead of the legacy `/login`. Aligns with T28 join/login UX (#1149) and satisfies #1110; please merge with or after #1149.

<sup>Written for commit e4c4ad950783a1fa08bc1661a13171d8879d20db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->