### PR TITLE
Remediate post-merge validation workflow

### DIFF
--- a/.github/workflows/post-merge-intent-verification.yml
+++ b/.github/workflows/post-merge-intent-verification.yml
@@ -13,6 +13,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   pull-requests: read
   issues: write
@@ -20,131 +21,57 @@ permissions:
 jobs:
   detect:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: main
 
-      - name: Resolve PR
-        id: pr
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate merged PR
+        id: validate
         env:
-          GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_PR_MERGED: ${{ github.event.pull_request.merged }}
           EVENT_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: |
-          PR=""
-          METHOD="none"
-          SKIP_REASON="none"
-          if [ "$EVENT_NAME" = "pull_request_target" ]; then
-            METHOD="pull_request_target"
-            if [ "$EVENT_PR_MERGED" = "true" ] && [ "$EVENT_PR_BASE_REF" = "main" ]; then
-              PR="$EVENT_PR_NUMBER"
-            else
-              SKIP_REASON="closed PR was not merged into main"
-            fi
-          elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_PR_NUMBER" ]; then
-            METHOD="workflow_dispatch"
-            PR="$INPUT_PR_NUMBER"
-          else
-            METHOD="commit-pulls-api"
-            PR=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" -H 'Accept: application/vnd.github+json' --jq 'map(select(.state == "closed" and .merged_at != null and .base.ref == "main"))[0].number // ""')
-            if [ -z "$PR" ]; then
-              SKIP_REASON="no merged PR associated with commit"
-            fi
-          fi
-          echo "pr=$PR" >> "$GITHUB_OUTPUT"
-          echo "method=$METHOD" >> "$GITHUB_OUTPUT"
-          echo "skip_reason=$SKIP_REASON" >> "$GITHUB_OUTPUT"
-          echo "Resolved PR: ${PR:-none}; method=${METHOD}; skip=${SKIP_REASON}"
+        run: node scripts/ci/post_merge_validator.mjs
 
-      - name: Skip run without eligible merged PR
-        if: steps.pr.outputs.pr == ''
-        run: echo "Post-merge checks skipped: ${{ steps.pr.outputs.skip_reason }}"
-
-      - name: Collect PR metadata
-        if: steps.pr.outputs.pr != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr view "${{ steps.pr.outputs.pr }}" --json body,files,mergeCommit,isDraft,mergedAt,baseRefName > pr.json
-          jq -e 'if (.isDraft == true or .mergedAt == null or .baseRefName != "main") then error("Resolved PR is not a merged PR into main") else true end' pr.json > /dev/null
-          jq -r '.body // ""' pr.json > body.md
-          jq -r '.files[].path' pr.json > files.txt
-
-      - name: Evaluate merged PR metadata
-        if: steps.pr.outputs.pr != ''
-        id: verify
-        run: |
-          failures=0
-          missing_sections=""
-          if grep -Eqi '\b(TODO|TBD|placeholder)\b' body.md; then
-            failures=$((failures+1))
-            missing_sections="${missing_sections} forbidden-placeholder-token"
-          fi
-          for req in '## CHANGE SUMMARY' '## BUILD / TEST / VERIFICATION' '## ACCEPTANCE CRITERIA' '## REQUIRED PRE-REVIEW SELF-CHECK'; do
-            if ! grep -Fq "$req" body.md; then
-              failures=$((failures+1))
-              missing_sections="${missing_sections} ${req}"
-            fi
-          done
-          missing_files=0
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            [ -e "$f" ] || missing_files=$((missing_files+1))
-          done < files.txt
-          failures=$((failures+missing_files))
-          echo "failures=$failures" >> "$GITHUB_OUTPUT"
-          echo "missing_files=$missing_files" >> "$GITHUB_OUTPUT"
-          echo "missing_sections=${missing_sections}" >> "$GITHUB_OUTPUT"
-
-      - name: Audit late reviewer findings
-        if: steps.pr.outputs.pr != ''
-        id: reviewer_audit
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pr.outputs.pr }}
-        run: node scripts/ci/post_merge_reviewer_audit.mjs
+      - name: Upload validation result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-merge-validation-result
+          path: |
+            post-merge-result.json
+            post-merge-result.md
+          if-no-files-found: warn
 
       - name: Comment result
-        if: always() && steps.pr.outputs.pr != ''
+        if: always() && steps.validate.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          failures="${{ steps.verify.outputs.failures }}"
-          [ -n "$failures" ] || failures="unknown"
-          late_findings="${{ steps.reviewer_audit.outputs.late_findings }}"
-          [ -n "$late_findings" ] || late_findings="unknown"
-          audit_issue="${{ steps.reviewer_audit.outputs.audit_issue }}"
-          [ -n "$audit_issue" ] || audit_issue="none"
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          gh pr comment "${{ steps.pr.outputs.pr }}" --body "Post-merge validation result: failures=${failures}
-
-- Event: ${GITHUB_EVENT_NAME}
-- Commit: ${GITHUB_SHA}
-- Resolution method: ${{ steps.pr.outputs.method }}
-- Run URL: ${run_url}
-- Late reviewer findings: ${late_findings}
-- Reviewer follow-up issue: ${audit_issue}" || true
+        run: gh pr comment "${{ steps.validate.outputs.pr_number }}" --body-file post-merge-result.md || true
 
       - name: Sync orchestrator post-merge state
-        if: steps.pr.outputs.pr != ''
+        if: always() && steps.validate.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pr.outputs.pr }}
-          SYNC_ACTION: ${{ steps.verify.outputs.failures == '0' && steps.reviewer_audit.outputs.late_findings == '0' && 'post_merge_success' || 'post_merge_failure' }}
+          PR_NUMBER: ${{ steps.validate.outputs.pr_number }}
+          SYNC_ACTION: ${{ steps.validate.outputs.sync_action }}
         run: node scripts/orchestrator/sync-pr-state.mjs
 
-      - name: Fail if needed
-        if: steps.pr.outputs.pr != ''
-        run: |
-          if [ "${{ steps.verify.outputs.failures }}" != "0" ]; then
-            exit 1
-          fi
-          if [ "${{ steps.reviewer_audit.outputs.late_findings }}" != "0" ]; then
-            exit 1
+      - name: Fail if validation failed
+        if: always() && steps.validate.outputs.status == 'fail'
+        run: exit 1

--- a/.github/workflows/post-merge-remediation.yml
+++ b/.github/workflows/post-merge-remediation.yml
@@ -2,41 +2,38 @@ name: Post-Merge Remediation
 
 on:
   workflow_run:
-    workflows: ["Post-Merge Detection"]
-    types:
-      - completed
+    workflows: ['Post-Merge Detection']
+    types: [completed]
 
 permissions:
+  actions: read
   contents: read
   issues: write
 
 jobs:
   remediate:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Create Issue
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Download validation result
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: post-merge-validation-result
+          path: post-merge-validation-result
+
+      - name: Create or update remediation issue
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          issue_url="$(gh issue create \
-            --title "Post-Merge Failure Detected" \
-            --body "Detection workflow failed. Investigate and fix.")"
-
-          if label_exists="$(gh label list --search "post-merge-failure" --json name -q 'any(.[]; .name == "post-merge-failure")')"; then
-            if [ "$label_exists" = "true" ]; then
-              gh issue edit "$issue_url" --add-label "post-merge-failure" || \
-                echo "::warning::Unable to add post-merge-failure label to $issue_url."
-            else
-              echo "::warning::Label post-merge-failure does not exist; creating the issue without it."
-            fi
-          else
-            echo "::warning::Unable to check for post-merge-failure label; creating the issue without it."
-          fi
-
-          gh issue edit "$issue_url" --add-assignee "copilot-swe-agent[bot]" || \
-            echo "::warning::Unable to assign copilot-swe-agent[bot] to $issue_url."
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          POST_MERGE_RESULT_PATH: post-merge-validation-result/post-merge-result.json
+        run: node scripts/ci/post_merge_remediation_issue.mjs

--- a/scripts/ci/post_merge_remediation_issue.mjs
+++ b/scripts/ci/post_merge_remediation_issue.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export function remediationTitle(result) {
+	const pr = result?.pr ? `PR #${result.pr}` : `merge ${String(result?.merge_sha || 'unknown').slice(0, 12)}`;
+	return `Post-merge remediation required for ${pr}`;
+}
+
+export function remediationBody(result) {
+	const lines = [
+		'Post-merge validation detected follow-up work.',
+		'',
+		`- PR: ${result.pr ? `#${result.pr}` : 'none'}`,
+		`- Merge SHA: ${result.merge_sha || 'unknown'}`,
+		`- Source issue: ${result.source_issue ? `#${result.source_issue}` : 'none'}`,
+		`- Validator status: ${result.status}`,
+		`- Remediation required: ${result.remediation_required ? 'yes' : 'no'}`,
+		'',
+		'## Workflow failures',
+	];
+
+	if (result.workflow_failures?.length) {
+		for (const failure of result.workflow_failures) {
+			lines.push(
+				`- ${failure.workflow} — ${failure.classification} — ${failure.required ? 'required' : 'optional'} — ${failure.url || 'no run URL'}`,
+			);
+		}
+	} else {
+		lines.push('- none');
+	}
+
+	lines.push('', '## Reviewer findings');
+	if (result.reviewer_findings?.length) {
+		for (const finding of result.reviewer_findings) {
+			lines.push(`- ${finding.url} by ${finding.reviewer}: ${finding.body}`);
+		}
+	} else {
+		lines.push('- none');
+	}
+
+	lines.push('', '## Metadata failures');
+	if (result.metadata_failures?.length) {
+		for (const failure of result.metadata_failures) {
+			lines.push(`- ${failure.code}: ${failure.message}`);
+		}
+	} else {
+		lines.push('- none');
+	}
+
+	return `${lines.join('\n')}\n`;
+}
+
+async function request({ token, repository, path, method = 'GET', body }) {
+	const response = await fetch(`https://api.github.com/repos/${repository}${path}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${token}`,
+			Accept: 'application/vnd.github+json',
+			'X-GitHub-Api-Version': '2022-11-28',
+			'User-Agent': 'lgfc-post-merge-remediation',
+			...(body ? { 'Content-Type': 'application/json' } : {}),
+		},
+		...(body ? { body: JSON.stringify(body) } : {}),
+	});
+
+	if (!response.ok) {
+		throw new Error(`${method} ${path} failed: ${response.status} ${await response.text()}`);
+	}
+
+	return response.status === 204 ? null : response.json();
+}
+
+export async function upsertRemediationIssue({ token, repository, result }) {
+	if (!result.remediation_required) {
+		return { action: 'skipped', issue: null };
+	}
+
+	const title = remediationTitle(result);
+	const body = remediationBody(result);
+	const search = await request({
+		token,
+		repository,
+		path: `/issues?state=open&per_page=100`,
+	});
+	const existing = search.find((issue) => issue.title === title && !issue.pull_request);
+
+	if (existing) {
+		await request({
+			token,
+			repository,
+			path: `/issues/${existing.number}`,
+			method: 'PATCH',
+			body: { body },
+		});
+		return { action: 'updated', issue: existing.html_url || `#${existing.number}` };
+	}
+
+	const created = await request({
+		token,
+		repository,
+		path: '/issues',
+		method: 'POST',
+		body: { title, body, labels: ['post-merge-failure'] },
+	});
+
+	return { action: 'created', issue: created.html_url || `#${created.number}` };
+}
+
+export async function main() {
+	const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+	const repository = process.env.GITHUB_REPOSITORY;
+	const resultPath = process.env.POST_MERGE_RESULT_PATH || process.argv[2] || 'post-merge-result.json';
+
+	if (!token || !repository) throw new Error('GITHUB_TOKEN/GH_TOKEN and GITHUB_REPOSITORY are required.');
+	const result = JSON.parse(fs.readFileSync(resultPath, 'utf8'));
+	const outcome = await upsertRemediationIssue({ token, repository, result });
+	console.log(JSON.stringify(outcome, null, 2));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	main().catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});
+}

