### PR TITLE
ci: establish PR Hygiene Foundation for Issue #1131

### DIFF
--- a/.github/workflows/diataxis-folder-authority-check.yml
+++ b/.github/workflows/diataxis-folder-authority-check.yml
@@ -12,6 +12,10 @@ on:
 jobs:
   validate-folder-intent:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
 
     steps:
       - name: Checkout PR
@@ -27,93 +31,49 @@ jobs:
             | tee diataxis_changed_files.txt || true
 
       - name: Validate DIATAXIS folder authority
-        run: |
-          if [ ! -s diataxis_changed_files.txt ]; then
-            echo "No DIATAXIS markdown files changed."
-            exit 0
-          fi
+        id: diataxis_audit
+        continue-on-error: true
+        env:
+          DIATAXIS_CHANGED_FILES_FILE: diataxis_changed_files.txt
+        run: node scripts/ci/diataxis_folder_audit.mjs > diataxis_folder_report.md
 
-          failures=0
+      - name: Post or update DIATAXIS correction advisory
+        if: steps.diataxis_audit.outcome == 'failure'
+        uses: actions/github-script@v7
+        env:
+          REMEDIATION_MARKER: '<!-- diataxis-folder-advisory -->'
+          REPORT_FILE: diataxis_folder_report.md
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = process.env.REMEDIATION_MARKER;
+            const report = fs.readFileSync(process.env.REPORT_FILE, 'utf8').trim();
+            const body = `${marker}\n${report}\n\nThis advisory is non-blocking during PR Hygiene Foundation rollout.`;
+            const issue_number = context.payload.pull_request.number;
 
-          while IFS= read -r file; do
-            echo "Validating ${file}"
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
 
