### PR TITLE
infra(ci): anchor T28 login invariant to Header href

### DIFF
--- a/scripts/ci/verify_lgfc_invariants.mjs
+++ b/scripts/ci/verify_lgfc_invariants.mjs
@@ -14,7 +14,7 @@ const header = fs.readFileSync('src/components/Header.tsx', 'utf8');
 const idxJoin = header.indexOf('href="/join"');
 const idxSearch = header.indexOf('href="/search"');
 const idxStore = header.indexOf('bonfire.com/store/lou-gehrig-fan-club');
-const idxLogin = header.indexOf('LOGIN_TAB_ROUTE');
+const idxLogin = header.indexOf('href={LOGIN_TAB_ROUTE}');
 
 must(idxJoin !== -1, 'Header missing Join link to /join');
 must(idxSearch !== -1, 'Header missing Search link to /search');


### PR DESCRIPTION
- **Issue:** #1110

One-line drift invariant fix for #1149. Merge before or with #1149.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors the T28 login invariant to the Header href by updating `scripts/ci/verify_lgfc_invariants.mjs` to check for `href={LOGIN_TAB_ROUTE}` instead of `LOGIN_TAB_ROUTE`. Prevents CI false positives and aligns with #1149; merge before or with it.

<sup>Written for commit de21717d414ac39c63a79bbc67556fd49a20fd1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->