### PR TITLE
ci: fix PR 1193 post-merge automation failures

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Cloudflare Pages snapshot script
+        id: cf_snapshot
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
@@ -55,6 +56,7 @@ jobs:
         run: bash scripts/cf_pages_snapshot.sh
 
       - name: Upload Cloudflare Pages snapshot artifacts
+        if: steps.cf_snapshot.outputs.snapshot_created == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cloudflare-pages-snapshot

--- a/scripts/cf_pages_snapshot.sh
+++ b/scripts/cf_pages_snapshot.sh
@@ -4,25 +4,28 @@
 # - Fetches Pages project metadata, domains, and recent deployments
 # - Writes timestamped JSON files to snapshots/cloudflare/
 # - Appends run timestamp to _smoketest.txt
-# - Fails fast if required env vars/secrets are missing
+# - Skips cleanly if optional Cloudflare env vars/secrets are missing
 #
 
 set -euo pipefail
 
-# --- Required env vars check ---
-if [[ -z "${CF_ACCOUNT_ID:-}" ]]; then
-  echo "ERROR: CF_ACCOUNT_ID environment variable is not set" >&2
-  exit 1
-fi
+# --- Optional env vars check ---
+missing=""
+[[ -n "${CF_ACCOUNT_ID:-}" ]] || missing="${missing:+$missing, }CF_ACCOUNT_ID"
+[[ -n "${CF_PAGES_PROJECT:-}" ]] || missing="${missing:+$missing, }CF_PAGES_PROJECT"
+[[ -n "${CLOUDFLARE_API_TOKEN:-}" ]] || missing="${missing:+$missing, }CLOUDFLARE_API_TOKEN"
 
-if [[ -z "${CF_PAGES_PROJECT:-}" ]]; then
-  echo "ERROR: CF_PAGES_PROJECT environment variable is not set" >&2
-  exit 2
-fi
-
-if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
-  echo "ERROR: CLOUDFLARE_API_TOKEN secret is not set" >&2
-  exit 3
+if [[ -n "$missing" ]]; then
+  message="Cloudflare Pages snapshot skipped; missing configuration: $missing"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "snapshot_created=false" >> "$GITHUB_OUTPUT"
+  fi
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::notice title=Cloudflare Pages snapshot skipped::$message"
+  else
+    echo "$message" >&2
+  fi
+  exit 0
 fi
 
 # --- Setup ---
@@ -185,3 +188,7 @@ echo "  - $DEPLOYMENTS_FILE"
 echo "  - $SMOKETEST_FILE (appended)"
 echo "  - $README_FILE (updated)"
 echo ""
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "snapshot_created=true" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/orchestrator/create-issues.mjs
+++ b/scripts/orchestrator/create-issues.mjs
@@ -22,10 +22,6 @@ function runGh(args) {
   return execFileSync('gh', args, { encoding: 'utf8' }).trim();
 }
 
-function runGit(args) {
-  return execFileSync('git', args, { encoding: 'utf8' }).trim();
-}
-
 export function missingRequiredLabels(existingLabels, requiredLabels) {
   const existing = new Set(existingLabels);
   return requiredLabels.filter((label) => !existing.has(label));
@@ -98,15 +94,6 @@ function isProductionReady(content) {
   return /Status:\s*production-ready/i.test(content);
 }
 
-function markIssuesCreated(filePath, content) {
-  const updated = content.replace(/Status:\s*production-ready/i, 'Status: issues-created');
-  if (updated !== content) {
-    fs.writeFileSync(filePath, updated);
-    return true;
-  }
-  return false;
-}
-
 function projectSlug(filePath) {
   return path.basename(filePath, path.extname(filePath));
 }
@@ -119,12 +106,14 @@ function parseTasks(content) {
     const block = content.slice(start, end).trim();
     const type = block.match(/^Type:\s*(.+)$/m)?.[1]?.trim();
     const agent = block.match(/^Agent:\s*(.+)$/m)?.[1]?.trim();
+    const status = block.match(/^Status:\s*(.+)$/m)?.[1]?.trim();
     return {
       id: `Task-${match[1]}`,
       number: match[1],
       title: match[2].trim(),
       type,
       agent,
+      status,
       block
     };
   });
@@ -196,6 +185,11 @@ export function labelsForTask(task, statusLabel = 'status:queued') {
   ];
 }
 
