### PR TITLE
feat: add admin operations surfaces

### DIFF
--- a/functions/api/admin/stats.ts
+++ b/functions/api/admin/stats.ts
@@ -9,39 +9,51 @@ export const onRequestGet = async (context: any): Promise<Response> => {
   const deny = requireAdmin(request, env);
   if (deny) return deny;
 
-  try {
-    const db = env.DB as any;
-    const tables = [
-      "join_requests",
-      "members",
-      "join_email_log",
-      "login_attempts",
-      "library_entries",
-      "photos",
-      "media_assets",
-      "page_content",
-      "content_blocks",
-      "content_revisions",
-      "faq_entries",
-      "events",
-      "milestones",
-      "friends",
-      "discussions",
-      "weekly_matchups",
-      "weekly_votes",
-      "footer_quotes",
-      "membership_card_content",
-      "welcome_email_content",
-      "admin_team_worklist"
-    ];
-    const counts: Record<string, number> = {};
+  const db = env.DB as any;
+  if (!db?.prepare) {
+    return new Response(JSON.stringify({ ok: false, error: "D1 binding is not configured." }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 
-    for (const t of tables) {
+  const tables = [
+    "join_requests",
+    "members",
+    "join_email_log",
+    "login_attempts",
+    "library_entries",
+    "photos",
+    "media_assets",
+    "page_content",
+    "content_blocks",
+    "content_revisions",
+    "faq_entries",
+    "events",
+    "milestones",
+    "friends",
+    "discussions",
+    "weekly_matchups",
+    "weekly_votes",
+    "footer_quotes",
+    "membership_card_content",
+    "welcome_email_content",
+    "admin_team_worklist"
+  ];
+  const counts: Record<string, number> = {};
+  const unavailable: Record<string, string> = {};
+
+  for (const t of tables) {
+    try {
       const r = await db.prepare(`SELECT COUNT(*) as n FROM ${t}`).all();
       counts[t] = Number((r?.results?.[0] as any)?.n || 0);
+    } catch (err: any) {
+      unavailable[t] = err?.message ? String(err.message) : "Unavailable";
     }
+  }
 
-    return new Response(JSON.stringify({ ok: true, counts }, null, 2), {
+  try {
+    return new Response(JSON.stringify({ ok: true, counts, unavailable }, null, 2), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });

--- a/src/app/admin/join-requests/page.tsx
+++ b/src/app/admin/join-requests/page.tsx
@@ -3,6 +3,9 @@
 import React, { useEffect, useState } from 'react';
 import PageShell from '@/components/PageShell';
 import AdminNav from '@/components/admin/AdminNav';
+import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
+import { adminJson, isRecord } from '@/lib/adminClient';
+import styles from '@/components/admin/AdminDashboard.module.css';
 
 type JoinRequest = {
   id: number;
@@ -16,11 +19,6 @@ type JoinRequest = {
   email_opt_in?: number | null;
   presence_status?: string | null;
 };
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null;
-}
-
 
 function asString(v: unknown): string | null {
   return typeof v === 'string' ? v : null;
@@ -65,33 +63,21 @@ function normalize(raw: unknown): JoinRequest | null {
   };
 }
 
-function getToken(): string {
-  if (typeof window === 'undefined') return '';
-  return window.localStorage.getItem('lgfc_admin_token') || '';
-}
-
 export default function AdminJoinRequestsPage() {
   const [status, setStatus] = useState<string>('');
   const [items, setItems] = useState<JoinRequest[]>([]);
 
   async function load() {
     setStatus('Loading…');
-    const token = getToken();
-    const res = await fetch('/api/admin/join-requests/list?limit=50', {
-      headers: token ? { 'x-admin-token': token } : {},
-      cache: 'no-store',
-    });
-    const data: unknown = await res.json().catch(() => ({}));
+    const result = await adminJson<{ ok: true; items?: unknown[] }>('/api/admin/join-requests/list?limit=50');
 
-    if (!isRecord(data) || data.ok !== true) {
-      const err = isRecord(data) && typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
-      setStatus(`Error: ${err}`);
+    if (!result.ok || !result.data) {
+      setStatus(`Error: ${result.error}`);
       setItems([]);
       return;
     }
 
-    const raw = (data as Record<string, unknown>).items;
-    const arr = Array.isArray(raw) ? raw : [];
+    const arr = Array.isArray(result.data.items) ? result.data.items : [];
     const normalized = arr.map(normalize).filter((x): x is JoinRequest => x !== null);
 
     setItems(normalized);
@@ -105,27 +91,28 @@ export default function AdminJoinRequestsPage() {
   return (
     <PageShell title="Join Requests" subtitle="Recent join requests captured from /join">
       <AdminNav />
-      <div style={{ marginTop: 14 }}>
+      <div className={styles.wrap}>
+        <AdminTokenPanel onSaved={() => void load()} />
         <button
           onClick={() => void load()}
-          style={{ border: '1px solid #ddd', borderRadius: 10, padding: '10px 12px', fontWeight: 700, cursor: 'pointer' }}
+          className={styles.btn}
         >
           Refresh
         </button>
 
-        {status ? <p style={{ marginTop: 10, opacity: 0.85 }}>{status}</p> : null}
+        {status ? <p className={styles.status}>{status}</p> : null}
 
-        <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>
+        <div className={styles.list}>
           {items.map((j) => (
-            <div key={j.id} style={{ border: '1px solid #eee', borderRadius: 12, padding: 12 }}>
-              <div style={{ fontWeight: 800 }}>{j.name}</div>
-              <div style={{ opacity: 0.85, marginTop: 4 }}>{j.email}</div>
-              <div style={{ opacity: 0.75, marginTop: 6, fontSize: 13 }}>
+            <div key={j.id} className={styles.listItem}>
+              <div className={styles.cardTitle}>{j.name}</div>
+              <div className={styles.status}>{j.email}</div>
+              <div className={styles.status}>
                 {j.created_at ? new Date(j.created_at).toLocaleString() : ''}
                 {j.presence_status ? ` • ${j.presence_status}` : ''}
                 {typeof j.email_opt_in === 'number' ? ` • opt-in: ${j.email_opt_in ? 'yes' : 'no'}` : ''}
               </div>
-              {j.message ? <div style={{ marginTop: 10, whiteSpace: 'pre-wrap' }}>{j.message}</div> : null}
+              {j.message ? <div className={styles.prewrap}>{j.message}</div> : null}
             </div>
           ))}
         </div>

--- a/src/app/admin/member-operations/page.tsx
+++ b/src/app/admin/member-operations/page.tsx
@@ -134,9 +134,7 @@ export default function AdminMemberOperationsPage() {
               <div className={styles.panelHeader}>
                 <div>
                   <div className={styles.panelTitle}>{endpoint.heading}</div>
-                  <p className={styles.status}>
-                    {current.updated_at ? `Last updated: ${current.updated_at}` : endpoint.emptyText}
-                  </p>
+                  {current.updated_at ? <p className={styles.status}>Last updated: {current.updated_at}</p> : null}
                 </div>
                 <button className={styles.btn} type="button" onClick={() => void saveEndpoint(endpoint)}>
                   Publish

--- a/src/app/admin/member-operations/page.tsx
+++ b/src/app/admin/member-operations/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import PageShell from '@/components/PageShell';
 import AdminNav from '@/components/admin/AdminNav';
 import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
@@ -61,7 +61,7 @@ export default function AdminMemberOperationsPage() {
     card: 'Loading membership card...',
   });
 
-  async function loadEndpoint(endpoint: ManagedEndpoint) {
+  const loadEndpoint = useCallback(async (endpoint: ManagedEndpoint) => {
     setMessages((current) => ({ ...current, [endpoint.key]: `Loading ${endpoint.heading.toLowerCase()}...` }));
     const result = await adminJson<Record<string, unknown>>(endpoint.path);
     if (!result.ok || !result.data) {
@@ -79,11 +79,11 @@ export default function AdminMemberOperationsPage() {
       ...current,
       [endpoint.key]: nextContent.body_md ? '' : endpoint.emptyText,
     }));
-  }
+  }, []);
 
-  async function loadAll() {
+  const loadAll = useCallback(async () => {
     await Promise.all(endpoints.map(loadEndpoint));
-  }
+  }, [loadEndpoint]);
 
   async function saveEndpoint(endpoint: ManagedEndpoint) {
     const current = content[endpoint.key];
@@ -119,7 +119,7 @@ export default function AdminMemberOperationsPage() {
 
   useEffect(() => {
     void loadAll();
-  }, []);
+  }, [loadAll]);
 
   return (
     <PageShell title="Member Operations" subtitle="Admin-managed member onboarding and card content">

--- a/src/app/admin/member-operations/page.tsx
+++ b/src/app/admin/member-operations/page.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import PageShell from '@/components/PageShell';
+import AdminNav from '@/components/admin/AdminNav';
+import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
+import { adminJson, isRecord } from '@/lib/adminClient';
+import styles from '@/components/admin/AdminDashboard.module.css';
+
+type ManagedContent = {
+  id?: number;
+  title: string;
+  body_md: string;
+  status?: string | null;
+  updated_at?: string | null;
+};
+
+type ManagedEndpoint = {
+  key: 'welcome' | 'card';
+  heading: string;
+  emptyText: string;
+  path: string;
+  defaultTitle: string;
+};
+
+const endpoints: ManagedEndpoint[] = [
+  {
+    key: 'welcome',
+    heading: 'Welcome Email',
+    emptyText: 'No welcome email content is published yet.',
+    path: '/api/admin/welcome-email',
+    defaultTitle: 'Welcome Email',
+  },
+  {
+    key: 'card',
+    heading: 'Membership Card',
+    emptyText: 'No membership card instructions are published yet.',
+    path: '/api/admin/membership-card',
+    defaultTitle: 'Membership Card',
+  },
+];
+
+function asContent(data: unknown, defaultTitle: string): ManagedContent {
+  if (!isRecord(data)) return { title: defaultTitle, body_md: '' };
+  return {
+    id: typeof data.id === 'number' ? data.id : undefined,
+    title: typeof data.title === 'string' && data.title.trim() ? data.title : defaultTitle,
+    body_md: typeof data.body_md === 'string' ? data.body_md : '',
+    status: typeof data.status === 'string' ? data.status : null,
+    updated_at: typeof data.updated_at === 'string' ? data.updated_at : null,
+  };
+}
+
+export default function AdminMemberOperationsPage() {
+  const [content, setContent] = useState<Record<ManagedEndpoint['key'], ManagedContent>>({
+    welcome: { title: 'Welcome Email', body_md: '' },
+    card: { title: 'Membership Card', body_md: '' },
+  });
+  const [messages, setMessages] = useState<Record<ManagedEndpoint['key'], string>>({
+    welcome: 'Loading welcome email...',
+    card: 'Loading membership card...',
+  });
+
+  async function loadEndpoint(endpoint: ManagedEndpoint) {
+    setMessages((current) => ({ ...current, [endpoint.key]: `Loading ${endpoint.heading.toLowerCase()}...` }));
+    const result = await adminJson<Record<string, unknown>>(endpoint.path);
+    if (!result.ok || !result.data) {
+      setMessages((current) => ({ ...current, [endpoint.key]: `Error: ${result.error}` }));
+      setContent((current) => ({
+        ...current,
+        [endpoint.key]: { title: endpoint.defaultTitle, body_md: '' },
+      }));
+      return;
+    }
+
+    const nextContent = asContent(result.data, endpoint.defaultTitle);
+    setContent((current) => ({ ...current, [endpoint.key]: nextContent }));
+    setMessages((current) => ({
+      ...current,
+      [endpoint.key]: nextContent.body_md ? '' : endpoint.emptyText,
+    }));
+  }
+
+  async function loadAll() {
+    await Promise.all(endpoints.map(loadEndpoint));
+  }
+
+  async function saveEndpoint(endpoint: ManagedEndpoint) {
+    const current = content[endpoint.key];
+    if (!current.body_md.trim()) {
+      setMessages((state) => ({ ...state, [endpoint.key]: 'Body content is required.' }));
+      return;
+    }
+
+    setMessages((state) => ({ ...state, [endpoint.key]: `Publishing ${endpoint.heading.toLowerCase()}...` }));
+    const result = await adminJson<{ ok: true }>(endpoint.path, {
+      method: 'POST',
+      body: JSON.stringify({
+        title: current.title,
+        body_md: current.body_md,
+      }),
+    });
+    if (!result.ok) {
+      setMessages((state) => ({ ...state, [endpoint.key]: `Error: ${result.error}` }));
+      return;
+    }
+    setMessages((state) => ({ ...state, [endpoint.key]: `${endpoint.heading} published.` }));
+  }
+
+  function updateContent(endpoint: ManagedEndpoint, patch: Partial<ManagedContent>) {
+    setContent((current) => ({
+      ...current,
+      [endpoint.key]: {
+        ...current[endpoint.key],
+        ...patch,
+      },
+    }));
+  }
+
+  useEffect(() => {
+    void loadAll();
+  }, []);
+
+  return (
+    <PageShell title="Member Operations" subtitle="Admin-managed member onboarding and card content">
+      <AdminNav />
+      <div className={styles.wrap}>
+        <AdminTokenPanel onSaved={() => void loadAll()} />
+
+        {endpoints.map((endpoint) => {
+          const current = content[endpoint.key];
+          return (
+            <section key={endpoint.key} className={styles.panel} aria-label={endpoint.heading}>
+              <div className={styles.panelHeader}>
+                <div>
+                  <div className={styles.panelTitle}>{endpoint.heading}</div>
+                  <p className={styles.status}>
+                    {current.updated_at ? `Last updated: ${current.updated_at}` : endpoint.emptyText}
+                  </p>
+                </div>
+                <button className={styles.btn} type="button" onClick={() => void saveEndpoint(endpoint)}>
+                  Publish
+                </button>
+              </div>
+              {messages[endpoint.key] ? <p className={styles.status}>{messages[endpoint.key]}</p> : null}
+              <div className={styles.formGrid}>
+                <label className={styles.field}>
+                  <span>Title</span>
+                  <input
+                    value={current.title}
+                    onChange={(event) => updateContent(endpoint, { title: event.target.value })}
+                  />
+                </label>
+                <label className={styles.fieldWide}>
+                  <span>Body markdown</span>
+                  <textarea
+                    value={current.body_md}
+                    rows={8}
+                    onChange={(event) => updateContent(endpoint, { body_md: event.target.value })}
+                  />
+                </label>
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/admin/worklist/page.tsx
+++ b/src/app/admin/worklist/page.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import PageShell from '@/components/PageShell';
+import AdminNav from '@/components/admin/AdminNav';
+import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
+import { adminJson, isRecord } from '@/lib/adminClient';
+import styles from '@/components/admin/AdminDashboard.module.css';
+
+type WorklistItem = {
+  id: number;
+  task: string;
+  owner?: string | null;
+  status: string;
+  needed_completion_date?: string | null;
+  updated_at?: string | null;
+};
+
+type WorklistResponse = { ok: true; results?: unknown[] };
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '' && Number.isFinite(Number(value))) return Number(value);
+  return null;
+}
+
+function normalizeWorklistItem(raw: unknown): WorklistItem | null {
+  if (!isRecord(raw)) return null;
+  const id = asNumber(raw.id);
+  const task = asString(raw.task);
+  const status = asString(raw.status) || 'open';
+  if (id === null || !task) return null;
+
+  return {
+    id: Math.trunc(id),
+    task,
+    status,
+    owner: asString(raw.owner),
+    needed_completion_date: asString(raw.needed_completion_date),
+    updated_at: asString(raw.updated_at),
+  };
+}
+
+export default function AdminWorklistPage() {
+  const [items, setItems] = useState<WorklistItem[]>([]);
+  const [status, setStatus] = useState('Loading worklist...');
+  const [task, setTask] = useState('');
+  const [owner, setOwner] = useState('');
+  const [neededDate, setNeededDate] = useState('');
+
+  async function load() {
+    setStatus('Loading worklist...');
+    const result = await adminJson<WorklistResponse>('/api/admin/worklist');
+    if (!result.ok || !result.data) {
+      setItems([]);
+      setStatus(`Error: ${result.error}`);
+      return;
+    }
+
+    const normalized = (Array.isArray(result.data.results) ? result.data.results : [])
+      .map(normalizeWorklistItem)
+      .filter((item): item is WorklistItem => item !== null);
+    setItems(normalized);
+    setStatus(normalized.length ? '' : 'No worklist items found.');
+  }
+
+  async function addItem(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!task.trim()) {
+      setStatus('Task is required.');
+      return;
+    }
+
+    setStatus('Adding worklist item...');
+    const result = await adminJson<{ ok: true }>('/api/admin/worklist', {
+      method: 'POST',
+      body: JSON.stringify({
+        task,
+        owner,
+        needed_completion_date: neededDate,
+      }),
+    });
+    if (!result.ok) {
+      setStatus(`Error: ${result.error}`);
+      return;
+    }
+
+    setTask('');
+    setOwner('');
+    setNeededDate('');
+    await load();
+  }
+
+  async function updateStatus(id: number, nextStatus: string) {
+    setStatus('Updating worklist item...');
+    const result = await adminJson<{ ok: true }>('/api/admin/worklist', {
+      method: 'PATCH',
+      body: JSON.stringify({ id, status: nextStatus }),
+    });
+    if (!result.ok) {
+      setStatus(`Error: ${result.error}`);
+      return;
+    }
+    await load();
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  return (
+    <PageShell title="Admin Worklist" subtitle="Operational admin tasks, owners, due dates, and status">
+      <AdminNav />
+      <div className={styles.wrap}>
+        <AdminTokenPanel onSaved={() => void load()} />
+
+        <form className={styles.panel} onSubmit={addItem}>
+          <div className={styles.panelHeader}>
+            <div className={styles.panelTitle}>Add worklist item</div>
+            <button className={styles.btn} type="submit">
+              Add item
+            </button>
+          </div>
+          <div className={styles.formGrid}>
+            <label className={styles.field}>
+              <span>Task</span>
+              <input value={task} onChange={(event) => setTask(event.target.value)} />
+            </label>
+            <label className={styles.field}>
+              <span>Owner</span>
+              <input value={owner} onChange={(event) => setOwner(event.target.value)} />
+            </label>
+            <label className={styles.field}>
+              <span>Needed completion date</span>
+              <input type="date" value={neededDate} onChange={(event) => setNeededDate(event.target.value)} />
+            </label>
+          </div>
+        </form>
+
+        <section className={styles.panel} aria-label="Admin worklist items">
+          <div className={styles.panelHeader}>
+            <div className={styles.panelTitle}>Current worklist</div>
+            <button className={styles.btn} type="button" onClick={() => void load()}>
+              Refresh
+            </button>
+          </div>
+          {status ? <p className={styles.status}>{status}</p> : null}
+          <div className={styles.list}>
+            {items.map((item) => (
+              <article key={item.id} className={styles.listItem}>
+                <div>
+                  <h2>{item.task}</h2>
+                  <p>
+                    {item.owner ? `Owner: ${item.owner}` : 'Owner unassigned'}
+                    {item.needed_completion_date ? ` | Due: ${item.needed_completion_date}` : ''}
+                  </p>
+                  <p>Status: {item.status}</p>
+                </div>
+                <div className={styles.actions}>
+                  {['open', 'in_progress', 'completed'].map((nextStatus) => (
+                    <button
+                      key={nextStatus}
+                      className={styles.btn}
+                      type="button"
+                      disabled={item.status === nextStatus}
+                      onClick={() => void updateStatus(item.id, nextStatus)}
+                    >
+                      {nextStatus.replace('_', ' ')}
+                    </button>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/components/admin/AdminDashboard.module.css
+++ b/src/components/admin/AdminDashboard.module.css
@@ -107,6 +107,7 @@
 .field input,
 .fieldWide input,
 .fieldWide textarea{
+  box-sizing:border-box;
   width:100%;
   border:1px solid rgba(0,0,0,0.22);
   border-radius:12px;

--- a/src/components/admin/AdminDashboard.module.css
+++ b/src/components/admin/AdminDashboard.module.css
@@ -1,3 +1,8 @@
+.wrap{
+  display:grid;
+  gap:18px;
+}
+
 .grid{
   display:grid;
   grid-template-columns:repeat(2,1fr);
@@ -12,15 +17,130 @@
 }
 
 .card{
+  display:block;
   border:1px solid rgba(0,0,0,0.12);
   border-radius:16px;
   padding:18px;
   background:white;
+  color:#111;
+  text-decoration:none;
+}
+
+.card:hover{
+  border-color: rgba(0,0,0,0.28);
 }
 
 .card h2{
   margin:0 0 6px 0;
   font-size:1.2rem;
+}
+
+.cardTitle{
+  font-weight:800;
+  font-size:1.05rem;
+}
+
+.cardBody{
+  margin-top:6px;
+  opacity:0.82;
+  line-height:1.45;
+}
+
+.panel{
+  border:1px solid rgba(0,0,0,0.12);
+  border-radius:16px;
+  padding:16px;
+  background:rgba(255,255,255,0.95);
+}
+
+.panelHeader{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  flex-wrap:wrap;
+}
+
+.panelTitle{
+  font-weight:800;
+  font-size:18px;
+}
+
+.btn{
+  padding:10px 14px;
+  border-radius:12px;
+  border:1px solid rgba(0,0,0,0.22);
+  background:#fff;
+  font-weight:700;
+  cursor:pointer;
+}
+
+.status{
+  margin:10px 0 0 0;
+  opacity:0.86;
+}
+
+.formGrid{
+  display:grid;
+  grid-template-columns:repeat(2, minmax(0, 1fr));
+  gap:12px;
+  margin-top:14px;
+}
+
+@media (max-width: 820px){
+  .formGrid{
+    grid-template-columns:1fr;
+  }
+}
+
+.field,
+.fieldWide{
+  display:grid;
+  gap:6px;
+  font-weight:700;
+}
+
+.fieldWide{
+  grid-column:1 / -1;
+}
+
+.field input,
+.fieldWide input,
+.fieldWide textarea{
+  width:100%;
+  border:1px solid rgba(0,0,0,0.22);
+  border-radius:12px;
+  padding:10px 12px;
+  font:inherit;
+  font-weight:400;
+}
+
+.list{
+  display:grid;
+  gap:10px;
+  margin-top:12px;
+}
+
+.listItem{
+  border:1px solid rgba(0,0,0,0.10);
+  border-radius:12px;
+  padding:12px;
+  background:#fff;
+}
+
+.listItem h2{
+  margin:0 0 6px 0;
+  font-size:1.05rem;
+}
+
+.listItem p{
+  margin:6px 0 0 0;
+  opacity:0.82;
+}
+
+.prewrap{
+  margin-top:10px;
+  white-space:pre-wrap;
 }
 
 .actions{
@@ -130,6 +250,24 @@
   grid-template-columns:repeat(3, 1fr);
   gap:10px;
   margin-top:12px;
+}
+
+.stat{
+  border:1px solid rgba(0,0,0,0.10);
+  border-radius:12px;
+  padding:10px 12px;
+  background:#fff;
+}
+
+.statLabel{
+  font-size:12px;
+  opacity:0.75;
+}
+
+.statValue{
+  font-size:18px;
+  font-weight:800;
+  margin-top:4px;
 }
 
 @media (max-width: 820px){

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -2,17 +2,11 @@
 
 import React, { useEffect, useState } from 'react';
 import styles from './AdminDashboard.module.css';
+import AdminTokenPanel from './AdminTokenPanel';
+import { adminJson, isRecord } from '@/lib/adminClient';
 
 type CountRow = { table: string; count: number };
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null;
-}
-
-function getToken(): string {
-  if (typeof window === 'undefined') return '';
-  return window.localStorage.getItem('lgfc_admin_token') || '';
-}
+type StatsResponse = { ok: true; counts?: Record<string, number | string>; unavailable?: Record<string, string> };
 
 function asCounts(data: unknown): CountRow[] {
   if (!isRecord(data) || data.ok !== true) return [];
@@ -31,25 +25,24 @@ function asCounts(data: unknown): CountRow[] {
 export default function AdminDashboard() {
   const [status, setStatus] = useState<string>('');
   const [rows, setRows] = useState<CountRow[]>([]);
+  const [unavailable, setUnavailable] = useState<string[]>([]);
 
   async function loadStats() {
     setStatus('Loading stats…');
-    const token = getToken();
-    const res = await fetch('/api/admin/stats', {
-      headers: token ? { 'x-admin-token': token } : {},
-      cache: 'no-store',
-    });
+    const result = await adminJson<StatsResponse>('/api/admin/stats');
 
-    const data: unknown = await res.json().catch(() => ({}));
-    if (!isRecord(data) || data.ok !== true) {
-      const err = isRecord(data) && typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
-      setStatus(`Error: ${err}`);
+    if (!result.ok || !result.data) {
+      setStatus(`Error: ${result.error}`);
       setRows([]);
+      setUnavailable([]);
       return;
     }
 
-    setRows(asCounts(data));
-    setStatus('');
+    const nextRows = asCounts(result.data);
+    const skipped = isRecord(result.data.unavailable) ? Object.keys(result.data.unavailable).sort() : [];
+    setRows(nextRows);
+    setUnavailable(skipped);
+    setStatus(nextRows.length ? '' : 'No D1 table counts returned.');
   }
 
   useEffect(() => {
@@ -58,6 +51,8 @@ export default function AdminDashboard() {
 
   return (
     <div className={styles.wrap}>
+      <AdminTokenPanel onSaved={() => void loadStats()} />
+
       <div className={styles.grid}>
         <a className={styles.card} href="/admin/content">
           <div className={styles.cardTitle}>Page Content</div>
@@ -72,6 +67,16 @@ export default function AdminDashboard() {
         <a className={styles.card} href="/admin/join-requests">
           <div className={styles.cardTitle}>Join Requests</div>
           <div className={styles.cardBody}>View recent join requests captured from /join.</div>
+        </a>
+
+        <a className={styles.card} href="/admin/worklist">
+          <div className={styles.cardTitle}>Worklist</div>
+          <div className={styles.cardBody}>Track admin operations tasks, owners, due dates, and status.</div>
+        </a>
+
+        <a className={styles.card} href="/admin/member-operations">
+          <div className={styles.cardTitle}>Member Operations</div>
+          <div className={styles.cardBody}>Manage welcome email copy and membership card instructions.</div>
         </a>
 
         <a className={styles.card} href="/admin/media-assets">
@@ -104,6 +109,9 @@ export default function AdminDashboard() {
         </div>
 
         {status ? <p className={styles.status}>{status}</p> : null}
+        {unavailable.length ? (
+          <p className={styles.status}>Unavailable tables: {unavailable.join(', ')}</p>
+        ) : null}
 
         <div className={styles.statsGrid}>
           {rows.map((r) => (

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -11,6 +11,8 @@ const items: Array<{ href: string; label: string }> = [
   { href: '/admin/cms', label: 'CMS Blocks' },
   { href: '/admin/fundraiser-preview', label: 'Fundraiser Preview' },
   { href: '/admin/join-requests', label: 'Join Requests' },
+  { href: '/admin/worklist', label: 'Worklist' },
+  { href: '/admin/member-operations', label: 'Member Operations' },
   { href: '/admin/media-assets', label: 'Media Assets' },
   { href: '/admin/d1-test', label: 'D1 Inspect' },
 ];

--- a/src/components/admin/AdminTokenPanel.tsx
+++ b/src/components/admin/AdminTokenPanel.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getStoredAdminToken, setStoredAdminToken } from '@/lib/adminClient';
+import styles from './AdminDashboard.module.css';
+
+type AdminTokenPanelProps = {
+  onSaved?: () => void;
+};
+
+export default function AdminTokenPanel({ onSaved }: AdminTokenPanelProps) {
+  const [token, setToken] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    setToken(getStoredAdminToken());
+  }, []);
+
+  function saveToken() {
+    setStoredAdminToken(token);
+    setMessage(token.trim() ? 'Admin token saved for this browser.' : 'Admin token cleared.');
+    onSaved?.();
+  }
+
+  return (
+    <section className={styles.tokenCard} aria-label="Admin API token">
+      <div className={styles.tokenRow}>
+        <label className={styles.tokenLabel} htmlFor="admin-token">
+          Admin token
+        </label>
+        <input
+          id="admin-token"
+          className={styles.tokenInput}
+          type="password"
+          value={token}
+          onChange={(event) => setToken(event.target.value)}
+          placeholder="Paste admin API token"
+          autoComplete="off"
+        />
+        <button className={styles.tokenBtn} type="button" onClick={saveToken}>
+          Save token
+        </button>
+      </div>
+      <p className={styles.tokenHelp}>
+        Admin pages are session-gated; operational APIs also require the configured admin token.
+      </p>
+      {message ? <p className={styles.tokenHelp}>{message}</p> : null}
+    </section>
+  );
+}

--- a/src/lib/adminClient.ts
+++ b/src/lib/adminClient.ts
@@ -1,0 +1,61 @@
+'use client';
+
+export const ADMIN_TOKEN_STORAGE_KEY = 'lgfc_admin_token';
+
+export type AdminJsonResult<T> = {
+  ok: boolean;
+  status: number;
+  data: T | null;
+  error: string;
+};
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function getStoredAdminToken(): string {
+  if (typeof window === 'undefined') return '';
+  return window.localStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) || '';
+}
+
+export function setStoredAdminToken(token: string): void {
+  if (typeof window === 'undefined') return;
+  const normalized = token.trim();
+  if (normalized) {
+    window.localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, normalized);
+  } else {
+    window.localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
+  }
+}
+
+export async function adminJson<T>(path: string, init: RequestInit = {}): Promise<AdminJsonResult<T>> {
+  const token = getStoredAdminToken();
+  const headers = new Headers(init.headers);
+  if (token) headers.set('x-admin-token', token);
+  if (init.body && !headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
+
+  try {
+    const response = await fetch(path, {
+      ...init,
+      headers,
+      cache: init.cache ?? 'no-store',
+    });
+    const data: unknown = await response.json().catch(() => ({}));
+    const ok = isRecord(data) && data.ok === true;
+    const error = isRecord(data) && typeof data.error === 'string' ? data.error : `HTTP ${response.status}`;
+
+    return {
+      ok,
+      status: response.status,
+      data: ok ? (data as T) : null,
+      error,
+    };
+  } catch {
+    return {
+      ok: false,
+      status: 0,
+      data: null,
+      error: 'Request failed.',
+    };
+  }
+}

--- a/tests/admin-operations.test.tsx
+++ b/tests/admin-operations.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AdminLayout from '@/app/admin/layout';
+import AdminJoinRequestsPage from '@/app/admin/join-requests/page';
+import AdminMemberOperationsPage from '@/app/admin/member-operations/page';
+import AdminWorklistPage from '@/app/admin/worklist/page';
+import AdminNav from '@/components/admin/AdminNav';
+import { onRequestGet as statsGet } from '../functions/api/admin/stats';
+import { onRequestGet as worklistGet } from '../functions/api/admin/worklist';
+
+const mockUseMemberSession = vi.hoisted(() => vi.fn());
+const mockUsePathname = vi.hoisted(() => vi.fn(() => '/admin'));
+
+vi.mock('@/hooks/useMemberSession', () => ({
+  useMemberSession: mockUseMemberSession,
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: mockUsePathname,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function adminRequest(path: string, token = 'secret'): Request {
+  return new Request(`https://www.lougehrigfanclub.com${path}`, {
+    headers: { 'x-admin-token': token },
+  });
+}
+
+describe('admin route shell', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    mockUsePathname.mockReturnValue('/admin');
+  });
+
+  it('keeps admin layout gated to authenticated admins', () => {
+    mockUseMemberSession.mockReturnValue({ isLoading: false, isAuthenticated: false, role: null });
+    const { rerender } = render(
+      <AdminLayout>
+        <div>Protected admin content</div>
+      </AdminLayout>,
+    );
+
+    expect(screen.queryByText('Protected admin content')).not.toBeInTheDocument();
+
+    mockUseMemberSession.mockReturnValue({ isLoading: false, isAuthenticated: true, role: 'admin' });
+    rerender(
+      <AdminLayout>
+        <div>Protected admin content</div>
+      </AdminLayout>,
+    );
+
+    expect(screen.getByText('Protected admin content')).toBeInTheDocument();
+  });
+
+  it('exposes operational admin areas without public navigation leakage', () => {
+    render(<AdminNav />);
+
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveAttribute('href', '/admin');
+    expect(screen.getByRole('link', { name: 'Join Requests' })).toHaveAttribute('href', '/admin/join-requests');
+    expect(screen.getByRole('link', { name: 'Worklist' })).toHaveAttribute('href', '/admin/worklist');
+    expect(screen.getByRole('link', { name: 'Member Operations' })).toHaveAttribute(
+      'href',
+      '/admin/member-operations',
+    );
+    expect(screen.queryByRole('link', { name: 'Join' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Store' })).not.toBeInTheDocument();
+  });
+});
+
+describe('admin operational pages', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    window.localStorage.setItem('lgfc_admin_token', 'secret');
+    mockUsePathname.mockReturnValue('/admin');
+  });
+
+  it('renders join-request empty states and sends the admin token', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ ok: true, items: [] }) as never);
+
+    render(<AdminJoinRequestsPage />);
+
+    expect(await screen.findByText('No join requests found.')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/admin/join-requests/list?limit=50',
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+    const headers = fetchMock.mock.calls[0][1]?.headers as Headers;
+    expect(headers.get('x-admin-token')).toBe('secret');
+  });
+
+  it('renders worklist empty states without crashing', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ ok: true, results: [] }) as never);
+
+    render(<AdminWorklistPage />);
+
+    expect(await screen.findByText('No worklist items found.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add item' })).toBeInTheDocument();
+  });
+
+  it('renders member-operation empty states without crashing', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ ok: true }) as never)
+      .mockResolvedValueOnce(jsonResponse({ ok: true }) as never);
+
+    render(<AdminMemberOperationsPage />);
+
+    expect(await screen.findAllByText('No welcome email content is published yet.')).not.toHaveLength(0);
+    expect(await screen.findAllByText('No membership card instructions are published yet.')).not.toHaveLength(0);
+  });
+});
+
+describe('admin operational APIs', () => {
+  it('returns partial stats when one table is unavailable', async () => {
+    const db = {
+      prepare: vi.fn((sql: string) => ({
+        all: async () => {
+          if (sql.includes('photos')) throw new Error('no such table: photos');
+          return { results: [{ n: 2 }] };
+        },
+      })),
+    };
+
+    const response = await statsGet({
+      request: adminRequest('/api/admin/stats'),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      counts: { join_requests: 2 },
+      unavailable: { photos: 'no such table: photos' },
+    });
+  });
+
+  it('lists an empty admin worklist safely', async () => {
+    const db = {
+      prepare: vi.fn(() => ({
+        bind: () => ({
+          all: async () => ({ results: [] }),
+        }),
+      })),
+    };
+
+    const response = await worklistGet({
+      request: adminRequest('/api/admin/worklist'),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ ok: true, results: [] });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #1119

## PRE-OPEN GATE PREFLIGHT (MANDATORY)
- [x] Read source Issue #1119.
- [x] Read admin design and production definition sources.
- [x] Confirm PR body file allowlist matches the changed-file list.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root.
- [x] Final diff confirms no ZIP file is committed.

## PROGRESS + READINESS (MANDATORY)
- Phase: Phase 5 website operational systems
- Task: T41 Admin operating shell and member operations
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: None
- Notes: Tracker closeout for T29/T40 is handled separately in PR #1173. Screen recording save failed in this VM because `libavutil.so.58` is missing; screenshot walkthrough artifacts are included instead.

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `docs/reference/design/LGFC-Production-Design-and-Standards.md`
- `docs/reference/projects/admin-production-definition.md`
- `docs/how-to/projects/admin-implementation-plan.md`
- `docs/reference/lgfc-implementation-coverage-map.md`
- `docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
- `docs/ops/trackers/LGFC-WEBSITE-IMPLEMENTATION-QUEUE-NORMALIZATION.md`

## DIATAXIS GAP (REQUIRED IF LEGACY_FALLBACK)
- [ ] Gap Identified
- Link to issue: N/A
- Description: N/A

## LABEL
- Intent label for this PR: feature

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical design reference: `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- Additional design/reference docs used for this PR:
  - `/docs/reference/projects/admin-production-definition.md`
  - `/docs/how-to/projects/admin-implementation-plan.md`
  - `/docs/reference/lgfc-implementation-coverage-map.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `functions/api/admin/stats.ts`
- `src/app/admin/join-requests/page.tsx`
- `src/app/admin/member-operations/page.tsx`
- `src/app/admin/worklist/page.tsx`
- `src/components/admin/AdminDashboard.module.css`
- `src/components/admin/AdminDashboard.tsx`
- `src/components/admin/AdminNav.tsx`
- `src/components/admin/AdminTokenPanel.tsx`
- `src/lib/adminClient.ts`
- `tests/admin-operations.test.tsx`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label expected: `feature`
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## DOCS-ONLY ASSERTION (REQUIRED FOR change-ops)
- [ ] This PR contains documentation-only changes
- [x] Not applicable — this PR changes scoped admin runtime UI/API behavior and tests.

## CHANGE SUMMARY
- Added admin Worklist and Member Operations pages with token-aware API calls and safe empty/error states.
- Added admin dashboard and navigation entry points for T41 operational surfaces.
- Reused a shared admin token helper/panel across scoped admin pages.
- Hardened admin stats to return partial counts when individual tables are unavailable.
- Added focused admin operations tests.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `npm test -- tests/admin-operations.test.tsx tests/mobile-navigation.test.tsx` — PASS, 17 tests
  - `npm run typecheck` — PASS
  - `npm test` — PASS, 17 files / 192 tests; existing React act warnings in async UI tests
  - `npm run build` — PASS; existing lint warnings remain in unrelated files (`admin/faq` hook dependency and existing `<img>` warnings)
  - Local browser walkthrough against built static export plus stubbed admin API responses — PASS
- Result summary:
  - PASS
- Walkthrough artifacts:
  - ![Admin dashboard with T41 links and stats](https://cursor.com/artifacts/c/art-fb17f583-b6ea-46b5-b7d7-aec0836652f7)
  - ![Join Requests operational surface](https://cursor.com/artifacts/c/art-8dba5cdb-96a8-440e-8870-1dba10747541)
  - ![Worklist operational surface](https://cursor.com/artifacts/c/art-9be3a009-ffdf-4da0-97b9-e6a6ad660fbc)
  - ![Member Operations empty states](https://cursor.com/artifacts/c/art-d4aca89d-193e-4830-8718-cdadd1fc43fb)
- If FAIL, explain: N/A

## DOCUMENTATION UPDATES
- [ ] Documentation updated in this PR
- [x] No documentation updates required
- Files: N/A

## REVIEWER RESPONSE ACCOUNTING
- [x] No reviewer comments exist yet.

Reviewer items:
- N/A — no reviewer comments exist yet.

## PR GATE READINESS CHECKLIST
- [x] PR issue-accounting uses exactly one source Issue: #1119
- [x] PR body contains the required Issue syntax
- [x] Allowed files section matches final diff exactly
- [x] Local checks executed and passed
- [x] No merge-readiness claim made before all gate surfaces inspected

## ACCEPTANCE CRITERIA
- [x] Admin routes remain protected.
- [x] Admin navigation exposes required operational areas without public-nav leakage.
- [x] Join-request and member-operation surfaces have safe empty/error states.
- [x] Stats/worklist surfaces render without runtime failure.
- [x] No public or Fan Club route behavior changes are introduced.
- [x] Verification complete.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] PR body contains the required Issue syntax
- [x] Allowed files section matches final diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] Local checks executed and passed
- [x] Commit message aligns with scope
- [x] No prohibited artifacts introduced
- [x] No merge-readiness claim made before all gate surfaces inspected
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a2bd109-fc6d-4b3e-ac44-989e138ff01a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a2bd109-fc6d-4b3e-ac44-989e138ff01a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds admin Worklist and Member Operations pages with a shared token panel and client, plus dashboard/nav updates, delivering T41 admin operations from #1119. Also strengthens the stats API with partial counts, an unavailable table list, and a clear 503 when D1 is missing.

- **New Features**
  - Worklist: add items, set owners/due dates, and update status with token-aware calls and safe states.
  - Member Operations: view/edit/publish welcome email and membership card content.
  - Dashboard: adds cards for Worklist and Member Operations; shows unavailable D1 tables from stats; includes `AdminTokenPanel`.
  - Shared tools: `AdminTokenPanel` to store the browser token and `adminJson` helper for token-aware admin API calls.

- **Bug Fixes**
  - Member Operations: stabilized data loading to avoid redundant fetches.
  - Admin operations polish: unified styles and clearer status/empty/error messages across pages.
  - `/api/admin/stats`: explicit D1 binding check; returns `unavailable` map with counts; 503 when unconfigured.

<sup>Written for commit ec9422c6191d4b35559ba652b9948e9f2523dda9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->