-            if [ ! -f "${file}" ]; then
-              echo "Skipping deleted file: ${file}"
-              continue
-            fi
-
-            case "${file}" in
-              docs/tutorials/*)
-                expected_doc_type="Tutorial"
-                ;;
-              docs/how-to/*)
-                expected_doc_type="How-To"
-                ;;
-              docs/reference/*)
-                expected_doc_type="Reference"
-                ;;
-              docs/explanation/*)
-                expected_doc_type="Explanation"
-                ;;
-              *)
-                echo "ERROR: ${file} is outside approved DIATAXIS content folders."
-                failures=$((failures + 1))
-                continue
-                ;;
-            esac
-
-            if ! head -n 1 "${file}" | grep -qx -- '---'; then
-              echo "ERROR: ${file} missing opening YAML-style authority header delimiter."
-              failures=$((failures + 1))
-            fi
-
-            for required_field in 'Doc Type:' 'Audience:' 'Authority Level:' 'Owns:' 'Does Not Own:' 'Canonical Reference:' 'Last Reviewed:'; do
-              if ! grep -q "^${required_field}" "${file}"; then
-                echo "ERROR: ${file} missing required header field: ${required_field}"
-                failures=$((failures + 1))
-              fi
-            done
-
-            if ! grep -qi "^Doc Type: .*${expected_doc_type}" "${file}"; then
-              echo "ERROR: ${file} Doc Type must match folder intent: ${expected_doc_type}"
-              failures=$((failures + 1))
-            fi
-
-            case "${file}" in
-              docs/reference/*)
-                if grep -Eqi '^##[[:space:]]+(Steps|Procedure|How to|Tutorial)|```(bash|sh|zsh|powershell)' "${file}"; then
-                  echo "ERROR: ${file} reference docs must not contain procedure/tutorial sections or executable command blocks."
-                  failures=$((failures + 1))
-                fi
-                ;;
-              docs/explanation/*)
-                if grep -Eqi '^##[[:space:]]+(Steps|Procedure|Commands|Runbook)|```(bash|sh|zsh|powershell)' "${file}"; then
-                  echo "ERROR: ${file} explanation docs must not contain procedural/runbook sections or executable command blocks."
-                  failures=$((failures + 1))
-                fi
-                ;;
-              docs/how-to/*)
-                if ! grep -Eqi '^##[[:space:]]+(Steps|Procedure|Execution)' "${file}"; then
-                  echo "ERROR: ${file} how-to docs must contain a task execution section."
-                  failures=$((failures + 1))
-                fi
-                ;;
-              docs/tutorials/*)
-                if ! grep -Eqi '^##[[:space:]]+(Goal|Outcome|Steps|Walkthrough)' "${file}"; then
-                  echo "ERROR: ${file} tutorial docs must contain learning-flow structure."
-                  failures=$((failures + 1))
-                fi
-                ;;
-            esac
-          done < diataxis_changed_files.txt
-
-          if [ "${failures}" -ne 0 ]; then
-            echo "DIATAXIS folder authority check failed with ${failures} issue(s)."
-            exit 1
-          fi
-
-          echo "DIATAXIS folder authority check passed."
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
+            }
 
       - name: Summary
         run: |

--- a/.github/workflows/docs-guardrails.yml
+++ b/.github/workflows/docs-guardrails.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -263,14 +264,66 @@ jobs:
               });
             }
 
-      - name: Fail PR when docs header remediation is required
+      - name: Report docs header remediation advisory
         if: github.event_name == 'pull_request' && steps.docs_header_check.outcome == 'failure'
         run: |
-          echo "Docs header check failed. See the remediation comment for required fixes."
-          exit 1
+          echo "Docs header remediation advisory posted. Non-blocking during PR Hygiene Foundation rollout."
 
       - name: Docs path bucket check
-        run: ./scripts/ci/docs_check_paths.sh .
+        id: docs_path_check
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        run: ./scripts/ci/docs_check_paths.sh . > "$RUNNER_TEMP/docs_path_report.txt"
+
+      - name: Post or update docs path remediation comment
+        if: github.event_name == 'pull_request' && steps.docs_path_check.outcome == 'failure'
+        uses: actions/github-script@v7
+        env:
+          REMEDIATION_MARKER: '<!-- docs-path-remediation -->'
+          REPORT_FILE: ${{ format('{0}/docs_path_report.txt', runner.temp) }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = process.env.REMEDIATION_MARKER;
+            const report = fs.existsSync(process.env.REPORT_FILE)
+              ? fs.readFileSync(process.env.REPORT_FILE, 'utf8').trim()
+              : 'Docs path check failed without captured output.';
+            const body = [
+              marker,
+              '## Docs Path Remediation Required',
+              '',
+              report,
+              '',
+              'Correction:',
+              '- Move markdown files into an approved documentation bucket.',
+              '- Approved active buckets include `docs/reference/`, `docs/how-to/`, `docs/explanation/`, `docs/governance/`, and `docs/ops/`.',
+              '',
+              'This advisory is non-blocking during PR Hygiene Foundation rollout.',
+            ].join('\n');
+            const issue_number = context.payload.pull_request.number;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
+            }
 
       - name: Canonical drift check (design)
         run: ./scripts/ci/docs_canonical_hashes_verify.sh .

--- a/.github/workflows/gate-intent-labeler.yml
+++ b/.github/workflows/gate-intent-labeler.yml
@@ -57,7 +57,46 @@ jobs:
             }
 
             if (!matchedIntent) {
-              core.setFailed('Mixed intent detected. Split PR into a single intent scope.');
+              const marker = '<!-- intent-labeler-advisory -->';
+              const body = [
+                marker,
+                '## Intent Label Advisory',
+                '',
+                'This PR does not match exactly one configured intent label.',
+                '',
+                'Changed files:',
+                ...changedFiles.map((file) => `- \`${file}\``),
+                '',
+                'Correction:',
+                '- Split this PR into one intent scope, or update the PR/file scope so all changed files match one configured intent.',
+                '- This advisory is non-blocking during PR Hygiene Foundation rollout.',
+              ].join('\n');
+
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100,
+              });
+
+              const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body,
+                });
+              }
+
+              core.warning('Mixed intent detected. Posted non-blocking PR hygiene advisory.');
               return;
             }
 

--- a/docs/reference/ci/pr-hygiene-foundation.md
+++ b/docs/reference/ci/pr-hygiene-foundation.md
@@ -1,0 +1,78 @@
+---
+Doc Type: Reference
+Audience: Human + AI
+Authority Level: Controlled
+Owns: PR Hygiene Foundation behavior, advisory correction surfaces, deterministic PR metadata remediation model
+Does Not Own: Merge protection consolidation, reviewer lifecycle redesign, workflow branch protection settings, or runtime behavior
+Canonical Reference: /docs/explanation/ci/lgfc-ci-production-design.md
+Related Issues: #1131, #1075, #1058
+Last Reviewed: 2026-06-02
+---
+
+# PR Hygiene Foundation
+
+## Purpose
+
+The PR Hygiene Foundation improves branch quality before merge-protection
+consolidation. It identifies deterministic PR defects early and provides
+corrective guidance without adding brittle blockers.
+
+## Scope
+
+This foundation covers:
+
+- source issue line normalization guidance
+- ZIP safety statement detection
+- required PR template section detection
+- file allowlist coverage detection
+- intent-label normalization when one intent is clear
+- mixed-intent advisory comments when one intent is not clear
+- documentation header remediation comments
+- documentation path bucket remediation comments
+- DIATAXIS folder intent remediation comments
+
+It does not consolidate merge protection, redesign reviewer lifecycle gates,
+change production website behavior, or alter Cloudflare runtime behavior.
+
+## Current Known Truth
+
+The repository CI design separates PR Hygiene from Merge Protection. PR Hygiene
+is corrective first and advisory when the correct automated fix is uncertain.
+
+The current foundation uses:
+
+- `.github/workflows/gate-intent-labeler.yml`
+- `.github/workflows/docs-guardrails.yml`
+- `.github/workflows/diataxis-folder-authority-check.yml`
+- `scripts/ci/pr_hygiene_audit.mjs`
+- `scripts/ci/diataxis_folder_audit.mjs`
+
+## Intended Final State
+
+PR Hygiene should make common deterministic defects easy to correct before they
+become noisy gate failures. It should not hide defects; it should report them in
+stable, source-linked PR comments and leave hard merge-safety decisions to the
+Merge Protection domain.
+
+## Advisory Surfaces
+
+| Surface | Corrective behavior | Blocking behavior |
+|---|---|---|
+| Intent labeler | Applies the matching intent label when one intent is clear | Mixed intent posts advisory instead of failing |
+| PR hygiene audit | Reports issue-line, ZIP statement, template, and allowlist defects | Advisory during foundation rollout |
+| Docs headers | Posts file-specific remediation comments with canonical template | Advisory on PRs during foundation rollout |
+| Docs paths | Posts path bucket remediation comments | Advisory on PRs during foundation rollout |
+| DIATAXIS folder intent | Posts folder-intent remediation comments | Advisory during foundation rollout |
+| Canonical drift | Verifies canonical documentation hashes | Remains deterministic check |
+
+## Acceptance Criteria
+
+This foundation is acceptable when:
+
+- clear intent labels are normalized automatically
+- mixed intent receives an actionable advisory comment
+- PR metadata defects receive an actionable advisory comment
+- documentation header and path defects receive remediation guidance
+- DIATAXIS folder mismatches receive correction guidance
+- behavior is covered by targeted tests
+- no runtime, website, Cloudflare, package, or reviewer lifecycle changes are introduced

--- a/scripts/ci/diataxis_folder_audit.mjs
+++ b/scripts/ci/diataxis_folder_audit.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+
+export const FOLDER_RULES = [
+  {
+    prefix: 'docs/tutorials/',
+    expectedDocType: 'Tutorial',
+    requiredStructure: /^##[ \t]+(Goal|Outcome|Steps|Walkthrough)/im,
+    requiredMessage: 'tutorial docs must contain learning-flow structure: Goal, Outcome, Steps, or Walkthrough',
+  },
+  {
+    prefix: 'docs/how-to/',
+    expectedDocType: 'How-To',
+    requiredStructure: /^##[ \t]+(Steps|Procedure|Execution)/im,
+    requiredMessage: 'how-to docs must contain a task execution section: Steps, Procedure, or Execution',
+  },
+  {
+    prefix: 'docs/reference/',
+    expectedDocType: 'Reference',
+    forbiddenStructure: /^##[ \t]+(Steps|Procedure|How to|Tutorial)|```(bash|sh|zsh|powershell)/im,
+    forbiddenMessage: 'reference docs must not contain procedure/tutorial sections or executable command blocks',
+  },
+  {
+    prefix: 'docs/explanation/',
+    expectedDocType: 'Explanation',
+    forbiddenStructure: /^##[ \t]+(Steps|Procedure|Commands|Runbook)|```(bash|sh|zsh|powershell)/im,
+    forbiddenMessage: 'explanation docs must not contain procedural/runbook sections or executable command blocks',
+  },
+];
+
+export const REQUIRED_HEADER_FIELDS = [
+  'Doc Type:',
+  'Audience:',
+  'Authority Level:',
+  'Owns:',
+  'Does Not Own:',
+  'Canonical Reference:',
+  'Last Reviewed:',
+];
+
+export function ruleForFile(file) {
+  return FOLDER_RULES.find((rule) => file.startsWith(rule.prefix)) || null;
+}
+
+export function readChangedFiles(path) {
+  if (!path || !fs.existsSync(path)) return [];
+  return fs.readFileSync(path, 'utf8').split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+export function auditDiataxisFile(file, content) {
+  const rule = ruleForFile(file);
+  const findings = [];
+
+  if (!rule) {
+    findings.push({
+      file,
+      code: 'OUTSIDE_DIATAXIS_FOLDER',
+      message: 'file is outside approved DIATAXIS content folders',
+      correction: 'Move the document into docs/tutorials, docs/how-to, docs/reference, or docs/explanation, or remove it from this workflow scope.',
+    });
+    return findings;
+  }
+
+  if (!content.startsWith('---\n')) {
+    findings.push({
+      file,
+      code: 'HEADER_FENCE_MISSING',
+      message: 'missing opening YAML-style authority header delimiter',
+      correction: 'Insert the repository documentation header block at the top of the file.',
+    });
+  }
+
+  for (const field of REQUIRED_HEADER_FIELDS) {
+    const fieldPattern = new RegExp(`^${field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'm');
+    if (!fieldPattern.test(content)) {
+      findings.push({
+        file,
+        code: 'HEADER_FIELD_MISSING',
+        message: `missing required header field: ${field}`,
+        correction: `Populate ${field} in the document header.`,
+      });
+    }
+  }
+
+  const docTypePattern = new RegExp(`^Doc Type: .*${rule.expectedDocType}`, 'im');
+  if (!docTypePattern.test(content)) {
+    findings.push({
+      file,
+      code: 'DOC_TYPE_FOLDER_MISMATCH',
+      message: `Doc Type must match folder intent: ${rule.expectedDocType}`,
+      correction: `Set Doc Type to ${rule.expectedDocType} or move the document to the folder that matches its actual type.`,
+    });
+  }
+
+  if (rule.requiredStructure && !rule.requiredStructure.test(content)) {
+    findings.push({
+      file,
+      code: 'REQUIRED_STRUCTURE_MISSING',
+      message: rule.requiredMessage,
+      correction: 'Add the required section heading for this DIATAXIS folder.',
+    });
+  }
+
+  if (rule.forbiddenStructure && rule.forbiddenStructure.test(content)) {
+    findings.push({
+      file,
+      code: 'FORBIDDEN_STRUCTURE_PRESENT',
+      message: rule.forbiddenMessage,
+      correction: 'Move procedural material to a how-to document, or remove command/tutorial content from this reference/explanation document.',
+    });
+  }
+
+  return findings;
+}
+
+export function auditDiataxisFiles(files, { root = '.' } = {}) {
+  const findings = [];
+  for (const file of files) {
+    if (!file) continue;
+    if (!fs.existsSync(`${root}/${file}`)) continue;
+    findings.push(...auditDiataxisFile(file, fs.readFileSync(`${root}/${file}`, 'utf8')));
+  }
+  return findings;
+}
+
+export function renderDiataxisReport(findings) {
+  const lines = ['## DIATAXIS Folder Hygiene Advisory', ''];
+  if (findings.length === 0) {
+    lines.push('No DIATAXIS folder hygiene defects detected.');
+    return lines.join('\n');
+  }
+
+  const byFile = new Map();
+  for (const finding of findings) {
+    if (!byFile.has(finding.file)) byFile.set(finding.file, []);
+    byFile.get(finding.file).push(finding);
+  }
+
+  for (const [file, fileFindings] of byFile) {
+    lines.push(`### \`${file}\``);
+    for (const finding of fileFindings) {
+      lines.push(`- ${finding.code}: ${finding.message}`);
+      lines.push(`  - Correction: ${finding.correction}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+export function runCli(env = process.env) {
+  const changedFilesPath = env.DIATAXIS_CHANGED_FILES_FILE;
+  const files = readChangedFiles(changedFilesPath);
+  const findings = auditDiataxisFiles(files, { root: env.DIATAXIS_ROOT || '.' });
+  console.log(renderDiataxisReport(findings));
+  return findings.length === 0 ? 0 : 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = runCli();
+}

--- a/scripts/ci/pr_hygiene_audit.mjs
+++ b/scripts/ci/pr_hygiene_audit.mjs
@@ -10,8 +10,24 @@ export const REQUIRED_TEMPLATE_SECTIONS = [
   'REQUIRED PRE-REVIEW SELF-CHECK',
 ];
 
+export function findIssueReferences(body) {
+  const text = body || '';
+  return [...text.matchAll(/#(\d+)/g)].map((match) => Number(match[1]));
+}
+
 export function hasRequiredIssueLine(body) {
   return /^- \*\*Issue:\*\* #\d+\s*$/m.test(body || '');
+}
+
+export function findCanonicalIssueLine(body) {
+  const text = body || '';
+  return text.split(/\r?\n/).find((line) => /^- \*\*Issue:\*\* #\d+\s*$/.test(line.trim())) || '';
+}
+
+export function suggestCanonicalIssueLine(body) {
+  const references = [...new Set(findIssueReferences(body))];
+  if (references.length !== 1) return '';
+  return `- **Issue:** #${references[0]}`;
 }
 
 export function hasZipSafetyStatement(body) {
@@ -56,9 +72,15 @@ export function buildPrHygieneReport({ body = '', changedFiles = [] } = {}) {
   const allowedFiles = parseAllowedFiles(body);
   const missingSections = missingTemplateSections(body);
   const unlistedChangedFiles = findUnlistedChangedFiles(changedFiles, allowedFiles);
+  const issueReferences = [...new Set(findIssueReferences(body))];
+  const canonicalIssueLine = findCanonicalIssueLine(body);
+  const suggestedIssueLine = hasRequiredIssueLine(body) ? canonicalIssueLine : suggestCanonicalIssueLine(body);
 
   return {
     hasRequiredIssueLine: hasRequiredIssueLine(body),
+    issueReferences,
+    canonicalIssueLine,
+    suggestedIssueLine,
     hasZipSafetyStatement: hasZipSafetyStatement(body),
     missingSections,
     allowedFiles,
@@ -80,6 +102,12 @@ export function renderPrHygieneReport(report) {
 
   if (!report.hasRequiredIssueLine) {
     lines.push('- Missing canonical source issue line: `- **Issue:** #123`.');
+    if (report.suggestedIssueLine) {
+      lines.push(`  - Suggested correction: \`${report.suggestedIssueLine}\`.`);
+    }
+    if (report.issueReferences.length > 1) {
+      lines.push(`  - Multiple issue references detected: ${report.issueReferences.map((issue) => `#${issue}`).join(', ')}. Keep exactly one primary source issue in the canonical line.`);
+    }
   }
 
   if (!report.hasZipSafetyStatement) {
@@ -95,6 +123,10 @@ export function renderPrHygieneReport(report) {
     for (const file of report.unlistedChangedFiles) {
       lines.push(`  - \`${file}\``);
     }
+  }
+
+  if (report.allowedFiles.length === 0) {
+    lines.push('- Missing or empty `Allowed files:` list under `FILE-TOUCH ALLOWLIST (MANDATORY)`.');
   }
 
   return lines.join('\n');

--- a/tests/diataxis-folder-audit.test.mjs
+++ b/tests/diataxis-folder-audit.test.mjs
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  auditDiataxisFile,
+  renderDiataxisReport,
+  ruleForFile,
+} from '../scripts/ci/diataxis_folder_audit.mjs';
+
+const referenceDoc = `---
+Doc Type: Reference
+Audience: Human + AI
+Authority Level: Controlled
+Owns: reference facts
+Does Not Own: procedures
+Canonical Reference: docs/reference/example.md
+Last Reviewed: 2026-06-02
+---
+
+# Reference Doc
+
+## Purpose
+
+Defines facts.
+`;
+
+describe('DIATAXIS folder hygiene audit', () => {
+  it('maps files to folder intent rules', () => {
+    expect(ruleForFile('docs/reference/example.md')?.expectedDocType).toBe('Reference');
+    expect(ruleForFile('docs/how-to/example.md')?.expectedDocType).toBe('How-To');
+    expect(ruleForFile('README.md')).toBe(null);
+  });
+
+  it('accepts a reference document that matches folder intent', () => {
+    expect(auditDiataxisFile('docs/reference/example.md', referenceDoc)).toEqual([]);
+  });
+
+  it('reports doc type mismatches and forbidden reference procedures', () => {
+    const findings = auditDiataxisFile('docs/reference/example.md', `${referenceDoc}\n## Steps\n\n\`\`\`bash\nnpm test\n\`\`\`\n`.replace('Doc Type: Reference', 'Doc Type: How-To'));
+
+    expect(findings.map((finding) => finding.code)).toContain('DOC_TYPE_FOLDER_MISMATCH');
+    expect(findings.map((finding) => finding.code)).toContain('FORBIDDEN_STRUCTURE_PRESENT');
+  });
+
+  it('reports missing how-to execution structure', () => {
+    const findings = auditDiataxisFile('docs/how-to/example.md', referenceDoc.replace('Doc Type: Reference', 'Doc Type: How-To'));
+    expect(findings.map((finding) => finding.code)).toContain('REQUIRED_STRUCTURE_MISSING');
+  });
+
+  it('renders actionable advisory text', () => {
+    const report = renderDiataxisReport([
+      {
+        file: 'docs/reference/example.md',
+        code: 'DOC_TYPE_FOLDER_MISMATCH',
+        message: 'Doc Type must match folder intent: Reference',
+        correction: 'Set Doc Type to Reference.',
+      },
+    ]);
+
+    expect(report).toContain('DIATAXIS Folder Hygiene Advisory');
+    expect(report).toContain('Set Doc Type to Reference.');
+  });
+});

--- a/tests/pr-hygiene-audit.test.mjs
+++ b/tests/pr-hygiene-audit.test.mjs
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildPrHygieneReport,
+  findIssueReferences,
   hasRequiredIssueLine,
   hasZipSafetyStatement,
   parseAllowedFiles,
   renderPrHygieneReport,
+  suggestCanonicalIssueLine,
 } from '../scripts/ci/pr_hygiene_audit.mjs';
 
 const validBody = `- **Issue:** #1131
@@ -35,6 +37,12 @@ describe('PR hygiene audit foundation', () => {
     expect(hasRequiredIssueLine('Closes #1131')).toBe(false);
   });
 
+  it('extracts issue references and suggests a canonical issue line', () => {
+    expect(findIssueReferences('Closes #1131')).toEqual([1131]);
+    expect(suggestCanonicalIssueLine('Closes #1131')).toBe('- **Issue:** #1131');
+    expect(suggestCanonicalIssueLine('Refs #1131 and #1075')).toBe('');
+  });
+
   it('detects ZIP safety statements', () => {
     expect(hasZipSafetyStatement('- [x] No ZIP file exists in the repo root.')).toBe(true);
     expect(hasZipSafetyStatement('No archive attached.')).toBe(false);
@@ -63,6 +71,7 @@ describe('PR hygiene audit foundation', () => {
 
     expect(report.isClean).toBe(false);
     expect(report.hasRequiredIssueLine).toBe(false);
+    expect(report.suggestedIssueLine).toBe('- **Issue:** #1131');
     expect(report.missingSections).toContain('MANDATORY FIRST STEP (ZIP SAFETY)');
     expect(report.unlistedChangedFiles).toEqual(['scripts/ci/pr_hygiene_audit.mjs']);
   });
@@ -75,6 +84,7 @@ describe('PR hygiene audit foundation', () => {
 
     const rendered = renderPrHygieneReport(report);
     expect(rendered).toContain('Missing canonical source issue line');
+    expect(rendered).toContain('Suggested correction');
     expect(rendered).toContain('Changed files not covered');
   });
 });


### PR DESCRIPTION
- **Issue:** #1131

## Summary
- Adds PR metadata hygiene reporting for canonical issue line, ZIP statement, PR template sections, and file allowlist coverage.
- Converts mixed-intent detection to a corrective advisory comment while preserving automatic intent-label normalization when one intent is clear.
- Converts DIATAXIS folder authority findings and docs path/header findings into PR hygiene remediation comments during the foundation rollout.
- Adds a reusable DIATAXIS folder audit script, targeted tests, and a CI reference note for the PR Hygiene Foundation.

## Changed Files
- `.github/workflows/gate-intent-labeler.yml`
- `.github/workflows/docs-guardrails.yml`
- `.github/workflows/diataxis-folder-authority-check.yml`
- `scripts/ci/pr_hygiene_audit.mjs`
- `scripts/ci/diataxis_folder_audit.mjs`
- `tests/pr-hygiene-audit.test.mjs`
- `tests/diataxis-folder-audit.test.mjs`
- `docs/reference/ci/pr-hygiene-foundation.md`

## Validation Results
- `npm test -- tests/pr-hygiene-audit.test.mjs tests/diataxis-folder-audit.test.mjs` — PASS, 12 tests
- `npm test -- tests/orchestrator-queue.test.mjs` — PASS, 22 tests
- `npm run typecheck` — PASS
- `./scripts/ci/docs_check_headers.sh .` — PASS
- `./scripts/ci/docs_canonical_hashes_verify.sh .` — PASS
- `git diff --check` — PASS

## Caveats
- `npm ci` was required in the clean worktree because `node_modules` was absent; it reported existing audit vulnerabilities. No package or lockfile changes were made.
- This PR does not start or create the next CI implementation issue.

## Scope Guard
- No merge-protection consolidation.
- No reviewer lifecycle redesign.
- No production website behavior changes.
- No Cloudflare runtime behavior changes.
- No package or dependency changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up the PR Hygiene Foundation for #1131, adding advisory CI checks that guide fixes for PR metadata, docs structure, and intent labels without blocking merges. Updates workflows to post corrective comments and adds a reusable DIATAXIS audit with tests and reference docs.

- **New Features**
  - Intent labeler posts a non-blocking mixed-intent advisory and still auto-applies a clear single intent (`.github/workflows/gate-intent-labeler.yml`).
  - Docs guardrails post remediation comments for headers and path buckets using `actions/github-script@v7` (advisory during rollout) (`.github/workflows/docs-guardrails.yml`).
  - Adds DIATAXIS folder audit script and workflow that generate correction advisories (`scripts/ci/diataxis_folder_audit.mjs`, `.github/workflows/diataxis-folder-authority-check.yml`).
  - PR hygiene audit suggests a canonical issue line, checks ZIP safety, required template sections, and allowlist coverage; reports unlisted changed files (`scripts/ci/pr_hygiene_audit.mjs`).
  - Adds targeted tests and a reference page documenting the foundation (`tests/*`, `docs/reference/ci/pr-hygiene-foundation.md`).

<sup>Written for commit ef0eda98916cdb5cb3947778aece8c024ab4a24d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->