### PR TITLE
Implement T44 admin media management workflow

### DIFF
--- a/functions/api/admin/media-assets/list.ts
+++ b/functions/api/admin/media-assets/list.ts
@@ -2,6 +2,7 @@
 // Returns recent media_assets. Protected by ADMIN_TOKEN.
 
 import { requireAdmin } from "../../../_lib/auth";
+import { requireD1, requireTables, jsonResponse } from "../../../_lib/d1";
 
 export const onRequestGet = async (context: any): Promise<Response> => {
   const { request, env } = context;
@@ -9,12 +10,18 @@ export const onRequestGet = async (context: any): Promise<Response> => {
   const deny = requireAdmin(request, env);
   if (deny) return deny;
 
+  const d1 = requireD1(env);
+  if (!d1.ok) return jsonResponse(d1.body, d1.status);
+
+  const tables = await requireTables(d1.db, ["media_assets"]);
+  if (!tables.ok) return jsonResponse(tables.body, tables.status);
+
   try {
     const url = new URL(request.url);
     const limitRaw = Number(url.searchParams.get("limit") || "100");
     const limit = Number.isFinite(limitRaw) ? Math.min(Math.max(limitRaw, 1), 500) : 100;
 
-    const db = env.DB as any;
+    const db = d1.db;
     const q = `
       SELECT id, media_uid, b2_key, b2_file_id, size, etag, ingested_at
       FROM media_assets

--- a/src/app/admin/media-assets/page.tsx
+++ b/src/app/admin/media-assets/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import PageShell from '@/components/PageShell';
 import AdminNav from '@/components/admin/AdminNav';
+import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
+import { adminJson } from '@/lib/adminClient';
 
 type MediaAsset = {
   id: number;
@@ -14,10 +16,23 @@ type MediaAsset = {
   ingested_at?: string | null;
 };
 
+type MediaListResponse = {
+  ok: true;
+  items: unknown[];
+};
+
+type MediaSyncResponse = {
+  ok: true;
+  listed: number;
+  maxObjects: number;
+  batches: number;
+  changes_reported: number;
+  note?: string;
+};
+
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null;
 }
-
 
 function asString(v: unknown): string | null {
   return typeof v === 'string' ? v : null;
@@ -54,57 +69,103 @@ function normalize(raw: unknown): MediaAsset | null {
   };
 }
 
-function getToken(): string {
-  if (typeof window === 'undefined') return '';
-  return window.localStorage.getItem('lgfc_admin_token') || '';
-}
-
 export default function AdminMediaAssetsPage() {
-  const [status, setStatus] = useState<string>('');
+  const [status, setStatus] = useState<string>('Idle.');
+  const [syncStatus, setSyncStatus] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(false);
+  const [syncing, setSyncing] = useState<boolean>(false);
   const [items, setItems] = useState<MediaAsset[]>([]);
 
-  async function load() {
+  const load = useCallback(async () => {
+    setLoading(true);
     setStatus('Loading…');
-    const token = getToken();
-    const res = await fetch('/api/admin/media-assets/list?limit=100', {
-      headers: token ? { 'x-admin-token': token } : {},
-      cache: 'no-store',
-    });
-    const data: unknown = await res.json().catch(() => ({}));
+    const result = await adminJson<MediaListResponse>('/api/admin/media-assets/list?limit=100');
 
-    if (!isRecord(data) || data.ok !== true) {
-      const err = isRecord(data) && typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
-      setStatus(`Error: ${err}`);
+    if (!result.ok) {
+      setStatus(`Error: ${result.error}`);
       setItems([]);
+      setLoading(false);
       return;
     }
 
-    const raw = (data as Record<string, unknown>).items;
-    const arr = Array.isArray(raw) ? raw : [];
+    const arr = Array.isArray(result.data?.items) ? result.data.items : [];
     const normalized = arr.map(normalize).filter((x): x is MediaAsset => x !== null);
 
     setItems(normalized);
-    setStatus(normalized.length ? '' : 'No media assets found.');
-  }
+    setStatus(normalized.length ? `Loaded ${normalized.length} media asset(s).` : 'No media assets found.');
+    setLoading(false);
+  }, []);
+
+  const syncFromB2 = useCallback(async () => {
+    setSyncing(true);
+    setSyncStatus('Syncing from B2…');
+
+    const result = await adminJson<MediaSyncResponse>('/api/admin/media-assets/sync-from-b2', {
+      method: 'POST',
+    });
+
+    if (!result.ok) {
+      setSyncStatus(`Sync error: ${result.error}`);
+      setSyncing(false);
+      return;
+    }
+
+    const data = result.data;
+    setSyncStatus(
+      `B2 sync complete: listed ${data?.listed ?? 0} object(s), reported ${data?.changes_reported ?? 0} D1 change(s).`,
+    );
+    setSyncing(false);
+    await load();
+  }, [load]);
 
   useEffect(() => {
     void load();
-  }, []);
+  }, [load]);
 
   return (
     <PageShell title="Media Assets" subtitle="D1 inventory of ingested media (B2 keys, size, etag)">
       <AdminNav />
-      <div style={{ marginTop: 14 }}>
-        <button
-          onClick={() => void load()}
-          style={{ border: '1px solid #ddd', borderRadius: 10, padding: '10px 12px', fontWeight: 700, cursor: 'pointer' }}
-        >
-          Refresh
-        </button>
+      <AdminTokenPanel onSaved={() => void load()} />
+
+      <div style={{ display: 'grid', gap: 14, marginTop: 16 }}>
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            style={{
+              border: '1px solid #ddd',
+              borderRadius: 10,
+              padding: '10px 12px',
+              fontWeight: 700,
+              cursor: loading ? 'not-allowed' : 'pointer',
+              background: loading ? 'rgba(0,0,0,0.05)' : 'white',
+            }}
+          >
+            {loading ? 'Loading…' : 'Refresh'}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => void syncFromB2()}
+            disabled={syncing}
+            style={{
+              border: '1px solid #ddd',
+              borderRadius: 10,
+              padding: '10px 12px',
+              fontWeight: 700,
+              cursor: syncing ? 'not-allowed' : 'pointer',
+              background: syncing ? 'rgba(0,0,0,0.05)' : 'white',
+            }}
+          >
+            {syncing ? 'Syncing…' : 'Sync from B2'}
+          </button>
+        </div>
 
         {status ? <p style={{ marginTop: 10, opacity: 0.85 }}>{status}</p> : null}
+        {syncStatus ? <p style={{ marginTop: 0, opacity: 0.85 }}>{syncStatus}</p> : null}
 
-        <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>
+        <div style={{ display: 'grid', gap: 10 }}>
           {items.map((m) => (
             <div key={m.id} style={{ border: '1px solid #eee', borderRadius: 12, padding: 12 }}>
               <div style={{ fontWeight: 800 }}>{m.b2_key}</div>

--- a/tests/admin-media-assets.test.tsx
+++ b/tests/admin-media-assets.test.tsx
@@ -1,0 +1,286 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AdminMediaAssetsPage from '@/app/admin/media-assets/page';
+import { onRequestGet as mediaListGet } from '../functions/api/admin/media-assets/list';
+import { onRequestPost as mediaSyncPost } from '../functions/api/admin/media-assets/sync-from-b2';
+
+const mockUsePathname = vi.hoisted(() => vi.fn(() => '/admin/media-assets'));
+
+vi.mock('next/navigation', () => ({
+  usePathname: mockUsePathname,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function adminGetRequest(path: string, token = 'secret'): Request {
+  return new Request(`https://www.lougehrigfanclub.com${path}`, {
+    headers: { 'x-admin-token': token },
+  });
+}
+
+function adminPostRequest(path: string, token = 'secret'): Request {
+  return new Request(`https://www.lougehrigfanclub.com${path}`, {
+    method: 'POST',
+    headers: { 'x-admin-token': token },
+  });
+}
+
+function makeMediaDb(rows: Array<Record<string, unknown>> = []) {
+  let boundLimit = 0;
+  const db = {
+    prepare: vi.fn((sql: string) => ({
+      bind: (...args: unknown[]) => ({
+        all: async () => {
+          if (sql.includes('sqlite_master')) {
+            return { results: [{ name: 'media_assets' }] };
+          }
+
+          if (sql.includes('FROM media_assets')) {
+            boundLimit = Number(args[0]);
+            return { results: rows };
+          }
+
+          return { results: [] };
+        },
+      }),
+    })),
+  };
+
+  return {
+    db,
+    getBoundLimit: () => boundLimit,
+  };
+}
+
+describe('admin media assets page', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    window.localStorage.setItem('lgfc_admin_token', 'secret');
+    mockUsePathname.mockReturnValue('/admin/media-assets');
+  });
+
+  it('renders admin navigation and token controls', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ ok: true, items: [] }));
+
+    render(<AdminMediaAssetsPage />);
+
+    expect(screen.getByRole('link', { name: 'Media Assets' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Admin token')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('No media assets found.')).toBeInTheDocument();
+    });
+  });
+
+  it('loads media inventory with the stored admin token', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+      expect(String(input)).toBe('/api/admin/media-assets/list?limit=100');
+      expect(headers.get('x-admin-token')).toBe('secret');
+
+      return Promise.resolve(
+        jsonResponse({
+          ok: true,
+          items: [
+            {
+              id: 7,
+              media_uid: 'b2_abc',
+              b2_key: 'photos/lou.jpg',
+              b2_file_id: 'file-7',
+              size: 42,
+              etag: 'etag-7',
+              ingested_at: '2026-06-02T00:00:00Z',
+            },
+          ],
+        }),
+      );
+    });
+
+    render(<AdminMediaAssetsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('photos/lou.jpg')).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/admin/media-assets/list?limit=100',
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+  });
+
+  it('posts B2 sync, reports changes, and refreshes inventory', async () => {
+    let listCalls = 0;
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const path = String(input);
+      const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+      expect(headers.get('x-admin-token')).toBe('secret');
+
+      if (path === '/api/admin/media-assets/sync-from-b2') {
+        expect(init?.method).toBe('POST');
+        return Promise.resolve(
+          jsonResponse({ ok: true, listed: 2, maxObjects: 2000, batches: 1, changes_reported: 1 }),
+        );
+      }
+
+      listCalls += 1;
+      return Promise.resolve(
+        jsonResponse({
+          ok: true,
+          items:
+            listCalls > 1
+              ? [{ id: 8, media_uid: 'b2_def', b2_key: 'photos/new.jpg', size: 100 }]
+              : [],
+        }),
+      );
+    });
+
+    render(<AdminMediaAssetsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No media assets found.')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sync from B2' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('B2 sync complete: listed 2 object(s), reported 1 D1 change(s).')).toBeInTheDocument();
+      expect(screen.getByText('photos/new.jpg')).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/admin/media-assets/sync-from-b2',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('shows fail-closed sync errors from the API', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (String(input) === '/api/admin/media-assets/sync-from-b2') {
+        return Promise.resolve(jsonResponse({ ok: false, error: 'B2 secrets missing for this Pages environment' }, 503));
+      }
+      return Promise.resolve(jsonResponse({ ok: true, items: [] }));
+    });
+
+    render(<AdminMediaAssetsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No media assets found.')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sync from B2' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Sync error: B2 secrets missing for this Pages environment')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('media assets admin API', () => {
+  it('rejects unauthenticated list requests', async () => {
+    const response = await mediaListGet({
+      request: adminGetRequest('/api/admin/media-assets/list', ''),
+      env: { ADMIN_TOKEN: 'secret', DB: makeMediaDb().db },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('fails closed when D1 is unavailable for inventory list requests', async () => {
+    const response = await mediaListGet({
+      request: adminGetRequest('/api/admin/media-assets/list'),
+      env: { ADMIN_TOKEN: 'secret' },
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: 'Database unavailable',
+    });
+  });
+
+  it('caps inventory list limits and returns media rows', async () => {
+    const { db, getBoundLimit } = makeMediaDb([
+      {
+        id: 3,
+        media_uid: 'b2_row',
+        b2_key: 'photos/row.jpg',
+        b2_file_id: 'file-3',
+        size: 88,
+        etag: 'etag-3',
+        ingested_at: '2026-06-02T00:00:00Z',
+      },
+    ]);
+
+    const response = await mediaListGet({
+      request: adminGetRequest('/api/admin/media-assets/list?limit=9999'),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    expect(getBoundLimit()).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      items: [{ media_uid: 'b2_row', b2_key: 'photos/row.jpg' }],
+    });
+  });
+
+  it('fails closed when the media_assets table is missing', async () => {
+    const db = {
+      prepare: vi.fn(() => ({
+        bind: () => ({
+          all: async () => ({ results: [] }),
+        }),
+      })),
+    };
+
+    const response = await mediaListGet({
+      request: adminGetRequest('/api/admin/media-assets/list'),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: 'Database schema incomplete',
+      missingTables: ['media_assets'],
+    });
+  });
+
+  it('rejects unauthenticated B2 sync requests', async () => {
+    const response = await mediaSyncPost({
+      request: adminPostRequest('/api/admin/media-assets/sync-from-b2', ''),
+      env: { ADMIN_TOKEN: 'secret', DB: makeMediaDb().db },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('fails closed when B2 secrets are missing for sync', async () => {
+    const response = await mediaSyncPost({
+      request: adminPostRequest('/api/admin/media-assets/sync-from-b2'),
+      env: { ADMIN_TOKEN: 'secret', DB: makeMediaDb().db },
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: 'B2 secrets missing for this Pages environment',
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #1122

## PRE-OPEN GATE PREFLIGHT (MANDATORY)
- [x] Confirm exactly one same-repository, open, non-PR source issue exists.
- [x] Confirm one accepted issue-accounting line is present before opening/updating the PR.
- [x] Read the workflow files/check surfaces that run for this PR's touched paths.
- [x] Read `docs/reference/governance/troubleshooting-data-surface-requirements.md` before making any merge-readiness claim: not claiming merge readiness.
- [x] Confirm PR body file allowlist exactly matches the final changed-file list.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Website implementation T44
- Task: Media management workflows
- Status: DRAFT
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: None for implementation; PR remains draft pending human review.
- Notes: Project tracker status update intentionally omitted per current operator process revision.

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `docs/reference/design/LGFC-Production-Design-and-Standards.md`
- `docs/reference/projects/admin-production-definition.md`
- `docs/reference/design/dashboard.md`
- `docs/reference/architecture/access-model.md`
- `docs/ops/tasks/MEDIA-01.md`

## LABEL
- Intent label for this PR: feature

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical design reference: `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- Additional design/reference docs used for this PR:
  - `docs/reference/projects/admin-production-definition.md`
  - `docs/reference/design/dashboard.md`
  - `docs/reference/architecture/access-model.md`
  - `docs/ops/tasks/MEDIA-01.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `functions/api/admin/media-assets/list.ts`
- `src/app/admin/media-assets/page.tsx`
- `tests/admin-media-assets.test.tsx`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label intended
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## CHANGE SUMMARY
- Added admin token panel parity and visible B2 sync controls/status to `/admin/media-assets`.
- Added fail-closed D1/table guards to the admin media-assets list API.
- Added focused UI and API coverage for inventory list, B2 sync feedback, auth rejection, D1 failure, schema failure, and missing B2 secrets.

## BUILD / TEST / VERIFICATION
- Commands run:
  - PASS: `npm test -- tests/admin-media-assets.test.tsx`
  - PASS: `npm run typecheck`
  - PASS: `npm run build` (completed with existing non-blocking lint warnings in unrelated image/hook files)
  - PASS: `npm test`
  - PASS: `if compgen -G "*.zip" > /dev/null; then ...; else echo 'No root ZIP files present'; fi && git diff --name-only origin/main...HEAD`
  - PASS: Cloudflare Pages dev probe of `/api/session/me`, `/api/admin/media-assets/list`, and `/api/admin/media-assets/sync-from-b2` using seeded local D1 and missing B2 secrets
- Manual verification:
  - PASS: `/admin/media-assets/` rendered in Pages dev with admin session and token.
  - PASS: media inventory displayed `photos/manual-demo.jpg`.
  - PASS: `Sync from B2` showed fail-closed `B2 secrets missing for this Pages environment` without crashing.
  - Evidence: ![T44 media inventory loaded](https://cursor.com/artifacts/c/art-3268b934-b687-475e-9e2f-ade7bc278626)
  - Evidence: ![T44 media sync fail closed](https://cursor.com/artifacts/c/art-54a44681-86c8-41cf-8062-754275b54b5f)
  - Note: screen recording save failed due VM missing `libavutil.so.58`; screenshots were captured from the successful manual run.
- Gate verification:
  - Commit-level workflow runs inspected: YES
  - PR-level governance/accounting workflows inspected: YES
  - Failed job logs inspected for every failing gate: N/A for current latest run; stale `reviewer-response-completion` failures were superseded by a later passing `reviewer-response-completion` run.
  - Required gates rerun or re-evaluated after fixes: YES
- Result summary: PASS locally; PR remains draft.

## DOCUMENTATION UPDATES
- [x] No documentation updates required
- Files: N/A

## REVIEWER RESPONSE ACCOUNTING
- [x] Reviewed all reviewer comments: none present
- [x] Reviewed all bot comments: no actionable bot comments present
- [x] Reviewed all GitHub review threads: none present
- [x] Copilot disposition received or not applicable.
- [x] Codex disposition received or not applicable.
- [x] Gemini disposition received or not applicable.
- [x] Cubic disposition received or not applicable.
- [x] Every actionable reviewer comment has a PR-body disposition.
- [x] Every GitHub review thread has an explicit thread-state disposition: resolved, outdated, or intentionally left unresolved with rationale.

Reviewer items:
- N/A — no reviewer comments or review threads present during this update.

## PR GATE READINESS CHECKLIST
- [x] Live PR check panel inspected
- [x] Commit-level workflow runs inspected
- [x] PR-level pull_request_target workflows inspected
- [x] Latest head workflow runs inspected
- [x] Failed job logs inspected for every failing gate: stale reviewer-response failures superseded by later passing run
- [x] Workflow YAML or enforcement logic inspected before documenting gate behavior
- [x] PR issue-accounting confirms exactly one same-repository, open, non-PR source issue
- [x] PR body contains one accepted source-issue accounting line governed by `/docs/governance/PR_GOVERNANCE.md`.
- [x] All review threads and comments inspected
- [x] Actionable review feedback has PR-body disposition and GitHub thread-state disposition
- [x] Bot comments inspected
- [x] Reviewer-response accounting includes required reviewer comment IDs when required by gate logs
- [x] Required gates rerun or re-evaluated after fixes
- [ ] Final PR panel confirms merge-readiness: not claiming merge readiness; draft PR remains for human review

## POST-MERGE CLOSEOUT CHECKLIST
- [ ] PR merged state verified
- [ ] Merge commit recorded
- [ ] Source issue state inspected after merge
- [ ] Source issue closed manually when automation did not close it
- [x] Tracker/documentation update PR opened when implementation PR intentionally omitted tracker updates: not applicable per operator process revision
- [ ] Post-merge validation gates inspected when applicable

## ACCEPTANCE CRITERIA
- [x] Required source issue exists, is open, is same-repository, and is not a PR.
- [x] PR issue-accounting gate passes.
- [x] Drift gate passes.
- [x] Intent gate passes.
- [x] ZIP safety gate passes.
- [x] Quality checks pass.
- [x] Secret scan passes.
- [x] Repository-specific governance gates pass for latest run.
- [x] No out-of-scope file changes.
- [ ] PR is ready for human review: draft PR, not making ready claim.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] PR body contains one accepted source-issue accounting line governed by `/docs/governance/PR_GOVERNANCE.md`.
- [x] Allowed files section matches final diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] Local checks executed and passed or exact blocker documented
- [x] Commit message aligns with scope
- [x] No prohibited artifacts introduced
- [ ] Status is set to READY FOR REVIEW only after all required gates and reviewer-response obligations are complete
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a93f35a0-3087-4700-98bc-53b4438f9226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a93f35a0-3087-4700-98bc-53b4438f9226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the T44 admin media management workflow by adding a token panel and one-click “Sync from B2” to `/admin/media-assets`, with clear loading/sync status. Hardens the list API with fail-closed D1/table checks, a 500-item cap, and clearer errors.

- New Features
  - UI: `AdminTokenPanel`, Refresh and Sync from B2 actions with loading/sync messages; uses `adminJson` for admin requests.
  - API + Tests: `requireD1`/`requireTables`/`jsonResponse` guards, 401 on auth failure, 503 when DB unavailable or schema missing, limit capped to 500; tests cover token use, list/sync flow, and failure cases (D1 unavailable, missing table, missing B2 secrets).

<sup>Written for commit c01b8b0e44964bbd4aff96f1495cfb59e3829958. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->