+export function shouldCreateIssueForTask(task) {
+  const terminalStatuses = new Set(['complete', 'completed', 'closed', 'issues-created']);
+  return !terminalStatuses.has((task.status || '').toLowerCase());
+}
+
 export function main() {
   ensureLabels();
 
@@ -203,7 +197,6 @@ export function main() {
     ? fs.readdirSync(planDir).filter((name) => name.endsWith('.md') && name !== 'README.md').sort()
     : [];
 
-  const updatedPlans = [];
   const queueAlreadyOpen = openOrchestratorIssueExists();
   let createdIssueCount = 0;
 
@@ -218,6 +211,11 @@ export function main() {
     const tasks = parseTasks(content);
 
     for (const task of tasks) {
+      if (!shouldCreateIssueForTask(task)) {
+        console.log(`SKIP ${task.id} with terminal status: ${task.status}`);
+        continue;
+      }
+
       const marker = `lgfc-task-id:${slug}:${task.id}`;
       if (issueExists(marker)) {
         console.log(`SKIP existing issue for ${marker}`);
@@ -262,18 +260,6 @@ export function main() {
       createdIssueCount += 1;
       console.log(`CREATED issue for ${marker}`);
     }
-
-    if (!dryRun && markIssuesCreated(filePath, content)) {
-      updatedPlans.push(filePath);
-    }
-  }
-
-  if (updatedPlans.length > 0) {
-    runGit(['config', 'user.name', 'github-actions[bot]']);
-    runGit(['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com']);
-    runGit(['add', ...updatedPlans]);
-    runGit(['commit', '-m', 'ops: mark implementation plans as issues-created']);
-    runGit(['push', 'origin', 'HEAD:main']);
   }
 }
 

--- a/tests/orchestrator-queue.test.mjs
+++ b/tests/orchestrator-queue.test.mjs
@@ -104,6 +104,14 @@ describe('orchestrator issue creation queue model', () => {
 			),
 		).toEqual(['status:blocked', 'type:ci']);
 	});
+
+	it('skips task issue creation for terminal task statuses', () => {
+		expect(createIssues.shouldCreateIssueForTask({ status: 'completed' })).toBe(false);
+		expect(createIssues.shouldCreateIssueForTask({ status: 'closed' })).toBe(false);
+		expect(createIssues.shouldCreateIssueForTask({ status: 'issues-created' })).toBe(false);
+		expect(createIssues.shouldCreateIssueForTask({ status: 'active' })).toBe(true);
+		expect(createIssues.shouldCreateIssueForTask({})).toBe(true);
+	});
 });
 
 describe('CI orchestration engine', () => {


### PR DESCRIPTION
## Summary
- prevent the implementation issue factory from mutating implementation-plan files and direct-pushing to `main`
- skip task issue creation for task blocks already marked terminal, preventing completed Task 001 from being recreated
- make the Cloudflare Pages snapshot script skip cleanly when optional Cloudflare configuration is absent
- prevent skipped Cloudflare snapshot runs from uploading stale/partial artifacts
- add targeted test coverage for terminal task status skipping
- close stale duplicate Task 001 issue #1194 created by the failed PR #1193 post-merge issue-factory run

- **Issue:** #1206
- **Related PR:** #1193

## Changed files
- `.github/workflows/snapshot.yml`
- `scripts/orchestrator/create-issues.mjs`
- `scripts/cf_pages_snapshot.sh`
- `tests/orchestrator-queue.test.mjs`

## Live issue cleanup
- #1194 closed as duplicate/stale Task 001 artifact
- #1195 remains blocked until this remediation PR merges; it should become the next Task 002 queue item after remediation is accepted
- #1206 labeled as active Codex CI remediation

## REVIEWER RESPONSE ACCOUNTING
- [x] Cubic disposition received: one inline stale-artifact risk for skipped Cloudflare snapshot runs.
- [x] Reviewed selected reviewer comments.
- [x] Accepted / rejected / ignored each actionable selected-reviewer comment with rationale.
- review-comment:3347893649 — accepted — added a `snapshot_created` step output and gated Cloudflare artifact upload on `snapshot_created == true`, preventing skipped runs from uploading stale committed snapshot support files.
- review-comment:3347811320 — accepted — renamed the section heading from required env vars to optional env vars so the script comments match the skip-on-missing-configuration behavior.
- review-comment:3347803621 — accepted — replaced the Bash array-based missing-configuration accumulator with comma-separated string accumulation, preserving the skip behavior while improving Bash portability.

## Validation
- `npm test -- tests/orchestrator-queue.test.mjs` — passed
- `npm run typecheck` — passed
- `./scripts/ci/docs_check_headers.sh .` — passed
- `./scripts/ci/docs_canonical_hashes_verify.sh .` — passed
- `git diff --check` — passed
- `GITHUB_ACTIONS=true GITHUB_OUTPUT=<tmp> CF_ACCOUNT_ID= CF_PAGES_PROJECT= CLOUDFLARE_API_TOKEN= bash scripts/cf_pages_snapshot.sh` — passed; emitted skip notice and wrote `snapshot_created=false`

## Scope
- CI automation remediation only
- no production UI changes
- no website runtime behavior changes
- no package/dependency changes

## CHANGE SUMMARY
- Fixed PR #1193 post-merge automation failures by removing direct pushes from issue-factory automation, preventing completed task recreation, and making Cloudflare snapshot skips safe.
- Added a Cloudflare snapshot output guard so skipped runs do not upload stale artifacts.
- Closed stale duplicate Task 001 issue #1194 as part of live queue cleanup.

## BUILD / TEST / VERIFICATION
- npm test -- tests/orchestrator-queue.test.mjs — passed.
- npm run typecheck — passed.
- ./scripts/ci/docs_check_headers.sh . — passed.
- ./scripts/ci/docs_canonical_hashes_verify.sh . — passed.
- git diff --check — passed.
- Cloudflare missing-configuration script check emitted skip notice and snapshot_created=false.

## ACCEPTANCE CRITERIA
- Issue factory no longer mutates implementation plans or pushes directly to main.
- Completed implementation task blocks are not recreated as duplicate issues.
- Cloudflare snapshot missing configuration no longer fails the post-merge snapshot job.
- Skipped Cloudflare snapshot runs do not upload stale artifacts.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] Scope is limited to CI automation remediation.
- [x] No production UI or website runtime behavior changed.
- [x] No package or dependency changes were made.
- [x] Reviewer response accounting was included for accepted inline review comments.