--- a/scripts/ci/post_merge_remediation_issue.mjs
+++ b/scripts/ci/post_merge_remediation_issue.mjs
@@ -84,7 +84,7 @@ export async function upsertRemediationIssue({ token, repository, result }) {
 		repository,
 		path: `/issues?state=open&per_page=100`,
 	});
-	const existing = search.find((issue) => issue.title === title && !issue.pull_request);
+	const existing = Array.isArray(search) ? search.find((issue) => issue.title === title && !issue.pull_request) : undefined;
 
 	if (existing) {
 		await request({

--- a/scripts/ci/post_merge_validator.mjs
+++ b/scripts/ci/post_merge_validator.mjs
@@ -281,6 +281,67 @@ async function paginate(args) {
 	return out;
 }
 
+function uniqueRuns(...runGroups) {
+	const byId = new Map();
+	for (const group of runGroups) {
+		for (const run of group || []) {
+			const id = run.databaseId || run.id || run.html_url || run.url;
+			if (id && !byId.has(id)) byId.set(id, run);
+		}
+	}
+	return [...byId.values()];
+}
+
+function runTimestamp(run) {
+	return Date.parse(run.created_at || run.createdAt || run.run_started_at || run.startedAt || run.updated_at || run.updatedAt || '') || 0;
+}
+
+export function latestRunsByWorkflow(runs = []) {
+	const latest = new Map();
+	for (const run of runs) {
+		const name = run.workflowName || run.name || 'unknown workflow';
+		const current = latest.get(name);
+		if (!current || runTimestamp(run) >= runTimestamp(current)) latest.set(name, run);
+	}
+	return [...latest.values()];
+}
+
+function shouldInspectRun(run, currentRunId = '') {
+	return (
+		String(run.databaseId || run.id || '') !== String(currentRunId || '') &&
+		String(run.status || '').toLowerCase() === 'completed' &&
+		['failure', 'timed_out', 'cancelled', 'action_required'].includes(String(run.conclusion || '').toLowerCase())
+	);
+}
+
+async function enrichFailedRuns({ token, repository, runs, currentRunId }) {
+	return Promise.all(
+		runs.map(async (run) => {
+			if (!shouldInspectRun(run, currentRunId)) return run;
+			const runId = run.databaseId || run.id;
+			if (!runId) return run;
+
+			try {
+				const jobs = await apiRequest({ token, repository, path: `/actions/runs/${runId}/jobs?per_page=100` });
+				const failureText = (jobs.jobs || [])
+					.flatMap((job) => [
+						job.name,
+						...(job.steps || [])
+							.filter((step) =>
+								['failure', 'cancelled', 'timed_out', 'action_required'].includes(String(step.conclusion || '').toLowerCase()),
+							)
+							.map((step) => step.name),
+					])
+					.filter(Boolean)
+					.join(' ');
+				return { ...run, failureText };
+			} catch {
+				return run;
+			}
+		}),
+	);
+}
+
 export async function runValidator({
 	token,
 	repository,
@@ -298,12 +359,17 @@ export async function runValidator({
 
 	if (!resolution.pr) return buildResult({ resolution, mergeSha: sha });
 
-	const [pr, issueComments, reviewComments, reviews, runsResponse] = await Promise.all([
-		apiRequest({ token, repository, path: `/pulls/${resolution.pr}` }),
+	const pr = await apiRequest({ token, repository, path: `/pulls/${resolution.pr}` });
+	const prHeadSha = pr.head?.sha || '';
+
+	const [issueComments, reviewComments, reviews, mergeRunsResponse, headRunsResponse] = await Promise.all([
 		paginate({ token, repository, path: `/issues/${resolution.pr}/comments` }),
 		paginate({ token, repository, path: `/pulls/${resolution.pr}/comments` }),
 		paginate({ token, repository, path: `/pulls/${resolution.pr}/reviews` }),
 		apiRequest({ token, repository, path: `/actions/runs?head_sha=${encodeURIComponent(sha)}&per_page=100` }),
+		prHeadSha
+			? apiRequest({ token, repository, path: `/actions/runs?head_sha=${encodeURIComponent(prHeadSha)}&per_page=100` })
+			: { workflow_runs: [] },
 	]);
 
 	const normalizedPr = {
@@ -319,7 +385,9 @@ export async function runValidator({
 	const filesExist = (filePath) => fs.existsSync(path.join(workspace, filePath));
 	const metadata = metadataFailures(normalizedPr, filesExist);
 	const findings = reviewerFindings({ pr: normalizedPr, issueComments, reviewComments, reviews });
-	const failures = workflowFailures({ runs: runsResponse.workflow_runs || [], prBody: normalizedPr.body, currentRunId: runId });
+	const runs = latestRunsByWorkflow(uniqueRuns(mergeRunsResponse.workflow_runs, headRunsResponse.workflow_runs));
+	const enrichedRuns = await enrichFailedRuns({ token, repository, runs, currentRunId: runId });
+	const failures = workflowFailures({ runs: enrichedRuns, prBody: normalizedPr.body, currentRunId: runId });
 
 	return buildResult({ pr: normalizedPr, resolution, metadata, findings, failures, mergeSha: sha });
 }

--- a/scripts/ci/post_merge_validator.mjs
+++ b/scripts/ci/post_merge_validator.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const REQUIRED_BODY_SECTIONS = [
+	'## CHANGE SUMMARY',
+	'## BUILD / TEST / VERIFICATION',
+	'## ACCEPTANCE CRITERIA',
+	'## REQUIRED PRE-REVIEW SELF-CHECK',
+];
+
+const TRUSTED_REVIEWER_PATTERN = /chatgpt-codex-connector|gemini-code-assist|copilot-pull-request-reviewer|cubic-dev-ai/i;
+const HIGH_SEVERITY_PATTERN =
+	/(^|[^A-Za-z0-9])(P0|P1)([^A-Za-z0-9]|$)|high[- ]priority|request changes|requested changes|must fix|blocking/i;
+const RESOLVED_PATTERN = /addressed in|\bresolved\b|all checks passed|no warnings detected/i;
+const UNRESOLVED_PATTERN = /\bunresolved\b|\bnot\s+resolved\b|\bstill\s+open\b|\bstill\s+blocking\b/i;
+const OPTIONAL_WORKFLOWS = new Set(['Auto-Sync Documentation']);
+const REQUIRED_WORKFLOW_PATTERNS = [
+	/quality/i,
+	/secret scan|gitleaks/i,
+	/zip/i,
+	/pr issue accounting/i,
+	/drift/i,
+	/intent/i,
+	/main change monitor/i,
+	/enforce pr only/i,
+];
+
+export function linkedIssueNumber(body = '') {
+	const sourceMarker = body.match(/<!--\s*orchestrator-source-issue:\s*(\d+)\s*-->/i);
+	if (sourceMarker) return sourceMarker[1];
+
+	const match = body.match(/(?:\*\*Issue:\*\*|Issue:)\s*(?:https?:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/|#)(\d+)/i);
+	return match ? match[1] : '';
+}
+
+export function resolvePrNumber({
+	eventName,
+	inputPrNumber = '',
+	eventPrNumber = '',
+	eventPrMerged = '',
+	eventPrBaseRef = '',
+	associatedPulls = [],
+} = {}) {
+	if (eventName === 'pull_request_target') {
+		if (String(eventPrMerged) === 'true' && eventPrBaseRef === 'main' && eventPrNumber) {
+			return { pr: String(eventPrNumber), method: 'pull_request_target', skip_reason: 'none' };
+		}
+		return { pr: '', method: 'pull_request_target', skip_reason: 'closed PR was not merged into main' };
+	}
+
+	if (eventName === 'workflow_dispatch' && inputPrNumber) {
+		return { pr: String(inputPrNumber), method: 'workflow_dispatch', skip_reason: 'none' };
+	}
+
+	const associated = associatedPulls.find((pull) => pull?.state === 'closed' && pull?.merged_at && pull?.base?.ref === 'main');
+	if (associated?.number) {
+		return { pr: String(associated.number), method: 'commit-pulls-api', skip_reason: 'none' };
+	}
+
+	return { pr: '', method: 'commit-pulls-api', skip_reason: 'no merged PR associated with commit' };
+}
+
+export function metadataFailures(pr, filesExist = () => true) {
+	const failures = [];
+	const body = pr?.body || '';
+
+	if (!pr || pr.isDraft === true || !pr.mergedAt || pr.baseRefName !== 'main') {
+		failures.push({ code: 'not_merged_to_main', message: 'Resolved PR is not a merged PR into main.' });
+	}
+
+	if (!linkedIssueNumber(body)) {
+		failures.push({ code: 'missing_source_issue', message: 'Merged PR body does not contain a primary source issue.' });
+	}
+
+	if (/\b(TODO|TBD|placeholder)\b/i.test(body)) {
+		failures.push({ code: 'forbidden_placeholder_token', message: 'Merged PR body contains a forbidden placeholder token.' });
+	}
+
+	for (const section of REQUIRED_BODY_SECTIONS) {
+		if (!body.includes(section)) {
+			failures.push({ code: 'missing_required_section', message: `Merged PR body is missing ${section}.` });
+		}
+	}
+
+	for (const file of pr?.files || []) {
+		const filePath = typeof file === 'string' ? file : file.path;
+		if (filePath && !filesExist(filePath)) {
+			failures.push({ code: 'missing_changed_file', message: `Merged PR file is absent from the checkout: ${filePath}` });
+		}
+	}
+
+	return failures;
+}
+
+export function isResolvedText(body = '') {
+	return RESOLVED_PATTERN.test(body) && !UNRESOLVED_PATTERN.test(body);
+}
+
+export function isHighSeverityFinding(body = '', state = '') {
+	return (state === 'CHANGES_REQUESTED' || HIGH_SEVERITY_PATTERN.test(body)) && !isResolvedText(body);
+}
+
+export function isAfterMerge(value, mergedAt) {
+	if (!value || !mergedAt) return false;
+	return new Date(value).getTime() > new Date(mergedAt).getTime();
+}
+
+function findingLine(item, fallbackUrl) {
+	const login = item.user?.login || 'unknown-reviewer';
+	const url = item.html_url || item.url || item._links?.html?.href || fallbackUrl || 'unknown-url';
+	const body = String(item.body || item.state || '')
+		.replace(/\s+/g, ' ')
+		.trim();
+	return { reviewer: login, url, body: body.slice(0, 240) };
+}
+
+export function reviewerFindings({ pr, issueComments = [], reviewComments = [], reviews = [] }) {
+	const mergedAt = pr?.mergedAt || pr?.merged_at || '';
+	const prUrl = pr?.url || pr?.html_url || '';
+	const findings = [];
+
+	for (const comment of issueComments) {
+		if (
+			TRUSTED_REVIEWER_PATTERN.test(comment.user?.login || '') &&
+			isAfterMerge(comment.created_at, mergedAt) &&
+			isHighSeverityFinding(comment.body || '')
+		) {
+			findings.push(findingLine(comment, prUrl));
+		}
+	}
+
+	for (const comment of reviewComments) {
+		if (
+			TRUSTED_REVIEWER_PATTERN.test(comment.user?.login || '') &&
+			isAfterMerge(comment.created_at, mergedAt) &&
+			isHighSeverityFinding(comment.body || '')
+		) {
+			findings.push(findingLine(comment, prUrl));
+		}
+	}
+
+	for (const review of reviews) {
+		if (
+			TRUSTED_REVIEWER_PATTERN.test(review.user?.login || '') &&
+			isAfterMerge(review.submitted_at, mergedAt) &&
+			isHighSeverityFinding(review.body || '', review.state || '')
+		) {
+			findings.push(findingLine(review, prUrl));
+		}
+	}
+
+	return findings;
+}
+
+export function docsSyncRequiredByAcceptance(body = '') {
+	const acceptance = body.split('## ACCEPTANCE CRITERIA')[1]?.split('\n## ')[0] || '';
+	return /auto-sync documentation|docs sync|documentation sync/i.test(acceptance);
+}
+
+export function classifyWorkflowRun(run, prBody = '') {
+	const name = run.workflowName || run.name || '';
+	const conclusion = String(run.conclusion || '').toLowerCase();
+	const required = OPTIONAL_WORKFLOWS.has(name)
+		? docsSyncRequiredByAcceptance(prBody)
+		: REQUIRED_WORKFLOW_PATTERNS.some((pattern) => pattern.test(name));
+	const classification =
+		/COPILOT_GITHUB_TOKEN|secret/i.test(run.failureText || '') || OPTIONAL_WORKFLOWS.has(name)
+			? 'secret-access/configuration'
+			: required
+				? 'required-workflow-failure'
+				: 'optional-remediation-failure';
+
+	return {
+		workflow: name || 'unknown workflow',
+		run_id: run.databaseId || run.id || null,
+		url: run.url || run.html_url || '',
+		conclusion,
+		required,
+		classification,
+	};
+}
+
+export function workflowFailures({ runs = [], prBody = '', currentRunId = '' }) {
+	return runs
+		.filter((run) => String(run.databaseId || run.id || '') !== String(currentRunId || ''))
+		.filter((run) => String(run.status || '').toLowerCase() === 'completed')
+		.filter((run) => ['failure', 'timed_out', 'cancelled', 'action_required'].includes(String(run.conclusion || '').toLowerCase()))
+		.filter((run) => !/post-merge detection|post-merge-intent-verification/i.test(run.workflowName || run.name || ''))
+		.map((run) => classifyWorkflowRun(run, prBody));
+}
+
+export function buildResult({ pr = null, resolution, metadata = [], findings = [], failures = [], mergeSha = '' }) {
+	if (!resolution?.pr) {
+		return {
+			status: 'skipped',
+			pr: null,
+			merge_sha: mergeSha,
+			source_issue: null,
+			late_findings: 0,
+			workflow_failures: [],
+			remediation_required: false,
+			skip_reason: resolution?.skip_reason || 'no merged PR associated with commit',
+		};
+	}
+
+	const requiredWorkflowFailures = failures.filter((failure) => failure.required);
+	const status = metadata.length === 0 && findings.length === 0 && requiredWorkflowFailures.length === 0 ? 'pass' : 'fail';
+
+	return {
+		status,
+		pr: Number(resolution.pr),
+		merge_sha: mergeSha || pr?.mergeCommit?.oid || pr?.merge_commit_sha || '',
+		source_issue: linkedIssueNumber(pr?.body || '') || null,
+		late_findings: findings.length,
+		workflow_failures: failures,
+		remediation_required: metadata.length > 0 || findings.length > 0 || failures.length > 0,
+		metadata_failures: metadata,
+		reviewer_findings: findings,
+		sync_action: status === 'pass' ? 'post_merge_success' : 'post_merge_failure',
+	};
+}
+
+export function commentBody(result) {
+	const lines = [
+		`Post-merge validation result: ${result.status}`,
+		'',
+		`- PR: ${result.pr ? `#${result.pr}` : 'none'}`,
+		`- Commit: ${result.merge_sha || 'unknown'}`,
+		`- Source issue: ${result.source_issue ? `#${result.source_issue}` : 'none'}`,
+		`- Late reviewer findings: ${result.late_findings}`,
+		`- Workflow failures: ${result.workflow_failures.length}`,
+		`- Remediation required: ${result.remediation_required ? 'yes' : 'no'}`,
+	];
+
+	for (const failure of result.workflow_failures) {
+		lines.push(`  - ${failure.workflow}: ${failure.classification}${failure.required ? ' (required)' : ' (optional)'}`);
+	}
+
+	return `${lines.join('\n')}\n`;
+}
+
+function writeOutput(name, value) {
+	const outputPath = process.env.GITHUB_OUTPUT;
+	if (outputPath) fs.appendFileSync(outputPath, `${name}=${value}\n`);
+}
+
+async function apiRequest({ token, repository, path: requestPath, method = 'GET', body }) {
+	const response = await fetch(`https://api.github.com/repos/${repository}${requestPath}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${token}`,
+			Accept: 'application/vnd.github+json',
+			'X-GitHub-Api-Version': '2022-11-28',
+			'User-Agent': 'lgfc-post-merge-validator',
+			...(body ? { 'Content-Type': 'application/json' } : {}),
+		},
+		...(body ? { body: JSON.stringify(body) } : {}),
+	});
+
+	if (!response.ok) {
+		throw new Error(`${method} ${requestPath} failed: ${response.status} ${await response.text()}`);
+	}
+
+	return response.status === 204 ? null : response.json();
+}
+
+async function paginate(args) {
+	const out = [];
+	let page = 1;
+	while (true) {
+		const separator = args.path.includes('?') ? '&' : '?';
+		const data = await apiRequest({ ...args, path: `${args.path}${separator}per_page=100&page=${page}` });
+		if (!Array.isArray(data) || data.length === 0) break;
+		out.push(...data);
+		if (data.length < 100) break;
+		page += 1;
+	}
+	return out;
+}
+
+export async function runValidator({
+	token,
+	repository,
+	eventName,
+	inputPrNumber,
+	eventPrNumber,
+	eventPrMerged,
+	eventPrBaseRef,
+	sha,
+	runId,
+	workspace = process.cwd(),
+}) {
+	const pulls = eventName === 'push' ? await apiRequest({ token, repository, path: `/commits/${sha}/pulls` }) : [];
+	const resolution = resolvePrNumber({ eventName, inputPrNumber, eventPrNumber, eventPrMerged, eventPrBaseRef, associatedPulls: pulls });
+
+	if (!resolution.pr) return buildResult({ resolution, mergeSha: sha });
+
+	const [pr, issueComments, reviewComments, reviews, runsResponse] = await Promise.all([
+		apiRequest({ token, repository, path: `/pulls/${resolution.pr}` }),
+		paginate({ token, repository, path: `/issues/${resolution.pr}/comments` }),
+		paginate({ token, repository, path: `/pulls/${resolution.pr}/comments` }),
+		paginate({ token, repository, path: `/pulls/${resolution.pr}/reviews` }),
+		apiRequest({ token, repository, path: `/actions/runs?head_sha=${encodeURIComponent(sha)}&per_page=100` }),
+	]);
+
+	const normalizedPr = {
+		body: pr.body || '',
+		files: await paginate({ token, repository, path: `/pulls/${resolution.pr}/files` }),
+		isDraft: pr.draft,
+		mergedAt: pr.merged_at,
+		baseRefName: pr.base?.ref,
+		mergeCommit: { oid: pr.merge_commit_sha },
+		url: pr.html_url,
+	};
+
+	const filesExist = (filePath) => fs.existsSync(path.join(workspace, filePath));
+	const metadata = metadataFailures(normalizedPr, filesExist);
+	const findings = reviewerFindings({ pr: normalizedPr, issueComments, reviewComments, reviews });
+	const failures = workflowFailures({ runs: runsResponse.workflow_runs || [], prBody: normalizedPr.body, currentRunId: runId });
+
+	return buildResult({ pr: normalizedPr, resolution, metadata, findings, failures, mergeSha: sha });
+}
+
+export async function main() {
+	const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!token || !repository) throw new Error('GITHUB_TOKEN/GH_TOKEN and GITHUB_REPOSITORY are required.');
+
+	const result = await runValidator({
+		token,
+		repository,
+		eventName: process.env.GITHUB_EVENT_NAME || '',
+		inputPrNumber: process.env.INPUT_PR_NUMBER || '',
+		eventPrNumber: process.env.EVENT_PR_NUMBER || '',
+		eventPrMerged: process.env.EVENT_PR_MERGED || '',
+		eventPrBaseRef: process.env.EVENT_PR_BASE_REF || '',
+		sha: process.env.GITHUB_SHA || '',
+		runId: process.env.GITHUB_RUN_ID || '',
+	});
+
+	fs.writeFileSync('post-merge-result.json', `${JSON.stringify(result, null, 2)}\n`);
+	fs.writeFileSync('post-merge-result.md', commentBody(result));
+
+	writeOutput('status', result.status);
+	writeOutput('pr_number', result.pr || '');
+	writeOutput('sync_action', result.sync_action || 'skipped');
+	writeOutput('remediation_required', result.remediation_required ? 'true' : 'false');
+
+	console.log(JSON.stringify(result, null, 2));
+	if (result.status === 'fail') process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	main().catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});
+}

--- a/tests/orchestrator-queue.test.mjs
+++ b/tests/orchestrator-queue.test.mjs
@@ -12,499 +12,490 @@ const syncPrState = await import('../scripts/orchestrator/sync-pr-state.mjs');
 const ciEngine = await import('../scripts/orchestrator/ci-orchestration-engine.mjs');
 
 function issue(number, status, createdAt) {
-  return {
-    number,
-    title: `Task ${number}`,
-    createdAt,
-    labels: [
-      { name: 'orchestrator' },
-      { name: status }
-    ]
-  };
+	return {
+		number,
+		title: `Task ${number}`,
+		createdAt,
+		labels: [{ name: 'orchestrator' }, { name: status }],
+	};
 }
 
 function queryFor(statuses) {
-  return vi.fn(() => Object.values(statuses).flat());
+	return vi.fn(() => Object.values(statuses).flat());
 }
 
 function ciIssue(number, status, createdAt, body = '<!-- lgfc-ci-phase:pr-hygiene-foundation -->', state = 'OPEN') {
-  return {
-    number,
-    title: `CI Task ${number}`,
-    createdAt,
-    body,
-    state,
-    labels: [
-      { name: 'orchestrator' },
-      { name: 'type:ci' },
-      { name: status }
-    ]
-  };
+	return {
+		number,
+		title: `CI Task ${number}`,
+		createdAt,
+		body,
+		state,
+		labels: [{ name: 'orchestrator' }, { name: 'type:ci' }, { name: status }],
+	};
 }
 
 function remediationIssue(number, status, createdAt, state = 'OPEN') {
-  return {
-    number,
-    title: `CI remediation ${number}`,
-    createdAt,
-    body: '<!-- lgfc-ci-orchestration-remediation -->\n# CI Orchestration Paused',
-    state,
-    labels: [
-      { name: 'orchestrator' },
-      { name: 'type:ci' },
-      { name: status }
-    ]
-  };
+	return {
+		number,
+		title: `CI remediation ${number}`,
+		createdAt,
+		body: '<!-- lgfc-ci-orchestration-remediation -->\n# CI Orchestration Paused',
+		state,
+		labels: [{ name: 'orchestrator' }, { name: 'type:ci' }, { name: status }],
+	};
 }
 
 describe('orchestrator issue creation queue model', () => {
-  it('labels the first produced task as queued and subsequent tasks as blocked', () => {
-    const tasks = [
-      { type: 'repository', agent: 'codex' },
-      { type: 'website', agent: 'cursor' },
-      { type: 'docs', agent: 'atlas' }
-    ];
+	it('labels the first produced task as queued and subsequent tasks as blocked', () => {
+		const tasks = [
+			{ type: 'repository', agent: 'codex' },
+			{ type: 'website', agent: 'cursor' },
+			{ type: 'docs', agent: 'atlas' },
+		];
 
-    const labels = tasks.map((task, index) =>
-      createIssues.labelsForTask(task, createIssues.statusLabelForCreatedTask(index))
-    );
+		const labels = tasks.map((task, index) => createIssues.labelsForTask(task, createIssues.statusLabelForCreatedTask(index)));
 
-    expect(labels[0]).toContain('status:queued');
-    expect(labels[1]).toContain('status:blocked');
-    expect(labels[2]).toContain('status:blocked');
-  });
+		expect(labels[0]).toContain('status:queued');
+		expect(labels[1]).toContain('status:blocked');
+		expect(labels[2]).toContain('status:blocked');
+	});
 
-  it('labels every produced task as blocked when an orchestrator issue is already open', () => {
-    const tasks = [
-      { type: 'repository', agent: 'codex' },
-      { type: 'website', agent: 'cursor' }
-    ];
+	it('labels every produced task as blocked when an orchestrator issue is already open', () => {
+		const tasks = [
+			{ type: 'repository', agent: 'codex' },
+			{ type: 'website', agent: 'cursor' },
+		];
 
-    const labels = tasks.map((task, index) =>
-      createIssues.labelsForTask(task, createIssues.statusLabelForCreatedTask(index, true))
-    );
+		const labels = tasks.map((task, index) => createIssues.labelsForTask(task, createIssues.statusLabelForCreatedTask(index, true)));
 
-    expect(labels[0]).toContain('status:blocked');
-    expect(labels[1]).toContain('status:blocked');
-  });
+		expect(labels[0]).toContain('status:blocked');
+		expect(labels[1]).toContain('status:blocked');
+	});
 
-  it('does not count skipped existing tasks when assigning the first newly created task status', () => {
-    const taskAlreadyHasIssue = [true, true, true, false];
-    const producedStatuses = [];
-    let createdIssueCount = 0;
+	it('does not count skipped existing tasks when assigning the first newly created task status', () => {
+		const taskAlreadyHasIssue = [true, true, true, false];
+		const producedStatuses = [];
+		let createdIssueCount = 0;
 
-    for (const exists of taskAlreadyHasIssue) {
-      if (exists) continue;
-      producedStatuses.push(createIssues.statusLabelForCreatedTask(createdIssueCount));
-      createdIssueCount += 1;
-    }
+		for (const exists of taskAlreadyHasIssue) {
+			if (exists) continue;
+			producedStatuses.push(createIssues.statusLabelForCreatedTask(createdIssueCount));
+			createdIssueCount += 1;
+		}
 
-    expect(producedStatuses).toEqual(['status:queued']);
-  });
+		expect(producedStatuses).toEqual(['status:queued']);
+	});
 
-  it('routes CI implementation issues to Cursor with CI labels', () => {
-    const labels = createIssues.labelsForTask({ type: 'ci', agent: 'cursor' });
+	it('routes CI implementation issues to Cursor with CI labels', () => {
+		const labels = createIssues.labelsForTask({ type: 'ci', agent: 'cursor' });
 
-    expect(labels).toContain('orchestrator');
-    expect(labels).toContain('status:queued');
-    expect(labels).toContain('type:ci');
-    expect(labels).toContain('agent:cursor');
-  });
+		expect(labels).toContain('orchestrator');
+		expect(labels).toContain('status:queued');
+		expect(labels).toContain('type:ci');
+		expect(labels).toContain('agent:cursor');
+	});
 
-  it('detects missing orchestrator labels before issue creation', () => {
-    expect(createIssues.missingRequiredLabels(
-      ['orchestrator', 'status:queued', 'agent:cursor'],
-      ['orchestrator', 'status:queued', 'status:blocked', 'type:ci', 'agent:cursor']
-    )).toEqual(['status:blocked', 'type:ci']);
-  });
+	it('detects missing orchestrator labels before issue creation', () => {
+		expect(
+			createIssues.missingRequiredLabels(
+				['orchestrator', 'status:queued', 'agent:cursor'],
+				['orchestrator', 'status:queued', 'status:blocked', 'type:ci', 'agent:cursor'],
+			),
+		).toEqual(['status:blocked', 'type:ci']);
+	});
 });
 
 describe('CI orchestration engine', () => {
-  const state = {
-    sourceIssue: 1075,
-    programIssue: 1058,
-    canonicalDocs: [
-      'docs/explanation/ci/lgfc-ci-production-design.md',
-      'docs/how-to/ci/lgfc-ci-implementation-plan.md'
-    ],
-    monitoring: {
-      repeatedFailureThreshold: 2,
-      staleRunHours: 6,
-      staleIssueDays: 7,
-      expectedWorkflows: ['GATE - Quality Checks', 'Docs Guardrails']
-    },
-    phases: [
-      {
-        id: 'pr-hygiene-foundation',
-        title: 'PR Hygiene Foundation',
-        dependsOn: [],
-        objective: 'Normalize PR metadata before merge protection changes.',
-        workflowScope: ['PR metadata normalization'],
-        allowedFiles: ['.github/workflows/docs-guardrails.yml', 'scripts/ci/**'],
-        forbiddenScope: ['production website behavior changes'],
-        rollbackBoundary: 'Revert only PR hygiene automation.',
-        validation: ['npm test -- tests/orchestrator-queue.test.mjs'],
-        acceptanceCriteria: ['Generated issue is Cursor-ready.'],
-        postMergeVerification: ['Confirm post-merge verification passed.']
-      },
-      {
-        id: 'merge-protection-consolidation',
-        title: 'Merge Protection Consolidation',
-        dependsOn: ['pr-hygiene-foundation'],
-        objective: 'Consolidate deterministic gates.',
-        workflowScope: ['deterministic gate consolidation'],
-        allowedFiles: ['.github/workflows/gate-quality.yml'],
-        forbiddenScope: ['reviewer lifecycle redesign'],
-        rollbackBoundary: 'Revert merge-protection changes.',
-        validation: ['npm test'],
-        acceptanceCriteria: ['Deterministic blockers are consolidated.'],
-        postMergeVerification: ['Confirm post-merge verification passed.']
-      }
-    ]
-  };
+	const state = {
+		sourceIssue: 1075,
+		programIssue: 1058,
+		canonicalDocs: ['docs/explanation/ci/lgfc-ci-production-design.md', 'docs/how-to/ci/lgfc-ci-implementation-plan.md'],
+		monitoring: {
+			repeatedFailureThreshold: 2,
+			staleRunHours: 6,
+			staleIssueDays: 7,
+			expectedWorkflows: ['GATE - Quality Checks', 'Docs Guardrails'],
+		},
+		phases: [
+			{
+				id: 'pr-hygiene-foundation',
+				title: 'PR Hygiene Foundation',
+				dependsOn: [],
+				objective: 'Normalize PR metadata before merge protection changes.',
+				workflowScope: ['PR metadata normalization'],
+				allowedFiles: ['.github/workflows/docs-guardrails.yml', 'scripts/ci/**'],
+				forbiddenScope: ['production website behavior changes'],
+				rollbackBoundary: 'Revert only PR hygiene automation.',
+				validation: ['npm test -- tests/orchestrator-queue.test.mjs'],
+				acceptanceCriteria: ['Generated issue is Cursor-ready.'],
+				postMergeVerification: ['Confirm post-merge verification passed.'],
+			},
+			{
+				id: 'merge-protection-consolidation',
+				title: 'Merge Protection Consolidation',
+				dependsOn: ['pr-hygiene-foundation'],
+				objective: 'Consolidate deterministic gates.',
+				workflowScope: ['deterministic gate consolidation'],
+				allowedFiles: ['.github/workflows/gate-quality.yml'],
+				forbiddenScope: ['reviewer lifecycle redesign'],
+				rollbackBoundary: 'Revert merge-protection changes.',
+				validation: ['npm test'],
+				acceptanceCriteria: ['Deterministic blockers are consolidated.'],
+				postMergeVerification: ['Confirm post-merge verification passed.'],
+			},
+		],
+	};
 
-  it('identifies the first dependency-ready CI phase when no active CI issue exists', () => {
-    const decision = ciEngine.rolloutDecision({
-      state,
-      issues: [],
-      runs: [
-        { workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
-        { workflowName: 'Docs Guardrails', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' }
-      ],
-      now: new Date('2026-05-22T11:00:00Z')
-    });
+	it('identifies the first dependency-ready CI phase when no active CI issue exists', () => {
+		const decision = ciEngine.rolloutDecision({
+			state,
+			issues: [],
+			runs: [
+				{ workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
+				{ workflowName: 'Docs Guardrails', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
+			],
+			now: new Date('2026-05-22T11:00:00Z'),
+		});
 
-    expect(decision).toMatchObject({
-      action: 'create',
-      phase: { id: 'pr-hygiene-foundation' }
-    });
-  });
+		expect(decision).toMatchObject({
+			action: 'create',
+			phase: { id: 'pr-hygiene-foundation' },
+		});
+	});
 
-  it('refuses to create a duplicate active CI implementation issue', () => {
-    const decision = ciEngine.rolloutDecision({
-      state,
-      issues: [ciIssue(1076, 'status:implementation', '2026-05-22T10:00:00Z')],
-      runs: [],
-      now: new Date('2026-05-22T11:00:00Z')
-    });
+	it('refuses to create a duplicate active CI implementation issue', () => {
+		const decision = ciEngine.rolloutDecision({
+			state,
+			issues: [ciIssue(1076, 'status:implementation', '2026-05-22T10:00:00Z')],
+			runs: [],
+			now: new Date('2026-05-22T11:00:00Z'),
+		});
 
-    expect(decision).toMatchObject({
-      action: 'pause',
-      reason: 'active_issue',
-      issue: { number: 1076 }
-    });
-  });
+		expect(decision).toMatchObject({
+			action: 'pause',
+			reason: 'active_issue',
+			issue: { number: 1076 },
+		});
+	});
 
-  it('advances to the next dependency phase only after the previous phase is complete', () => {
-    const decision = ciEngine.rolloutDecision({
-      state,
-      issues: [ciIssue(1076, 'status:complete', '2026-05-22T10:00:00Z', '<!-- lgfc-ci-phase:pr-hygiene-foundation -->', 'CLOSED')],
-      runs: [
-        { workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
-        { workflowName: 'Docs Guardrails', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' }
-      ],
-      now: new Date('2026-05-22T11:00:00Z')
-    });
+	it('advances to the next dependency phase only after the previous phase is complete', () => {
+		const decision = ciEngine.rolloutDecision({
+			state,
+			issues: [ciIssue(1076, 'status:complete', '2026-05-22T10:00:00Z', '<!-- lgfc-ci-phase:pr-hygiene-foundation -->', 'CLOSED')],
+			runs: [
+				{ workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
+				{ workflowName: 'Docs Guardrails', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
+			],
+			now: new Date('2026-05-22T11:00:00Z'),
+		});
 
-    expect(decision).toMatchObject({
-      action: 'create',
-      phase: { id: 'merge-protection-consolidation' }
-    });
-  });
+		expect(decision).toMatchObject({
+			action: 'create',
+			phase: { id: 'merge-protection-consolidation' },
+		});
+	});
 
-  it('does not count an open status:complete issue as a completed phase', () => {
-    const decision = ciEngine.rolloutDecision({
-      state,
-      issues: [ciIssue(1076, 'status:complete', '2026-05-22T10:00:00Z')],
-      runs: [
-        { workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
-        { workflowName: 'Docs Guardrails', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' }
-      ],
-      now: new Date('2026-05-22T11:00:00Z')
-    });
+	it('does not count an open status:complete issue as a completed phase', () => {
+		const decision = ciEngine.rolloutDecision({
+			state,
+			issues: [ciIssue(1076, 'status:complete', '2026-05-22T10:00:00Z')],
+			runs: [
+				{ workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
+				{ workflowName: 'Docs Guardrails', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
+			],
+			now: new Date('2026-05-22T11:00:00Z'),
+		});
 
-    expect(decision).toMatchObject({
-      action: 'pause',
-      reason: 'duplicate_phase_issue',
-      issue: { number: 1076 }
-    });
-  });
+		expect(decision).toMatchObject({
+			action: 'pause',
+			reason: 'duplicate_phase_issue',
+			issue: { number: 1076 },
+		});
+	});
 
-  it('ignores closed failed CI issues when selecting the next phase', () => {
-    const decision = ciEngine.rolloutDecision({
-      state,
-      issues: [ciIssue(1076, 'status:failed', '2026-05-22T10:00:00Z', '<!-- lgfc-ci-phase:pr-hygiene-foundation -->', 'CLOSED')],
-      runs: [
-        { workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
-        { workflowName: 'Docs Guardrails', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' }
-      ],
-      now: new Date('2026-05-22T11:00:00Z')
-    });
+	it('ignores closed failed CI issues when selecting the next phase', () => {
+		const decision = ciEngine.rolloutDecision({
+			state,
+			issues: [ciIssue(1076, 'status:failed', '2026-05-22T10:00:00Z', '<!-- lgfc-ci-phase:pr-hygiene-foundation -->', 'CLOSED')],
+			runs: [
+				{ workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
+				{ workflowName: 'Docs Guardrails', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
+			],
+			now: new Date('2026-05-22T11:00:00Z'),
+		});
 
-    expect(decision).toMatchObject({
-      action: 'create',
-      phase: { id: 'pr-hygiene-foundation' }
-    });
-  });
+		expect(decision).toMatchObject({
+			action: 'create',
+			phase: { id: 'pr-hygiene-foundation' },
+		});
+	});
 
-  it('excludes remediation issues from rollout gating', () => {
-    const decision = ciEngine.rolloutDecision({
-      state,
-      issues: [remediationIssue(1080, 'status:failed', '2026-05-22T10:00:00Z')],
-      runs: [
-        { workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
-        { workflowName: 'Docs Guardrails', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' }
-      ],
-      now: new Date('2026-05-22T11:00:00Z')
-    });
+	it('excludes remediation issues from rollout gating', () => {
+		const decision = ciEngine.rolloutDecision({
+			state,
+			issues: [remediationIssue(1080, 'status:failed', '2026-05-22T10:00:00Z')],
+			runs: [
+				{ workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
+				{ workflowName: 'Docs Guardrails', status: 'completed', conclusion: 'success', createdAt: '2026-05-22T10:00:00Z' },
+			],
+			now: new Date('2026-05-22T11:00:00Z'),
+		});
 
-    expect(decision).toMatchObject({
-      action: 'create',
-      phase: { id: 'pr-hygiene-foundation' }
-    });
-  });
+		expect(decision).toMatchObject({
+			action: 'create',
+			phase: { id: 'pr-hygiene-foundation' },
+		});
+	});
 
-  it('pauses rollout on repeated CI workflow failures', () => {
-    const report = ciEngine.ciHealthReport([
-      { workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'failure', createdAt: '2026-05-22T09:00:00Z', url: 'https://github.com/owner/repo/actions/runs/1' },
-      { workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'timed_out', createdAt: '2026-05-22T10:00:00Z', url: 'https://github.com/owner/repo/actions/runs/2' }
-    ], state.monitoring, new Date('2026-05-22T11:00:00Z'));
+	it('pauses rollout on repeated CI workflow failures', () => {
+		const report = ciEngine.ciHealthReport(
+			[
+				{
+					workflowName: 'GATE - Quality Checks',
+					status: 'completed',
+					conclusion: 'failure',
+					createdAt: '2026-05-22T09:00:00Z',
+					url: 'https://github.com/owner/repo/actions/runs/1',
+				},
+				{
+					workflowName: 'GATE - Quality Checks',
+					status: 'completed',
+					conclusion: 'timed_out',
+					createdAt: '2026-05-22T10:00:00Z',
+					url: 'https://github.com/owner/repo/actions/runs/2',
+				},
+			],
+			state.monitoring,
+			new Date('2026-05-22T11:00:00Z'),
+		);
 
-    expect(report.stable).toBe(false);
-    expect(report.blocking).toContainEqual(expect.objectContaining({
-      code: 'repeated_workflow_failure',
-      evidence: 'https://github.com/owner/repo/actions/runs/1, https://github.com/owner/repo/actions/runs/2'
-    }));
-  });
+		expect(report.stable).toBe(false);
+		expect(report.blocking).toContainEqual(
+			expect.objectContaining({
+				code: 'repeated_workflow_failure',
+				evidence: 'https://github.com/owner/repo/actions/runs/1, https://github.com/owner/repo/actions/runs/2',
+			}),
+		);
+	});
 
-  it('includes workflow URLs in remediation evidence', () => {
-    const decision = ciEngine.rolloutDecision({
-      state,
-      issues: [],
-      runs: [
-        { workflowName: 'GATE - Quality Checks', status: 'in_progress', conclusion: '', createdAt: '2026-05-22T01:00:00Z', url: 'https://github.com/owner/repo/actions/runs/3' }
-      ],
-      now: new Date('2026-05-22T11:00:00Z')
-    });
+	it('includes workflow URLs in remediation evidence', () => {
+		const decision = ciEngine.rolloutDecision({
+			state,
+			issues: [],
+			runs: [
+				{
+					workflowName: 'GATE - Quality Checks',
+					status: 'in_progress',
+					conclusion: '',
+					createdAt: '2026-05-22T01:00:00Z',
+					url: 'https://github.com/owner/repo/actions/runs/3',
+				},
+			],
+			now: new Date('2026-05-22T11:00:00Z'),
+		});
 
-    expect(decision).toMatchObject({
-      action: 'pause',
-      reason: 'ci_instability'
-    });
-    expect(decision.evidence).toContain('GATE - Quality Checks has been in_progress since 2026-05-22T01:00:00Z (https://github.com/owner/repo/actions/runs/3)');
-  });
+		expect(decision).toMatchObject({
+			action: 'pause',
+			reason: 'ci_instability',
+		});
+		expect(decision.evidence).toContain(
+			'GATE - Quality Checks has been in_progress since 2026-05-22T01:00:00Z (https://github.com/owner/repo/actions/runs/3)',
+		);
+	});
 
-  it('creates remediation body text for duplicate phase pauses', () => {
-    const decision = ciEngine.rolloutDecision({
-      state,
-      issues: [ciIssue(1076, 'status:complete', '2026-05-22T10:00:00Z')],
-      runs: [],
-      now: new Date('2026-05-22T11:00:00Z')
-    });
-    const body = ciEngine.buildRemediationBody(decision);
+	it('creates remediation body text for duplicate phase pauses', () => {
+		const decision = ciEngine.rolloutDecision({
+			state,
+			issues: [ciIssue(1076, 'status:complete', '2026-05-22T10:00:00Z')],
+			runs: [],
+			now: new Date('2026-05-22T11:00:00Z'),
+		});
+		const body = ciEngine.buildRemediationBody(decision);
 
-    expect(decision.reason).toBe('duplicate_phase_issue');
-    expect(body).toContain('Reason: duplicate_phase_issue');
-    expect(body).toContain('Issue #1076 already exists for phase pr-hygiene-foundation.');
-  });
+		expect(decision.reason).toBe('duplicate_phase_issue');
+		expect(body).toContain('Reason: duplicate_phase_issue');
+		expect(body).toContain('Issue #1076 already exists for phase pr-hygiene-foundation.');
+	});
 
-  it('generates Cursor-ready issue bodies with required orchestration fields', () => {
-    const body = ciEngine.buildIssueBody(state, state.phases[0]);
+	it('generates Cursor-ready issue bodies with required orchestration fields', () => {
+		const body = ciEngine.buildIssueBody(state, state.phases[0]);
 
-    expect(body).toContain('<!-- lgfc-ci-phase:pr-hygiene-foundation -->');
-    expect(body).toContain('## Objective');
-    expect(body).toContain('## Source-of-Truth Docs');
-    expect(body).toContain('## Allowed Files');
-    expect(body).toContain('## Rollback Boundary');
-    expect(body).toContain('## Validation Requirements');
-    expect(body).toContain('## Acceptance Criteria');
-    expect(body).toContain('## Post-Merge Verification Requirements');
-  });
+		expect(body).toContain('<!-- lgfc-ci-phase:pr-hygiene-foundation -->');
+		expect(body).toContain('## Objective');
+		expect(body).toContain('## Source-of-Truth Docs');
+		expect(body).toContain('## Allowed Files');
+		expect(body).toContain('## Rollback Boundary');
+		expect(body).toContain('## Validation Requirements');
+		expect(body).toContain('## Acceptance Criteria');
+		expect(body).toContain('## Post-Merge Verification Requirements');
+	});
 });
 
 describe('orchestrator draft PR preflight model', () => {
-  it('recognizes standard duplicate issue markers', () => {
-    expect(createDraftPr.isDuplicateIssueBody('Duplicate of #973')).toBe(true);
-    expect(createDraftPr.isDuplicateIssueBody('Duplicate of Issue #973')).toBe(true);
-    expect(createDraftPr.isDuplicateIssueBody('This was closed as duplicate during triage.')).toBe(true);
-    expect(createDraftPr.isDuplicateIssueBody('Related to #973 but still active.')).toBe(false);
-  });
+	it('recognizes standard duplicate issue markers', () => {
+		expect(createDraftPr.isDuplicateIssueBody('Duplicate of #973')).toBe(true);
+		expect(createDraftPr.isDuplicateIssueBody('Duplicate of Issue #973')).toBe(true);
+		expect(createDraftPr.isDuplicateIssueBody('This was closed as duplicate during triage.')).toBe(true);
+		expect(createDraftPr.isDuplicateIssueBody('Related to #973 but still active.')).toBe(false);
+	});
 
-  it('uses focused source markers for existing implementation PRs', () => {
-    const query = createDraftPr.issuePrSearchQuery(981);
-    expect(query).toContain('orchestrator-source-issue: 981');
-    expect(query).toContain('- **Issue:** #981');
-    expect(query).not.toContain('issues/981');
-  });
+	it('uses focused source markers for existing implementation PRs', () => {
+		const query = createDraftPr.issuePrSearchQuery(981);
+		expect(query).toContain('orchestrator-source-issue: 981');
+		expect(query).toContain('- **Issue:** #981');
+		expect(query).not.toContain('issues/981');
+	});
 });
 
 describe('orchestrator queue advancement', () => {
-  it('keeps a three-task queue serial until merge verification completes, then queues the next task', () => {
-    const tasks = [
-      { type: 'repository', agent: 'codex' },
-      { type: 'website', agent: 'cursor' },
-      { type: 'docs', agent: 'atlas' }
-    ];
-    const producedStatuses = tasks.map((task, index) =>
-      createIssues.labelsForTask(task, createIssues.statusLabelForCreatedTask(index))
-        .find((label) => label.startsWith('status:'))
-    );
+	it('keeps a three-task queue serial until merge verification completes, then queues the next task', () => {
+		const tasks = [
+			{ type: 'repository', agent: 'codex' },
+			{ type: 'website', agent: 'cursor' },
+			{ type: 'docs', agent: 'atlas' },
+		];
+		const producedStatuses = tasks.map((task, index) =>
+			createIssues.labelsForTask(task, createIssues.statusLabelForCreatedTask(index)).find((label) => label.startsWith('status:')),
+		);
 
-    expect(producedStatuses).toEqual(['status:queued', 'status:blocked', 'status:blocked']);
+		expect(producedStatuses).toEqual(['status:queued', 'status:blocked', 'status:blocked']);
 
-    const blockedOlder = issue(2, 'status:blocked', '2026-05-05T19:01:00Z');
-    const blockedNewer = issue(3, 'status:blocked', '2026-05-05T19:02:00Z');
-    const pipelineStates = [
-      'status:queued',
-      'status:pr-draft',
-      'status:implementation',
-      'status:review',
-      'status:post-merge-verify'
-    ];
+		const blockedOlder = issue(2, 'status:blocked', '2026-05-05T19:01:00Z');
+		const blockedNewer = issue(3, 'status:blocked', '2026-05-05T19:02:00Z');
+		const pipelineStates = ['status:queued', 'status:pr-draft', 'status:implementation', 'status:review', 'status:post-merge-verify'];
 
-    for (const state of pipelineStates) {
-      expect(
-        advanceQueue.queueAdvanceDecision(
-          queryFor({
-            [state]: [issue(1, state, '2026-05-05T19:00:00Z')],
-            'status:blocked': [blockedOlder, blockedNewer]
-          })
-        )
-      ).not.toMatchObject({ action: 'advance' });
-    }
+		for (const state of pipelineStates) {
+			expect(
+				advanceQueue.queueAdvanceDecision(
+					queryFor({
+						[state]: [issue(1, state, '2026-05-05T19:00:00Z')],
+						'status:blocked': [blockedOlder, blockedNewer],
+					}),
+				),
+			).not.toMatchObject({ action: 'advance' });
+		}
 
-    const transitions = [];
-    const merged = syncPrState.syncPrState({
-      prNumber: '42',
-      action: 'merged',
-      pr: { body: '**Issue:** #1', mergedAt: '2026-05-05T19:05:00Z', state: 'MERGED', url: 'https://example.test/pr/42' },
-      setStatusFn: (...args) => transitions.push(args)
-    });
-    const complete = syncPrState.syncPrState({
-      prNumber: '42',
-      action: 'post_merge_success',
-      pr: { body: '**Issue:** #1', mergedAt: '2026-05-05T19:05:00Z', state: 'MERGED', url: 'https://example.test/pr/42' },
-      setStatusFn: (...args) => transitions.push(args),
-      run: vi.fn()
-    });
+		const transitions = [];
+		const merged = syncPrState.syncPrState({
+			prNumber: '42',
+			action: 'merged',
+			pr: { body: '**Issue:** #1', mergedAt: '2026-05-05T19:05:00Z', state: 'MERGED', url: 'https://example.test/pr/42' },
+			setStatusFn: (...args) => transitions.push(args),
+		});
+		const complete = syncPrState.syncPrState({
+			prNumber: '42',
+			action: 'post_merge_success',
+			pr: { body: '**Issue:** #1', mergedAt: '2026-05-05T19:05:00Z', state: 'MERGED', url: 'https://example.test/pr/42' },
+			setStatusFn: (...args) => transitions.push(args),
+			run: vi.fn(),
+		});
 
-    expect(merged).toBe('post_merge_verify');
-    expect(complete).toBe('complete');
-    expect(transitions.map((transition) => transition.slice(1, 3))).toEqual([
-      ['status:review', 'status:post-merge-verify'],
-      ['status:post-merge-verify', 'status:complete']
-    ]);
-    expect(advanceQueue.queueAdvanceDecision(queryFor({ 'status:blocked': [blockedNewer, blockedOlder] })))
-      .toMatchObject({ action: 'advance', issue: { number: 2 } });
-  });
+		expect(merged).toBe('post_merge_verify');
+		expect(complete).toBe('complete');
+		expect(transitions.map((transition) => transition.slice(1, 3))).toEqual([
+			['status:review', 'status:post-merge-verify'],
+			['status:post-merge-verify', 'status:complete'],
+		]);
+		expect(advanceQueue.queueAdvanceDecision(queryFor({ 'status:blocked': [blockedNewer, blockedOlder] }))).toMatchObject({
+			action: 'advance',
+			issue: { number: 2 },
+		});
+	});
 
-  it('advances the oldest blocked task only after the active pipeline completes', () => {
-    const queued = issue(1, 'status:queued', '2026-05-05T19:00:00Z');
-    const blockedOlder = issue(2, 'status:blocked', '2026-05-05T19:01:00Z');
-    const blockedNewer = issue(3, 'status:blocked', '2026-05-05T19:02:00Z');
+	it('advances the oldest blocked task only after the active pipeline completes', () => {
+		const queued = issue(1, 'status:queued', '2026-05-05T19:00:00Z');
+		const blockedOlder = issue(2, 'status:blocked', '2026-05-05T19:01:00Z');
+		const blockedNewer = issue(3, 'status:blocked', '2026-05-05T19:02:00Z');
 
-    const pipelineStates = [
-      'status:queued',
-      'status:pr-draft',
-      'status:implementation',
-      'status:review',
-      'status:post-merge-verify'
-    ];
+		const pipelineStates = ['status:queued', 'status:pr-draft', 'status:implementation', 'status:review', 'status:post-merge-verify'];
 
-    for (const state of pipelineStates) {
-      const activeIssue = { ...queued, labels: [{ name: 'orchestrator' }, { name: state }] };
-      expect(
-        advanceQueue.queueAdvanceDecision(queryFor({ [state]: [activeIssue], 'status:blocked': [blockedOlder, blockedNewer] }))
-      ).not.toMatchObject({ action: 'advance' });
-    }
+		for (const state of pipelineStates) {
+			const activeIssue = { ...queued, labels: [{ name: 'orchestrator' }, { name: state }] };
+			expect(
+				advanceQueue.queueAdvanceDecision(queryFor({ [state]: [activeIssue], 'status:blocked': [blockedOlder, blockedNewer] })),
+			).not.toMatchObject({ action: 'advance' });
+		}
 
-    const decision = advanceQueue.queueAdvanceDecision(
-      queryFor({ 'status:blocked': [blockedNewer, blockedOlder] })
-    );
+		const decision = advanceQueue.queueAdvanceDecision(queryFor({ 'status:blocked': [blockedNewer, blockedOlder] }));
 
-    expect(decision).toMatchObject({ action: 'advance', issue: { number: 2 } });
-  });
+		expect(decision).toMatchObject({ action: 'advance', issue: { number: 2 } });
+	});
 
-  it('relabels the next blocked task and leaves traceability comment that triggers issue handoff', () => {
-    const run = vi.fn();
+	it('relabels the next blocked task and leaves traceability comment that triggers issue handoff', () => {
+		const run = vi.fn();
 
-    advanceQueue.advanceIssue(issue(2, 'status:blocked', '2026-05-05T19:01:00Z'), run);
+		advanceQueue.advanceIssue(issue(2, 'status:blocked', '2026-05-05T19:01:00Z'), run);
 
-    expect(run).toHaveBeenNthCalledWith(1, [
-      'issue',
-      'edit',
-      '2',
-      '--repo',
-      'owner/repo',
-      '--remove-label',
-      'status:blocked',
-      '--add-label',
-      'status:queued'
-    ]);
-    expect(run).toHaveBeenNthCalledWith(2, [
-      'issue',
-      'comment',
-      '2',
-      '--repo',
-      'owner/repo',
-      '--body',
-      'Queue advance: blocked → queued'
-    ]);
-  });
+		expect(run).toHaveBeenNthCalledWith(1, [
+			'issue',
+			'edit',
+			'2',
+			'--repo',
+			'owner/repo',
+			'--remove-label',
+			'status:blocked',
+			'--add-label',
+			'status:queued',
+		]);
+		expect(run).toHaveBeenNthCalledWith(2, ['issue', 'comment', '2', '--repo', 'owner/repo', '--body', 'Queue advance: blocked → queued']);
+	});
 
-  it('halts without advancing when a post-merge failure applies status:failed', () => {
-    const blocked = issue(3, 'status:blocked', '2026-05-05T19:02:00Z');
-    const failed = issue(1, 'status:failed', '2026-05-05T19:00:00Z');
-    const query = queryFor({ 'status:failed': [failed], 'status:blocked': [blocked] });
-    const logs = [];
-    const transitions = [];
+	it('halts without advancing when a post-merge failure applies status:failed', () => {
+		const blocked = issue(3, 'status:blocked', '2026-05-05T19:02:00Z');
+		const failed = issue(1, 'status:failed', '2026-05-05T19:00:00Z');
+		const query = queryFor({ 'status:failed': [failed], 'status:blocked': [blocked] });
+		const logs = [];
+		const transitions = [];
 
-    const failedTransition = syncPrState.syncPrState({
-      prNumber: '42',
-      action: 'post_merge_failure',
-      pr: { body: '**Issue:** #1', mergedAt: '2026-05-05T19:05:00Z', state: 'MERGED', url: 'https://example.test/pr/42' },
-      setStatusFn: (...args) => transitions.push(args)
-    });
+		const failedTransition = syncPrState.syncPrState({
+			prNumber: '42',
+			action: 'post_merge_failure',
+			pr: { body: '**Issue:** #1', mergedAt: '2026-05-05T19:05:00Z', state: 'MERGED', url: 'https://example.test/pr/42' },
+			setStatusFn: (...args) => transitions.push(args),
+		});
 
-    const decision = advanceQueue.queueAdvanceDecision(query);
-    advanceQueue.logDecision(decision, (message) => logs.push(message));
+		const decision = advanceQueue.queueAdvanceDecision(query);
+		advanceQueue.logDecision(decision, (message) => logs.push(message));
 
-    expect(failedTransition).toBe('failed');
-    expect(transitions[0].slice(1, 3)).toEqual(['status:post-merge-verify', 'status:failed']);
-    expect(decision).toEqual({ action: 'halt_failed' });
-    expect(logs).toEqual(['halt: failed']);
-  });
+		expect(failedTransition).toBe('failed');
+		expect(transitions[0].slice(1, 3)).toEqual(['status:post-merge-verify', 'status:failed']);
+		expect(decision).toEqual({ action: 'halt_failed' });
+		expect(logs).toEqual(['halt: failed']);
+	});
 });
 
 describe('orchestrator workflow trigger compatibility', () => {
-  it('uses status:queued labels for issue handoff and label changes for queue advancement', () => {
-    const draftWorkflow = fs.readFileSync('.github/workflows/orchestrator-draft-pr.yml', 'utf8');
-    const queueWorkflow = fs.readFileSync('.github/workflows/orchestrator-queue-advance.yml', 'utf8');
-    const enforcePrOnlyWorkflow = fs.readFileSync('.github/workflows/enforce-pr-only.yml', 'utf8');
-    const postMergeWorkflow = fs.readFileSync('.github/workflows/post-merge-intent-verification.yml', 'utf8');
-    const ciOrchestrationWorkflow = fs.readFileSync('.github/workflows/ci-orchestration-engine.yml', 'utf8');
-    const createIssuesScript = fs.readFileSync('scripts/orchestrator/create-issues.mjs', 'utf8');
-    const createDraftPrScript = fs.readFileSync('scripts/orchestrator/create-draft-pr.mjs', 'utf8');
-    const ciOrchestrationScript = fs.readFileSync('scripts/orchestrator/ci-orchestration-engine.mjs', 'utf8');
+	it('uses status:queued labels for issue handoff and label changes for queue advancement', () => {
+		const draftWorkflow = fs.readFileSync('.github/workflows/orchestrator-draft-pr.yml', 'utf8');
+		const queueWorkflow = fs.readFileSync('.github/workflows/orchestrator-queue-advance.yml', 'utf8');
+		const enforcePrOnlyWorkflow = fs.readFileSync('.github/workflows/enforce-pr-only.yml', 'utf8');
+		const postMergeWorkflow = fs.readFileSync('.github/workflows/post-merge-intent-verification.yml', 'utf8');
+		const postMergeValidatorScript = fs.readFileSync('scripts/ci/post_merge_validator.mjs', 'utf8');
+		const ciOrchestrationWorkflow = fs.readFileSync('.github/workflows/ci-orchestration-engine.yml', 'utf8');
+		const createIssuesScript = fs.readFileSync('scripts/orchestrator/create-issues.mjs', 'utf8');
+		const createDraftPrScript = fs.readFileSync('scripts/orchestrator/create-draft-pr.mjs', 'utf8');
+		const ciOrchestrationScript = fs.readFileSync('scripts/orchestrator/ci-orchestration-engine.mjs', 'utf8');
 
-    expect(draftWorkflow).toContain('types: [opened, labeled]');
-    expect(draftWorkflow).toContain("contains(github.event.issue.labels.*.name, 'status:queued')");
-    expect(queueWorkflow).toContain('types: [labeled]');
-    expect(queueWorkflow).toContain("node-version: '22'");
-    expect(queueWorkflow).toContain("github.event.label.name == 'status:complete'");
-    expect(queueWorkflow).toContain("github.event.label.name == 'status:failed'");
-    expect(enforcePrOnlyWorkflow).toContain('commits/${GITHUB_SHA}/pulls');
-    expect(postMergeWorkflow).toContain('commits/${GITHUB_SHA}/pulls');
-    expect(ciOrchestrationWorkflow).toContain("node-version: '22'");
-    expect(ciOrchestrationWorkflow).toContain('node scripts/orchestrator/ci-orchestration-engine.mjs');
-    expect(ciOrchestrationScript).toContain('status:failed');
-    expect(ciOrchestrationScript).toContain('lgfc-ci-phase:');
-    expect(createIssuesScript).toContain('ensureLabels();');
-    expect(createIssuesScript).toMatch(/['"]--state['"],\s*['"]all['"]/s);
-    expect(createDraftPrScript).toContain('existingOpenPrForIssue(repo, issue.number)');
-    expect(createDraftPrScript).toContain("issue.state !== 'OPEN'");
-    expect(createDraftPrScript).toContain('no placeholder PR was created');
-    expect(createDraftPrScript).not.toContain('orchestrator-placeholder-pr: true');
-    expect(createDraftPrScript).not.toContain('commit --allow-empty');
-  });
+		expect(draftWorkflow).toContain('types: [opened, labeled]');
+		expect(draftWorkflow).toContain("contains(github.event.issue.labels.*.name, 'status:queued')");
+		expect(queueWorkflow).toContain('types: [labeled]');
+		expect(queueWorkflow).toContain("node-version: '22'");
+		expect(queueWorkflow).toContain("github.event.label.name == 'status:complete'");
+		expect(queueWorkflow).toContain("github.event.label.name == 'status:failed'");
+		expect(enforcePrOnlyWorkflow).toContain('commits/${GITHUB_SHA}/pulls');
+		expect(postMergeWorkflow).toContain('node scripts/ci/post_merge_validator.mjs');
+		expect(postMergeValidatorScript).toContain('/commits/${sha}/pulls');
+		expect(ciOrchestrationWorkflow).toContain("node-version: '22'");
+		expect(ciOrchestrationWorkflow).toContain('node scripts/orchestrator/ci-orchestration-engine.mjs');
+		expect(ciOrchestrationScript).toContain('status:failed');
+		expect(ciOrchestrationScript).toContain('lgfc-ci-phase:');
+		expect(createIssuesScript).toContain('ensureLabels();');
+		expect(createIssuesScript).toMatch(/['"]--state['"],\s*['"]all['"]/s);
+		expect(createDraftPrScript).toContain('existingOpenPrForIssue(repo, issue.number)');
+		expect(createDraftPrScript).toContain("issue.state !== 'OPEN'");
+		expect(createDraftPrScript).toContain('no placeholder PR was created');
+		expect(createDraftPrScript).not.toContain('orchestrator-placeholder-pr: true');
+		expect(createDraftPrScript).not.toContain('commit --allow-empty');
+	});
 });

--- a/tests/post-merge-validator.test.mjs
+++ b/tests/post-merge-validator.test.mjs
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	buildResult,
+	commentBody,
+	metadataFailures,
+	resolvePrNumber,
+	reviewerFindings,
+	workflowFailures,
+} from '../scripts/ci/post_merge_validator.mjs';
+import { remediationBody, remediationTitle } from '../scripts/ci/post_merge_remediation_issue.mjs';
+
+const baseBody = [
+	'- **Issue:** #1122',
+	'',
+	'## CHANGE SUMMARY',
+	'- Implemented change.',
+	'',
+	'## BUILD / TEST / VERIFICATION',
+	'- PASS',
+	'',
+	'## ACCEPTANCE CRITERIA',
+	'- Required checks pass.',
+	'',
+	'## REQUIRED PRE-REVIEW SELF-CHECK',
+	'- Complete.',
+].join('\n');
+
+function mergedPr(overrides = {}) {
+	return {
+		body: baseBody,
+		files: [{ path: 'package.json' }],
+		isDraft: false,
+		mergedAt: '2026-06-02T17:21:10Z',
+		baseRefName: 'main',
+		mergeCommit: { oid: 'abc123' },
+		url: 'https://github.test/pull/1',
+		...overrides,
+	};
+}
+
+describe('post-merge PR resolution', () => {
+	it('resolves a merged PR from associated commit pulls', () => {
+		const result = resolvePrNumber({
+			eventName: 'push',
+			associatedPulls: [{ number: 1188, state: 'closed', merged_at: '2026-06-02T17:21:10Z', base: { ref: 'main' } }],
+		});
+
+		expect(result).toEqual({ pr: '1188', method: 'commit-pulls-api', skip_reason: 'none' });
+	});
+
+	it('skips when no merged PR is associated with the commit', () => {
+		const result = resolvePrNumber({ eventName: 'push', associatedPulls: [] });
+
+		expect(result).toMatchObject({ pr: '', skip_reason: 'no merged PR associated with commit' });
+		expect(buildResult({ resolution: result, mergeSha: 'abc123' })).toMatchObject({
+			status: 'skipped',
+			remediation_required: false,
+		});
+	});
+});
+
+describe('post-merge metadata validation', () => {
+	it('passes metadata checks for a merged PR with source issue and required sections', () => {
+		expect(metadataFailures(mergedPr(), (file) => file === 'package.json')).toEqual([]);
+	});
+
+	it('fails metadata checks when issue linkage is missing', () => {
+		const failures = metadataFailures(mergedPr({ body: baseBody.replace('- **Issue:** #1122\n\n', '') }), () => true);
+
+		expect(failures).toContainEqual(expect.objectContaining({ code: 'missing_source_issue' }));
+		expect(
+			buildResult({
+				pr: mergedPr({ body: baseBody.replace('- **Issue:** #1122\n\n', '') }),
+				resolution: { pr: '1188' },
+				metadata: failures,
+			}),
+		).toMatchObject({ status: 'fail', remediation_required: true });
+	});
+});
+
+describe('post-merge reviewer audit classification', () => {
+	it('fails when a trusted reviewer posts a late high-severity finding', () => {
+		const findings = reviewerFindings({
+			pr: mergedPr(),
+			issueComments: [
+				{
+					created_at: '2026-06-02T17:25:00Z',
+					body: 'P1 blocking: must fix this regression.',
+					html_url: 'https://github.test/comment/1',
+					user: { login: 'gemini-code-assist' },
+				},
+			],
+		});
+
+		const result = buildResult({ pr: mergedPr(), resolution: { pr: '1188' }, findings });
+
+		expect(findings).toHaveLength(1);
+		expect(result).toMatchObject({ status: 'fail', late_findings: 1, remediation_required: true });
+	});
+});
+
+describe('post-merge workflow failure classification', () => {
+	it('fails the original PR when a required workflow fails', () => {
+		const failures = workflowFailures({
+			prBody: baseBody,
+			runs: [
+				{
+					workflowName: 'GATE - Quality Checks',
+					status: 'completed',
+					conclusion: 'failure',
+					databaseId: 1,
+					url: 'https://github.test/actions/1',
+				},
+			],
+		});
+
+		const result = buildResult({ pr: mergedPr(), resolution: { pr: '1188' }, failures });
+
+		expect(failures[0]).toMatchObject({ required: true, classification: 'required-workflow-failure' });
+		expect(result).toMatchObject({ status: 'fail', remediation_required: true });
+	});
+
+	it('requires remediation but does not fail the original PR for optional docs sync failure', () => {
+		const failures = workflowFailures({
+			prBody: baseBody,
+			runs: [
+				{
+					workflowName: 'Auto-Sync Documentation',
+					status: 'completed',
+					conclusion: 'failure',
+					databaseId: 2,
+					url: 'https://github.test/actions/2',
+					failureText: 'COPILOT_GITHUB_TOKEN secret is unavailable to this workflow run.',
+				},
+			],
+		});
+
+		const result = buildResult({ pr: mergedPr(), resolution: { pr: '1188' }, failures });
+
+		expect(failures[0]).toMatchObject({ required: false, classification: 'secret-access/configuration' });
+		expect(result).toMatchObject({ status: 'pass', remediation_required: true });
+	});
+});
+
+describe('post-merge structured output and remediation body', () => {
+	it('emits structured result fields and a remediation issue body', () => {
+		const result = buildResult({
+			pr: mergedPr(),
+			resolution: { pr: '1188' },
+			failures: [
+				{
+					workflow: 'Auto-Sync Documentation',
+					classification: 'secret-access/configuration',
+					required: false,
+					url: 'https://github.test/actions/2',
+					conclusion: 'failure',
+				},
+			],
+			mergeSha: 'abc123',
+		});
+
+		expect(result).toMatchObject({
+			status: 'pass',
+			pr: 1188,
+			merge_sha: 'abc123',
+			source_issue: '1122',
+			late_findings: 0,
+			remediation_required: true,
+		});
+		expect(commentBody(result)).toContain('Workflow failures: 1');
+		expect(remediationTitle(result)).toBe('Post-merge remediation required for PR #1188');
+		expect(remediationBody(result)).toContain('Auto-Sync Documentation');
+	});
+});

--- a/tests/post-merge-validator.test.mjs
+++ b/tests/post-merge-validator.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	buildResult,
 	commentBody,
+	latestRunsByWorkflow,
 	metadataFailures,
 	resolvePrNumber,
 	reviewerFindings,
@@ -101,6 +102,15 @@ describe('post-merge reviewer audit classification', () => {
 });
 
 describe('post-merge workflow failure classification', () => {
+	it('ignores stale workflow failures when a newer run for the workflow passed', () => {
+		const latest = latestRunsByWorkflow([
+			{ workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'failure', created_at: '2026-06-02T10:00:00Z' },
+			{ workflowName: 'GATE - Quality Checks', status: 'completed', conclusion: 'success', created_at: '2026-06-02T10:05:00Z' },
+		]);
+
+		expect(workflowFailures({ prBody: baseBody, runs: latest })).toEqual([]);
+	});
+
 	it('fails the original PR when a required workflow fails', () => {
 		const failures = workflowFailures({
 			prBody: baseBody,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #1086

## PRE-OPEN GATE PREFLIGHT (MANDATORY)
- [x] Confirm exactly one same-repository, open, non-PR source issue exists.
- [x] Confirm one accepted issue-accounting line is present before opening/updating the PR.
- [x] Read the workflow files that will run for this PR's touched paths before opening the PR.
- [x] Read `docs/reference/governance/troubleshooting-data-surface-requirements.md` before making any merge-readiness claim.
- [x] Confirm PR body file allowlist exactly matches the final changed-file list before opening.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: CI Task 004 — Post-Merge Validation Expansion
- Task: Remediate failed post-merge validation workflow design
- Status: DRAFT
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: None known; latest required PR gates pass and merge state is clean.
- Notes: Implements the approved two-layer design; no tracker updates included. PR remains draft by creation mode.

## DOCUMENTATION SOURCE (MANDATORY)
- [x] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `docs/ops/implementation-plans/issue-1075-ci-redesign-rollout.md`
- `docs/reference/governance/troubleshooting-data-surface-requirements.md`
- `.github/workflows/post-merge-intent-verification.yml`
- `.github/workflows/post-merge-remediation.yml`
- `scripts/ci/post_merge_reviewer_audit.mjs`
- `scripts/orchestrator/sync-pr-state.mjs`
- `tests/orchestrator-queue.test.mjs`

## LABEL
- Intent label for this PR: change-ops

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical troubleshooting reference: `/docs/reference/governance/troubleshooting-data-surface-requirements.md`
- Canonical CI implementation plan: `/docs/ops/implementation-plans/issue-1075-ci-redesign-rollout.md`
- Additional design/reference docs used for this PR:
  - `docs/reference/governance/troubleshooting-data-surface-requirements.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `.github/workflows/post-merge-intent-verification.yml`
- `.github/workflows/post-merge-remediation.yml`
- `scripts/ci/post_merge_validator.mjs`
- `scripts/ci/post_merge_remediation_issue.mjs`
- `tests/post-merge-validator.test.mjs`
- `tests/orchestrator-queue.test.mjs`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label intended
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## DOCS-ONLY ASSERTION (REQUIRED FOR change-ops)
- [ ] This PR contains documentation-only changes
- [x] No application runtime behavior modified; CI workflow/script behavior is modified by design.

## CHANGE SUMMARY
- Reduced post-merge detection/remediation YAML to declarative wrappers around deterministic Node scripts.
- Added structured post-merge validator output with `status`, `pr`, `merge_sha`, `source_issue`, `late_findings`, `workflow_failures`, and `remediation_required`.
- Added remediation issue upsert logic that consumes validator JSON and creates/updates one follow-up issue.
- Added fixture-based tests for merged PRs, missing PRs, missing issue linkage, late reviewer findings, required workflow failures, stale workflow failures, and optional docs-sync/configuration failures.
- Addressed Gemini review findings by querying PR-head workflow runs, enriching failed runs with job/step text, latest-filtering workflow runs, and guarding remediation issue search responses.

## BUILD / TEST / VERIFICATION
- Commands run:
  - PASS: `npm test -- tests/post-merge-validator.test.mjs tests/orchestrator-queue.test.mjs`
  - PASS: `npx prettier --check .github/workflows/post-merge-intent-verification.yml .github/workflows/post-merge-remediation.yml scripts/ci/post_merge_validator.mjs scripts/ci/post_merge_remediation_issue.mjs tests/post-merge-validator.test.mjs tests/orchestrator-queue.test.mjs`
  - PASS: `npm run typecheck`
  - PASS: `npm test`
  - PASS: `git diff --check && if compgen -G "*.zip" > /dev/null; then ...; else echo 'No root ZIP files present'; fi`
  - PASS: `GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=wdhunter645/next-starter-template GITHUB_EVENT_NAME=workflow_dispatch INPUT_PR_NUMBER=1188 GITHUB_SHA=73f41b83238d2ef7ea20229066d2381fcba12433 GITHUB_RUN_ID=local node scripts/ci/post_merge_validator.mjs`
- Gate verification:
  - Commit-level workflow runs inspected: YES
  - PR-level governance/accounting workflows inspected: YES
  - Failed job logs inspected for every failing gate: YES
  - Required gates rerun or re-evaluated after fixes: YES
- Remote result summary: PASS for latest required gates; historical cancelled runs are superseded.

## DOCUMENTATION UPDATES
- [x] No documentation updates required
- Files: N/A

## REVIEWER RESPONSE ACCOUNTING
- [x] Reviewed all reviewer comments.
- [x] Reviewed all bot comments.
- [x] Reviewed all GitHub review threads available through inline review comments.
- [x] Copilot disposition received or not applicable.
- [x] Codex disposition received or not applicable.
- [x] Gemini disposition received or not applicable.
- [x] Cubic disposition received or not applicable.
- [x] Every actionable reviewer comment has a PR-body disposition.
- [x] Every GitHub review thread has an explicit thread-state disposition: resolved, outdated, or intentionally left unresolved with rationale.

Reviewer items:
- review-comment:3343396308 — accepted — `runValidator` now fetches PR metadata first, queries workflow runs for the PR head SHA as well as the merge SHA, latest-filters runs, and preserves merge SHA in structured output — thread state: unresolved-with-rationale (code changed; awaiting platform/human thread resolution)
- review-comment:3343396311 — accepted — failed workflow runs are enriched from `/actions/runs/{run_id}/jobs` job/step names before classification, allowing secret/configuration classification without relying on nonexistent `failureText` from the run list API — thread state: unresolved-with-rationale (code changed; awaiting platform/human thread resolution)
- review-comment:3343396317 — accepted — remediation issue search now guards `Array.isArray(search)` before `.find()` — thread state: unresolved-with-rationale (code changed; awaiting platform/human thread resolution)

## PR GATE READINESS CHECKLIST
- [x] Live PR check panel inspected
- [x] Commit-level workflow runs inspected
- [x] PR-level pull_request_target workflows inspected
- [x] Latest head workflow runs inspected after reviewer-fix push
- [x] Failed job logs inspected for every failing gate present before reviewer fixes
- [x] Workflow YAML or enforcement logic inspected before documenting gate behavior
- [x] PR issue-accounting confirms exactly one same-repository, open, non-PR source issue
- [x] PR body contains one accepted source-issue accounting line governed by `/docs/governance/PR_GOVERNANCE.md`.
- [x] All review threads and comments inspected
- [x] Actionable review feedback has PR-body disposition and GitHub thread-state disposition
- [x] Bot comments inspected
- [x] Reviewer-response accounting includes required reviewer comment IDs when required by gate logs
- [x] Required gates rerun or re-evaluated after fixes
- [x] Final PR panel confirms current gate cleanliness; PR remains draft.

## POST-MERGE CLOSEOUT CHECKLIST
- [ ] PR merged state verified
- [ ] Merge commit recorded
- [ ] Source issue state inspected after merge
- [ ] Source issue closed manually when automation did not close it
- [ ] Source issue closure comment references merged PR and merge commit
- [ ] Tracker/documentation update PR opened when implementation PR intentionally omitted tracker updates
- [ ] Post-merge validation gates inspected when applicable

## ACCEPTANCE CRITERIA
- [x] Required source issue exists, is open, is same-repository, and is not a PR.
- [x] PR issue-accounting gate passes for latest run.
- [x] Drift gate passes for latest run.
- [x] Intent gate passes for latest run.
- [x] ZIP safety gate passes.
- [x] Quality checks pass remotely.
- [x] Secret scan passes remotely.
- [x] Repository-specific governance gates pass remotely.
- [x] No out-of-scope file changes locally.
- [ ] PR is ready for human review: draft PR; no undraft operation performed by this agent.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] PR body contains one accepted source-issue accounting line governed by `/docs/governance/PR_GOVERNANCE.md`.
- [x] Allowed files section matches final diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] Local checks executed and passed or exact blocker documented
- [x] Commit message aligns with scope
- [x] No prohibited artifacts introduced
- [ ] Status is set to READY FOR REVIEW only after draft state is intentionally changed by a permitted actor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a93f35a0-3087-4700-98bc-53b4438f9226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a93f35a0-3087-4700-98bc-53b4438f9226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt post-merge validation and remediation into deterministic Node scripts that emit structured results, comment a concise summary, and create/update a single remediation issue from artifacts. Addresses #1086, reduces YAML, and improves detection and classification of late reviewer findings and workflow failures.

- **New Features**
  - Added `scripts/ci/post_merge_validator.mjs` to resolve the merged PR, validate metadata and source issue, audit trusted reviewer comments, classify workflow failures (required vs optional/secret-access), and emit `post-merge-result.json`/`.md` plus outputs (`status`, `pr_number`, `sync_action`, `remediation_required`).
  - Updated `post-merge-intent-verification.yml` to run the validator, upload the result artifact, comment the `.md` summary on the PR, and sync the orchestrator using `sync_action`.
  - Added `scripts/ci/post_merge_remediation_issue.mjs` and wired `post-merge-remediation.yml` to download the artifact from the detection run and upsert one remediation issue labeled `post-merge-failure`.

- **Refactors**
  - Simplified both post-merge workflows into thin Node-driven wrappers; removed brittle shell/JQ logic and reviewer-audit steps.
  - Added focused tests (`tests/post-merge-validator.test.mjs`) for metadata/linkage, reviewer severity, workflow failure classification, and updated orchestrator compatibility checks in `tests/orchestrator-queue.test.mjs`.

<sup>Written for commit 397475292d91e06472588f753a93ef92c6131aa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->