### PR TITLE
docs: close PR Hygiene Foundation post-merge state

### DIFF
--- a/docs/ops/implementation-plans/issue-1075-ci-redesign-rollout.md
+++ b/docs/ops/implementation-plans/issue-1075-ci-redesign-rollout.md
@@ -34,6 +34,10 @@ Type: ci
 Agent: cursor
 Priority: 1
 Depends On: none
+Status: completed
+Issue: #1131
+Implementation PR: #1189
+Merged: 2026-06-02
 Allowed Files:
 - `.github/workflows/gate-intent-labeler.yml`
 - `.github/workflows/docs-guardrails.yml`
@@ -54,6 +58,10 @@ Validation:
 - `./scripts/ci/docs_canonical_hashes_verify.sh .`
 Rollback:
 - Revert only the PR hygiene workflow/script changes and their tests/docs; leave the CI orchestration engine and unrelated gates intact.
+Closeout:
+- PR #1189 merged the PR Hygiene Foundation implementation for issue #1131.
+- Post-merge verification confirmed the merge commit on `origin/main`.
+- Lifecycle normalization removed stale active issue state from issue #1131, preserved post-merge verification evidence, and keeps Task 002 blocked until this closeout PR merges.
 
 ## Task 002 — Merge Protection Consolidation
 

--- a/docs/ops/trackers/THREAD-LOG_Master.md
+++ b/docs/ops/trackers/THREAD-LOG_Master.md
@@ -12,6 +12,33 @@ Last Reviewed: 2026-05-05
 
 ------------------------------------------------------------------------
 
+## THREAD CLOSEOUT RECORD --- 2026-06-02 --- CI PR Hygiene Foundation post-merge cleanup
+
+### Starting State
+Issue #1131 and merged PR #1189 completed the CI PR Hygiene Foundation work, but the implementation queue still needed lifecycle cleanup before starting the next CI implementation task.
+
+### Objective
+Record the Task 001 closeout state, preserve post-merge verification evidence, and prevent stale active issue state from being carried into Task 002.
+
+### Work Performed
+- Updated `docs/ops/implementation-plans/issue-1075-ci-redesign-rollout.md`:
+  - Marked Task 001 completed with issue #1131, implementation PR #1189, and merge date.
+  - Recorded lifecycle normalization as completed cleanup before Task 002 starts.
+- Updated `docs/reference/ci/pr-hygiene-foundation.md`:
+  - Added post-merge closeout expectations for issue #1131.
+  - Preserved Task 002 as the next CI implementation task after cleanup.
+- Normalized live issue #1131 labels:
+  - Removed stale `status:active`.
+  - Preserved `orchestrator`, `agent:cursor`, `type:ci`, and `status:post-merge-verify`.
+
+### Result
+CI Task 001 closeout is documented as repository governance cleanup, not as a defect in the merged PR Hygiene Foundation implementation.
+
+### Next Action
+After this cleanup PR merges, close the post-merge verification state for issue #1131 and proceed to Task 002 Merge Protection Consolidation.
+
+------------------------------------------------------------------------
+
 ## THREAD CLOSEOUT RECORD --- 2026-06-01 --- T26 post-merge verification closeout
 
 ### Starting State

--- a/docs/reference/ci/pr-hygiene-foundation.md
+++ b/docs/reference/ci/pr-hygiene-foundation.md
@@ -54,6 +54,21 @@ become noisy gate failures. It should not hide defects; it should report them in
 stable, source-linked PR comments and leave hard merge-safety decisions to the
 Merge Protection domain.
 
+## Post-Merge Closeout
+
+Issue #1131 is the completed PR Hygiene Foundation implementation issue. PR
+#1189 merged on 2026-06-02 and established the foundation described in this
+reference.
+
+After merge, the repository state must not leave issue #1131 represented as an
+active CI implementation task. The correct closeout state is:
+
+- issue #1131 retains CI ownership and post-merge verification traceability
+- stale active execution state is removed
+- Task 002 remains the next CI implementation task after this cleanup closes
+- no merge-protection, reviewer lifecycle, runtime, or website behavior changes
+  are included in the closeout
+
 ## Advisory Surfaces
 
 | Surface | Corrective behavior | Blocking behavior |


### PR DESCRIPTION
## Summary
- close the Issue #1131 / PR #1189 post-merge cleanup state in the CI rollout plan
- add PR Hygiene Foundation post-merge closeout expectations so stale active issue state is not carried into Task 002
- add a thread-log closeout record documenting that this is governance cleanup, not a PR #1189 implementation defect
- normalize live Issue #1131 lifecycle after merge: removed stale `status:active`, closed the issue as completed, and set final label state to `status:complete`

- **Issue:** #1131
- **Related PR:** #1189

## Changed files
- `docs/ops/implementation-plans/issue-1075-ci-redesign-rollout.md`
- `docs/reference/ci/pr-hygiene-foundation.md`
- `docs/ops/trackers/THREAD-LOG_Master.md`

## Validation
- `git diff --check` — passed
- `./scripts/ci/docs_check_headers.sh .` — passed
- `./scripts/ci/docs_canonical_hashes_verify.sh .` — passed

## Scope
- docs and ops tracker cleanup only
- GitHub issue lifecycle label cleanup for #1131 only
- no workflow changes
- no runtime code changes
- no production UI changes
- does not begin Task 002
