### PR TITLE
feat: implement T48 weekly matchup administration

### DIFF
--- a/functions/api/admin/matchup/close-active.ts
+++ b/functions/api/admin/matchup/close-active.ts
@@ -1,0 +1,47 @@
+// POST /api/admin/matchup/close-active
+// Admin-only. Closes the current active weekly matchup (rotation control).
+
+import { requireAdmin } from "../../../_lib/auth";
+import { requireD1, requireTables, jsonResponse } from "../../../_lib/d1";
+
+export const onRequestPost = async (context: any): Promise<Response> => {
+  const { request, env } = context;
+
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  const d1 = requireD1(env);
+  if (!d1.ok) return jsonResponse(d1.body, d1.status);
+
+  const tables = await requireTables(d1.db, ["weekly_matchups"]);
+  if (!tables.ok) return jsonResponse(tables.body, tables.status);
+
+  try {
+    const active = await d1.db
+      .prepare(
+        "SELECT id, week_start FROM weekly_matchups WHERE status='active' ORDER BY week_start DESC LIMIT 1",
+      )
+      .first();
+
+    if (!active) {
+      return jsonResponse({ ok: true, changed: 0, note: "No active matchup to close." }, 200);
+    }
+
+    const out = await d1.db
+      .prepare("UPDATE weekly_matchups SET status='closed' WHERE status='active'")
+      .run();
+
+    return jsonResponse(
+      {
+        ok: true,
+        changed: out?.meta?.changes || 0,
+        closed_id: Number((active as any).id),
+        closed_week_start: String((active as any).week_start || ""),
+      },
+      200,
+    );
+  } catch (err: any) {
+    console.error("admin matchup close-active error:", err);
+    return jsonResponse({ ok: false, error: "server_error", detail: String(err?.message || err) }, 500);
+  }
+};

--- a/functions/api/admin/matchup/create.ts
+++ b/functions/api/admin/matchup/create.ts
@@ -18,7 +18,7 @@ export const onRequestPost = async (context: any): Promise<Response> => {
   const d1 = requireD1(env);
   if (!d1.ok) return jsonResponse(d1.body, d1.status);
 
-  const tables = await requireTables(d1.db, ["weekly_matchups"]);
+  const tables = await requireTables(d1.db, ["weekly_matchups", "photos"]);
   if (!tables.ok) return jsonResponse(tables.body, tables.status);
 
   try {
@@ -26,7 +26,20 @@ export const onRequestPost = async (context: any): Promise<Response> => {
     const week_start = String(body?.week_start || "").trim();
     const photo_a_id = Number(body?.photo_a_id);
     const photo_b_id = Number(body?.photo_b_id);
-    const statusRaw = String(body?.status || "closed").trim().toLowerCase();
+    const statusRaw =
+      body?.status === undefined || body?.status === null
+        ? "closed"
+        : String(body.status).trim().toLowerCase();
+
+    if (
+      body?.status !== undefined &&
+      body?.status !== null &&
+      String(body.status).trim() !== "" &&
+      !STATUS_VALUES.has(statusRaw)
+    ) {
+      return jsonResponse({ ok: false, error: "invalid_status" }, 400);
+    }
+
     const status = STATUS_VALUES.has(statusRaw) ? statusRaw : "closed";
 
     if (!isValidWeekStart(week_start)) {
@@ -40,6 +53,16 @@ export const onRequestPost = async (context: any): Promise<Response> => {
     }
     if (photo_a_id === photo_b_id) {
       return jsonResponse({ ok: false, error: "photo_ids_must_differ" }, 400);
+    }
+
+    const photoA = await d1.db.prepare("SELECT id FROM photos WHERE id = ?").bind(photo_a_id).first();
+    if (!photoA) {
+      return jsonResponse({ ok: false, error: "photo_a_not_found" }, 400);
+    }
+
+    const photoB = await d1.db.prepare("SELECT id FROM photos WHERE id = ?").bind(photo_b_id).first();
+    if (!photoB) {
+      return jsonResponse({ ok: false, error: "photo_b_not_found" }, 400);
     }
 
     const out = await d1.db
@@ -56,11 +79,12 @@ export const onRequestPost = async (context: any): Promise<Response> => {
         return jsonResponse({ ok: false, error: "server_error", detail: "missing_insert_id" }, 500);
       }
 
-      await d1.db
-        .prepare("UPDATE weekly_matchups SET status='closed' WHERE status='active' AND id != ?")
-        .bind(newId)
-        .run();
-      await d1.db.prepare("UPDATE weekly_matchups SET status='active' WHERE id = ?").bind(newId).run();
+      await d1.db.batch([
+        d1.db
+          .prepare("UPDATE weekly_matchups SET status='closed' WHERE status='active' AND id != ?")
+          .bind(newId),
+        d1.db.prepare("UPDATE weekly_matchups SET status='active' WHERE id = ?").bind(newId),
+      ]);
     }
 
     return jsonResponse({ ok: true, id: newId || null }, 200);

--- a/functions/api/admin/matchup/create.ts
+++ b/functions/api/admin/matchup/create.ts
@@ -1,0 +1,66 @@
+// POST /api/admin/matchup/create
+// Admin-only. Creates a weekly matchup row.
+//
+// Body: { week_start, photo_a_id, photo_b_id, status? }
+
+import { requireAdmin } from "../../../_lib/auth";
+import { requireD1, requireTables, jsonResponse } from "../../../_lib/d1";
+import { isValidWeekStart } from "./list";
+
+const STATUS_VALUES = new Set(["active", "closed"]);
+
+export const onRequestPost = async (context: any): Promise<Response> => {
+  const { request, env } = context;
+
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  const d1 = requireD1(env);
+  if (!d1.ok) return jsonResponse(d1.body, d1.status);
+
+  const tables = await requireTables(d1.db, ["weekly_matchups"]);
+  if (!tables.ok) return jsonResponse(tables.body, tables.status);
+
+  try {
+    const body = await request.json().catch(() => null);
+    const week_start = String(body?.week_start || "").trim();
+    const photo_a_id = Number(body?.photo_a_id);
+    const photo_b_id = Number(body?.photo_b_id);
+    const statusRaw = String(body?.status || "closed").trim().toLowerCase();
+    const status = STATUS_VALUES.has(statusRaw) ? statusRaw : "closed";
+
+    if (!isValidWeekStart(week_start)) {
+      return jsonResponse({ ok: false, error: "invalid_week_start" }, 400);
+    }
+    if (!Number.isFinite(photo_a_id) || photo_a_id <= 0) {
+      return jsonResponse({ ok: false, error: "invalid_photo_a_id" }, 400);
+    }
+    if (!Number.isFinite(photo_b_id) || photo_b_id <= 0) {
+      return jsonResponse({ ok: false, error: "invalid_photo_b_id" }, 400);
+    }
+    if (photo_a_id === photo_b_id) {
+      return jsonResponse({ ok: false, error: "photo_ids_must_differ" }, 400);
+    }
+
+    if (status === "active") {
+      await d1.db.prepare("UPDATE weekly_matchups SET status='closed' WHERE status='active';").run();
+    }
+
+    const out = await d1.db
+      .prepare(
+        `INSERT INTO weekly_matchups (week_start, photo_a_id, photo_b_id, status)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .bind(week_start, photo_a_id, photo_b_id, status)
+      .run();
+
+    return jsonResponse({ ok: true, id: out?.meta?.last_row_id ?? null }, 200);
+  } catch (err: any) {
+    const message = String(err?.message || err);
+    if (message.includes("UNIQUE")) {
+      return jsonResponse({ ok: false, error: "week_start_already_exists" }, 409);
+    }
+    console.error("admin matchup create error:", err);
+    return jsonResponse({ ok: false, error: "server_error", detail: message }, 500);
+  }
+};

--- a/functions/api/admin/matchup/create.ts
+++ b/functions/api/admin/matchup/create.ts
@@ -42,19 +42,28 @@ export const onRequestPost = async (context: any): Promise<Response> => {
       return jsonResponse({ ok: false, error: "photo_ids_must_differ" }, 400);
     }
 
-    if (status === "active") {
-      await d1.db.prepare("UPDATE weekly_matchups SET status='closed' WHERE status='active';").run();
-    }
-
     const out = await d1.db
       .prepare(
         `INSERT INTO weekly_matchups (week_start, photo_a_id, photo_b_id, status)
          VALUES (?, ?, ?, ?)`,
       )
-      .bind(week_start, photo_a_id, photo_b_id, status)
+      .bind(week_start, photo_a_id, photo_b_id, "closed")
       .run();
 
-    return jsonResponse({ ok: true, id: out?.meta?.last_row_id ?? null }, 200);
+    const newId = Number(out?.meta?.last_row_id || 0);
+    if (status === "active") {
+      if (!Number.isFinite(newId) || newId <= 0) {
+        return jsonResponse({ ok: false, error: "server_error", detail: "missing_insert_id" }, 500);
+      }
+
+      await d1.db
+        .prepare("UPDATE weekly_matchups SET status='closed' WHERE status='active' AND id != ?")
+        .bind(newId)
+        .run();
+      await d1.db.prepare("UPDATE weekly_matchups SET status='active' WHERE id = ?").bind(newId).run();
+    }
+
+    return jsonResponse({ ok: true, id: newId || null }, 200);
   } catch (err: any) {
     const message = String(err?.message || err);
     if (message.includes("UNIQUE")) {

--- a/functions/api/admin/matchup/list.ts
+++ b/functions/api/admin/matchup/list.ts
@@ -1,0 +1,77 @@
+// GET /api/admin/matchup/list?limit=50
+// Returns weekly matchups with vote totals for admin review.
+
+import { requireAdmin } from "../../../_lib/auth";
+import { requireD1, requireTables, jsonResponse } from "../../../_lib/d1";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export const onRequestGet = async (context: any): Promise<Response> => {
+  const { request, env } = context;
+
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  const d1 = requireD1(env);
+  if (!d1.ok) return jsonResponse(d1.body, d1.status);
+
+  const tables = await requireTables(d1.db, ["weekly_matchups", "weekly_votes"]);
+  if (!tables.ok) return jsonResponse(tables.body, tables.status);
+
+  try {
+    const url = new URL(request.url);
+    const limitRaw = Number(url.searchParams.get("limit") || "50");
+    const limit = Number.isFinite(limitRaw) ? Math.min(Math.max(limitRaw, 1), 200) : 50;
+
+    const rows = await d1.db
+      .prepare(
+        `SELECT id, week_start, photo_a_id, photo_b_id, status, created_at
+         FROM weekly_matchups
+         ORDER BY week_start DESC, id DESC
+         LIMIT ?`,
+      )
+      .bind(limit)
+      .all();
+
+    const matchups = rows?.results || [];
+    const items = [];
+
+    for (const row of matchups) {
+      const week_start = String((row as any).week_start || "");
+      const totalsRow = await d1.db
+        .prepare(
+          `SELECT SUM(CASE WHEN choice='a' THEN 1 ELSE 0 END) AS a,
+                  SUM(CASE WHEN choice='b' THEN 1 ELSE 0 END) AS b
+           FROM weekly_votes
+           WHERE week_start = ?`,
+        )
+        .bind(week_start)
+        .first();
+
+      const a = Number((totalsRow as any)?.a || 0);
+      const b = Number((totalsRow as any)?.b || 0);
+      const winner = a === b ? "tie" : a > b ? "a" : "b";
+
+      items.push({
+        id: Number((row as any).id),
+        week_start,
+        photo_a_id: Number((row as any).photo_a_id),
+        photo_b_id: Number((row as any).photo_b_id),
+        status: String((row as any).status || ""),
+        created_at: String((row as any).created_at || ""),
+        votes: { a, b, total: a + b, winner },
+      });
+    }
+
+    const active = items.find((item) => item.status === "active") || null;
+
+    return jsonResponse({ ok: true, active, items }, 200);
+  } catch (err: any) {
+    console.error("admin matchup list error:", err);
+    return jsonResponse({ ok: false, error: "Failed to list matchups." }, 500);
+  }
+};
+
+export function isValidWeekStart(value: string): boolean {
+  return DATE_RE.test(value);
+}

--- a/functions/api/admin/matchup/list.ts
+++ b/functions/api/admin/matchup/list.ts
@@ -25,45 +25,41 @@ export const onRequestGet = async (context: any): Promise<Response> => {
 
     const rows = await d1.db
       .prepare(
-        `SELECT id, week_start, photo_a_id, photo_b_id, status, created_at
-         FROM weekly_matchups
-         ORDER BY week_start DESC, id DESC
+        `SELECT
+           m.id,
+           m.week_start,
+           m.photo_a_id,
+           m.photo_b_id,
+           m.status,
+           m.created_at,
+           COALESCE(SUM(CASE WHEN v.choice = 'a' THEN 1 ELSE 0 END), 0) AS a,
+           COALESCE(SUM(CASE WHEN v.choice = 'b' THEN 1 ELSE 0 END), 0) AS b
+         FROM weekly_matchups m
+         LEFT JOIN weekly_votes v ON v.week_start = m.week_start
+         GROUP BY m.id
+         ORDER BY m.week_start DESC, m.id DESC
          LIMIT ?`,
       )
       .bind(limit)
       .all();
 
-    const matchups = rows?.results || [];
-    const items = [];
+    const items = (rows?.results || []).map((row: any) => {
+      const a = Number(row.a || 0);
+      const b = Number(row.b || 0);
+      const winner = a === b ? 'tie' : a > b ? 'a' : 'b';
 
-    for (const row of matchups) {
-      const week_start = String((row as any).week_start || "");
-      const totalsRow = await d1.db
-        .prepare(
-          `SELECT SUM(CASE WHEN choice='a' THEN 1 ELSE 0 END) AS a,
-                  SUM(CASE WHEN choice='b' THEN 1 ELSE 0 END) AS b
-           FROM weekly_votes
-           WHERE week_start = ?`,
-        )
-        .bind(week_start)
-        .first();
-
-      const a = Number((totalsRow as any)?.a || 0);
-      const b = Number((totalsRow as any)?.b || 0);
-      const winner = a === b ? "tie" : a > b ? "a" : "b";
-
-      items.push({
-        id: Number((row as any).id),
-        week_start,
-        photo_a_id: Number((row as any).photo_a_id),
-        photo_b_id: Number((row as any).photo_b_id),
-        status: String((row as any).status || ""),
-        created_at: String((row as any).created_at || ""),
+      return {
+        id: Number(row.id),
+        week_start: String(row.week_start || ''),
+        photo_a_id: Number(row.photo_a_id),
+        photo_b_id: Number(row.photo_b_id),
+        status: String(row.status || ''),
+        created_at: String(row.created_at || ''),
         votes: { a, b, total: a + b, winner },
-      });
-    }
+      };
+    });
 
-    const active = items.find((item) => item.status === "active") || null;
+    const active = items.find((item: { status: string }) => item.status === "active") || null;
 
     return jsonResponse({ ok: true, active, items }, 200);
   } catch (err: any) {
@@ -73,5 +69,17 @@ export const onRequestGet = async (context: any): Promise<Response> => {
 };
 
 export function isValidWeekStart(value: string): boolean {
-  return DATE_RE.test(value);
+  if (!DATE_RE.test(value)) return false;
+
+  const [year, month, day] = value.split('-').map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    return false;
+  }
+
+  return parsed.getUTCDay() === 1;
 }

--- a/functions/api/admin/matchup/update.ts
+++ b/functions/api/admin/matchup/update.ts
@@ -1,0 +1,83 @@
+// POST /api/admin/matchup/update
+// Admin-only. Updates matchup photos or status.
+//
+// Body: { id, photo_a_id?, photo_b_id?, status? }
+
+import { requireAdmin } from "../../../_lib/auth";
+import { requireD1, requireTables, jsonResponse } from "../../../_lib/d1";
+
+const STATUS_VALUES = new Set(["active", "closed"]);
+
+export const onRequestPost = async (context: any): Promise<Response> => {
+  const { request, env } = context;
+
+  const deny = requireAdmin(request, env);
+  if (deny) return deny;
+
+  const d1 = requireD1(env);
+  if (!d1.ok) return jsonResponse(d1.body, d1.status);
+
+  const tables = await requireTables(d1.db, ["weekly_matchups"]);
+  if (!tables.ok) return jsonResponse(tables.body, tables.status);
+
+  try {
+    const body = await request.json().catch(() => null);
+    const id = Number(body?.id);
+    const photo_a_id = body?.photo_a_id === undefined ? null : Number(body.photo_a_id);
+    const photo_b_id = body?.photo_b_id === undefined ? null : Number(body.photo_b_id);
+    const statusRaw = body?.status === undefined ? null : String(body.status).trim().toLowerCase();
+
+    if (!Number.isFinite(id) || id <= 0) {
+      return jsonResponse({ ok: false, error: "invalid_id" }, 400);
+    }
+
+    const existing = await d1.db
+      .prepare("SELECT id, photo_a_id, photo_b_id, status FROM weekly_matchups WHERE id = ?")
+      .bind(id)
+      .first();
+
+    if (!existing) {
+      return jsonResponse({ ok: false, error: "matchup_not_found" }, 404);
+    }
+
+    const nextPhotoA = photo_a_id === null ? Number((existing as any).photo_a_id) : photo_a_id;
+    const nextPhotoB = photo_b_id === null ? Number((existing as any).photo_b_id) : photo_b_id;
+    const nextStatus =
+      statusRaw === null
+        ? String((existing as any).status || "closed")
+        : STATUS_VALUES.has(statusRaw)
+          ? statusRaw
+          : null;
+
+    if (nextStatus === null) {
+      return jsonResponse({ ok: false, error: "invalid_status" }, 400);
+    }
+    if (!Number.isFinite(nextPhotoA) || nextPhotoA <= 0 || !Number.isFinite(nextPhotoB) || nextPhotoB <= 0) {
+      return jsonResponse({ ok: false, error: "invalid_photo_ids" }, 400);
+    }
+    if (nextPhotoA === nextPhotoB) {
+      return jsonResponse({ ok: false, error: "photo_ids_must_differ" }, 400);
+    }
+
+    if (nextStatus === "active") {
+      await d1.db
+        .prepare("UPDATE weekly_matchups SET status='closed' WHERE status='active' AND id != ?")
+        .bind(id)
+        .run();
+    }
+
+    const out = await d1.db
+      .prepare(
+        `UPDATE weekly_matchups
+         SET photo_a_id=?, photo_b_id=?, status=?
+         WHERE id=?`,
+      )
+      .bind(nextPhotoA, nextPhotoB, nextStatus, id)
+      .run();
+
+    return jsonResponse({ ok: true, changed: out?.meta?.changes || 0 }, 200);
+  } catch (err: any) {
+    console.error("admin matchup update error:", err);
+    return jsonResponse({ ok: false, error: "server_error", detail: String(err?.message || err) }, 500);
+  }
+};

--- a/functions/api/admin/matchup/update.ts
+++ b/functions/api/admin/matchup/update.ts
@@ -60,10 +60,21 @@ export const onRequestPost = async (context: any): Promise<Response> => {
     }
 
     if (nextStatus === "active") {
-      await d1.db
-        .prepare("UPDATE weekly_matchups SET status='closed' WHERE status='active' AND id != ?")
-        .bind(id)
-        .run();
+      const batchResults = await d1.db.batch([
+        d1.db
+          .prepare("UPDATE weekly_matchups SET status='closed' WHERE status='active' AND id != ?")
+          .bind(id),
+        d1.db
+          .prepare(
+            `UPDATE weekly_matchups
+             SET photo_a_id=?, photo_b_id=?, status=?
+             WHERE id=?`,
+          )
+          .bind(nextPhotoA, nextPhotoB, nextStatus, id),
+      ]);
+
+      const changed = batchResults?.[1]?.meta?.changes || 0;
+      return jsonResponse({ ok: true, changed }, 200);
     }
 
     const out = await d1.db

--- a/src/app/admin/matchup/page.tsx
+++ b/src/app/admin/matchup/page.tsx
@@ -157,8 +157,15 @@ export default function AdminMatchupPage() {
     const photo_a_id = Number(draft.photo_a_id);
     const photo_b_id = Number(draft.photo_b_id);
 
-    if (!week_start || !Number.isFinite(photo_a_id) || !Number.isFinite(photo_b_id)) {
-      setStatus('Create blocked. Week start and both photo IDs are required.');
+    if (
+      !week_start ||
+      !Number.isFinite(photo_a_id) ||
+      photo_a_id <= 0 ||
+      !Number.isFinite(photo_b_id) ||
+      photo_b_id <= 0 ||
+      photo_a_id === photo_b_id
+    ) {
+      setStatus('Create blocked. Week start and two distinct positive photo IDs are required.');
       return;
     }
 

--- a/src/app/admin/matchup/page.tsx
+++ b/src/app/admin/matchup/page.tsx
@@ -1,0 +1,405 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import PageShell from '@/components/PageShell';
+import AdminNav from '@/components/admin/AdminNav';
+import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
+import { adminJson } from '@/lib/adminClient';
+
+type MatchupRecord = {
+  id: number;
+  week_start: string;
+  photo_a_id: number;
+  photo_b_id: number;
+  status: string;
+  created_at: string;
+  votes: { a: number; b: number; total: number; winner: string };
+};
+
+type MatchupListResponse = {
+  ok: true;
+  active: MatchupRecord | null;
+  items: MatchupRecord[];
+};
+
+type PublicCurrentResponse = {
+  ok: boolean;
+  week_start?: string | null;
+  matchup_id?: number | null;
+  items?: Array<{ id: number; url: string; title?: string; description?: string }>;
+  error?: string;
+};
+
+type PublicResultsResponse = {
+  ok: boolean;
+  week_start?: string | null;
+  totals?: { a: number; b: number };
+  last_week?: { week_start: string; totals: { a: number; b: number }; winner: string } | null;
+  error?: string;
+};
+
+type MatchupDraft = {
+  week_start: string;
+  photo_a_id: string;
+  photo_b_id: string;
+  activate_on_create: boolean;
+};
+
+const EMPTY_DRAFT: MatchupDraft = {
+  week_start: '',
+  photo_a_id: '',
+  photo_b_id: '',
+  activate_on_create: false,
+};
+
+function fieldStyle(): React.CSSProperties {
+  return {
+    padding: '10px 12px',
+    borderRadius: 10,
+    border: '1px solid rgba(0,0,0,0.16)',
+    width: '100%',
+  };
+}
+
+function buttonStyle(disabled = false): React.CSSProperties {
+  return {
+    padding: '10px 12px',
+    borderRadius: 10,
+    border: '1px solid rgba(0,0,0,0.18)',
+    background: disabled ? 'rgba(0,0,0,0.05)' : 'white',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    fontWeight: 700,
+  };
+}
+
+function mondayForDate(date = new Date()): string {
+  const utc = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = utc.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  utc.setUTCDate(utc.getUTCDate() + diff);
+  const y = utc.getUTCFullYear();
+  const m = String(utc.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(utc.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export default function AdminMatchupPage() {
+  const [status, setStatus] = useState('Idle.');
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const [items, setItems] = useState<MatchupRecord[]>([]);
+  const [active, setActive] = useState<MatchupRecord | null>(null);
+  const [draft, setDraft] = useState<MatchupDraft>({ ...EMPTY_DRAFT, week_start: mondayForDate() });
+  const [publicCurrent, setPublicCurrent] = useState<PublicCurrentResponse | null>(null);
+  const [publicResults, setPublicResults] = useState<PublicResultsResponse | null>(null);
+  const [previewWeek, setPreviewWeek] = useState('');
+
+  const selected = useMemo(
+    () => items.find((item) => item.week_start === previewWeek) ?? active ?? items[0] ?? null,
+    [active, items, previewWeek],
+  );
+
+  const loadPublicPreview = useCallback(async (weekStart?: string) => {
+    try {
+      const currentRes = await fetch('/api/matchup/current', { cache: 'no-store' });
+      const currentData = (await currentRes.json().catch(() => ({}))) as PublicCurrentResponse;
+      setPublicCurrent(currentData?.ok ? currentData : { ok: false, error: currentData?.error || `HTTP ${currentRes.status}` });
+
+      const week = weekStart || currentData?.week_start || '';
+      if (!week) {
+        setPublicResults({ ok: true, week_start: null, totals: { a: 0, b: 0 }, last_week: null });
+        return;
+      }
+
+      const resultsRes = await fetch(`/api/matchup/results?week_start=${encodeURIComponent(week)}`, {
+        cache: 'no-store',
+      });
+      const resultsData = (await resultsRes.json().catch(() => ({}))) as PublicResultsResponse;
+      setPublicResults(
+        resultsData?.ok
+          ? resultsData
+          : { ok: false, error: resultsData?.error || `HTTP ${resultsRes.status}` },
+      );
+    } catch {
+      setPublicCurrent({ ok: false, error: 'Request failed.' });
+      setPublicResults({ ok: false, error: 'Request failed.' });
+    }
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setStatus('Loading weekly matchups…');
+
+    const result = await adminJson<MatchupListResponse>('/api/admin/matchup/list?limit=50');
+
+    if (!result.ok) {
+      setItems([]);
+      setActive(null);
+      setStatus(`Error: ${result.error}`);
+      setLoading(false);
+      return;
+    }
+
+    const nextItems = Array.isArray(result.data?.items) ? result.data.items : [];
+    const nextActive = result.data?.active ?? nextItems.find((item) => item.status === 'active') ?? null;
+    setItems(nextItems);
+    setActive(nextActive);
+    setPreviewWeek(nextActive?.week_start || nextItems[0]?.week_start || '');
+    setStatus(nextItems.length ? `Loaded ${nextItems.length} matchup record(s).` : 'No matchup records found.');
+    setLoading(false);
+
+    await loadPublicPreview(nextActive?.week_start || nextItems[0]?.week_start);
+  }, [loadPublicPreview]);
+
+  const createMatchup = useCallback(async () => {
+    const week_start = draft.week_start.trim();
+    const photo_a_id = Number(draft.photo_a_id);
+    const photo_b_id = Number(draft.photo_b_id);
+
+    if (!week_start || !Number.isFinite(photo_a_id) || !Number.isFinite(photo_b_id)) {
+      setStatus('Create blocked. Week start and both photo IDs are required.');
+      return;
+    }
+
+    setSaving(true);
+    setStatus('Creating matchup…');
+
+    const result = await adminJson<{ ok: true; id: number | null }>('/api/admin/matchup/create', {
+      method: 'POST',
+      body: JSON.stringify({
+        week_start,
+        photo_a_id,
+        photo_b_id,
+        status: draft.activate_on_create ? 'active' : 'closed',
+      }),
+    });
+
+    if (!result.ok) {
+      setStatus(`Create error: ${result.error}`);
+      setSaving(false);
+      return;
+    }
+
+    setSaving(false);
+    await load();
+    setStatus(`Matchup created${result.data?.id ? ` (#${result.data.id})` : ''}.`);
+  }, [draft, load]);
+
+  const activateMatchup = useCallback(
+    async (record: MatchupRecord) => {
+      setStatus(`Activating matchup ${record.id}…`);
+
+      const result = await adminJson<{ ok: true; changed: number }>('/api/admin/matchup/update', {
+        method: 'POST',
+        body: JSON.stringify({ id: record.id, status: 'active' }),
+      });
+
+      if (!result.ok) {
+        setStatus(`Activate error: ${result.error}`);
+        return;
+      }
+
+      await load();
+      setStatus(`Matchup ${record.id} is now active.`);
+    },
+    [load],
+  );
+
+  const closeActiveMatchup = useCallback(async () => {
+    setClosing(true);
+    setStatus('Closing active matchup…');
+
+    const result = await adminJson<{ ok: true; changed: number; closed_id?: number; note?: string }>(
+      '/api/admin/matchup/close-active',
+      { method: 'POST' },
+    );
+
+    if (!result.ok) {
+      setStatus(`Close error: ${result.error}`);
+      setClosing(false);
+      return;
+    }
+
+    setClosing(false);
+    await load();
+    setStatus(
+      result.data?.note ||
+        `Closed active matchup${result.data?.closed_id ? ` (#${result.data.closed_id})` : ''}.`,
+    );
+  }, [load]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (previewWeek) {
+      void loadPublicPreview(previewWeek);
+    }
+  }, [loadPublicPreview, previewWeek]);
+
+  return (
+    <PageShell
+      title="Weekly Matchup"
+      subtitle="Review active matchup state, vote totals, and rotation controls without changing public voting contracts."
+    >
+      <AdminNav />
+      <AdminTokenPanel onSaved={() => void load()} />
+
+      <div style={{ display: 'grid', gap: 18, marginTop: 16 }}>
+        <section style={{ border: '1px solid rgba(0,0,0,0.12)', borderRadius: 14, padding: 14 }}>
+          <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'center' }}>
+            <button type="button" onClick={() => void load()} disabled={loading} style={buttonStyle(loading)}>
+              {loading ? 'Loading…' : 'Refresh'}
+            </button>
+            <button type="button" onClick={() => void closeActiveMatchup()} disabled={closing} style={buttonStyle(closing)}>
+              {closing ? 'Closing…' : 'Close active matchup'}
+            </button>
+            <span style={{ opacity: 0.85 }}>{status}</span>
+          </div>
+
+          {active ? (
+            <p style={{ marginTop: 12, marginBottom: 0, color: '#184d12', fontWeight: 700 }}>
+              Active matchup: week {active.week_start} (photos {active.photo_a_id} vs {active.photo_b_id}) — votes{' '}
+              {active.votes.a}/{active.votes.b} (winner: {active.votes.winner})
+            </p>
+          ) : (
+            <p style={{ marginTop: 12, marginBottom: 0, color: '#7a4b00', fontWeight: 700 }}>
+              No active matchup in D1. Public `/api/matchup/current` may fall back to photo list behavior.
+            </p>
+          )}
+        </section>
+
+        <section style={{ border: '1px solid rgba(0,0,0,0.12)', borderRadius: 14, padding: 14 }}>
+          <h2 style={{ marginTop: 0 }}>Create matchup</h2>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10 }}>
+            <label style={{ display: 'grid', gap: 6 }}>
+              Week start (Monday, YYYY-MM-DD)
+              <input
+                value={draft.week_start}
+                onChange={(e) => setDraft((prev) => ({ ...prev, week_start: e.target.value }))}
+                style={fieldStyle()}
+              />
+            </label>
+            <label style={{ display: 'grid', gap: 6 }}>
+              Photo A ID
+              <input
+                type="number"
+                value={draft.photo_a_id}
+                onChange={(e) => setDraft((prev) => ({ ...prev, photo_a_id: e.target.value }))}
+                style={fieldStyle()}
+              />
+            </label>
+            <label style={{ display: 'grid', gap: 6 }}>
+              Photo B ID
+              <input
+                type="number"
+                value={draft.photo_b_id}
+                onChange={(e) => setDraft((prev) => ({ ...prev, photo_b_id: e.target.value }))}
+                style={fieldStyle()}
+              />
+            </label>
+          </div>
+
+          <label style={{ display: 'flex', gap: 10, alignItems: 'center', marginTop: 12, fontWeight: 700 }}>
+            <input
+              type="checkbox"
+              checked={draft.activate_on_create}
+              onChange={(e) => setDraft((prev) => ({ ...prev, activate_on_create: e.target.checked }))}
+            />
+            Activate immediately (closes any other active matchup)
+          </label>
+
+          <button
+            type="button"
+            onClick={() => void createMatchup()}
+            disabled={saving}
+            style={{ ...buttonStyle(saving), marginTop: 12 }}
+          >
+            {saving ? 'Creating…' : 'Create matchup'}
+          </button>
+        </section>
+
+        <section style={{ border: '1px solid rgba(0,0,0,0.12)', borderRadius: 14, padding: 14 }}>
+          <h2 style={{ marginTop: 0 }}>Matchup inventory</h2>
+          {items.length === 0 ? (
+            <p>No matchup records found.</p>
+          ) : (
+            <div style={{ display: 'grid', gap: 12 }}>
+              {items.map((record) => (
+                <article key={record.id} style={{ border: '1px solid rgba(0,0,0,0.1)', borderRadius: 12, padding: 12 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, flexWrap: 'wrap' }}>
+                    <div>
+                      <h3 style={{ margin: 0 }}>
+                        Week {record.week_start} — {record.status}
+                      </h3>
+                      <div style={{ opacity: 0.75, fontSize: 13 }}>
+                        id {record.id} · photos {record.photo_a_id} vs {record.photo_b_id} · votes {record.votes.a}/
+                        {record.votes.b} ({record.votes.winner})
+                      </div>
+                    </div>
+                    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                      <button type="button" onClick={() => setPreviewWeek(record.week_start)} style={buttonStyle()}>
+                        Preview week
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void activateMatchup(record)}
+                        disabled={record.status === 'active'}
+                        style={buttonStyle(record.status === 'active')}
+                      >
+                        Activate
+                      </button>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section style={{ border: '1px solid rgba(0,0,0,0.12)', borderRadius: 14, padding: 14 }}>
+          <h2 style={{ marginTop: 0 }}>Public read-path preview</h2>
+          <p style={{ opacity: 0.85 }}>
+            These calls use the same public contracts as the homepage Weekly Matchup component. Missing or invalid active
+            matchup data fails closed to safe empty/fallback behavior.
+          </p>
+
+          <div style={{ display: 'grid', gap: 10, marginTop: 10 }}>
+            <div>
+              <strong>/api/matchup/current</strong>
+              {publicCurrent?.ok ? (
+                <div style={{ marginTop: 6 }}>
+                  week_start: {publicCurrent.week_start || '(none)'} · items: {publicCurrent.items?.length ?? 0}
+                  {publicCurrent.matchup_id ? ` · matchup_id: ${publicCurrent.matchup_id}` : ''}
+                </div>
+              ) : (
+                <div style={{ marginTop: 6, color: '#7a4b00' }}>
+                  unavailable: {publicCurrent?.error || 'missing matchup content'}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <strong>/api/matchup/results</strong>
+              {selected ? <span> (week {selected.week_start})</span> : null}
+              {publicResults?.ok ? (
+                <div style={{ marginTop: 6 }}>
+                  totals: {publicResults.totals?.a ?? 0}/{publicResults.totals?.b ?? 0}
+                  {publicResults.last_week
+                    ? ` · last closed week ${publicResults.last_week.week_start} winner ${publicResults.last_week.winner}`
+                    : ''}
+                </div>
+              ) : (
+                <div style={{ marginTop: 6, color: '#7a4b00' }}>
+                  unavailable: {publicResults?.error || 'results not available'}
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/admin/matchup/page.tsx
+++ b/src/app/admin/matchup/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PageShell from '@/components/PageShell';
 import AdminNav from '@/components/admin/AdminNav';
 import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
@@ -94,6 +94,7 @@ export default function AdminMatchupPage() {
   const [publicCurrent, setPublicCurrent] = useState<PublicCurrentResponse | null>(null);
   const [publicResults, setPublicResults] = useState<PublicResultsResponse | null>(null);
   const [previewWeek, setPreviewWeek] = useState('');
+  const previewRequestRef = useRef(0);
 
   const selected = useMemo(
     () => items.find((item) => item.week_start === previewWeek) ?? active ?? items[0] ?? null,
@@ -101,9 +102,13 @@ export default function AdminMatchupPage() {
   );
 
   const loadPublicPreview = useCallback(async (weekStart?: string) => {
+    const requestId = ++previewRequestRef.current;
+
     try {
       const currentRes = await fetch('/api/matchup/current', { cache: 'no-store' });
       const currentData = (await currentRes.json().catch(() => ({}))) as PublicCurrentResponse;
+      if (requestId !== previewRequestRef.current) return;
+
       setPublicCurrent(currentData?.ok ? currentData : { ok: false, error: currentData?.error || `HTTP ${currentRes.status}` });
 
       const week = weekStart || currentData?.week_start || '';
@@ -116,12 +121,15 @@ export default function AdminMatchupPage() {
         cache: 'no-store',
       });
       const resultsData = (await resultsRes.json().catch(() => ({}))) as PublicResultsResponse;
+      if (requestId !== previewRequestRef.current) return;
+
       setPublicResults(
         resultsData?.ok
           ? resultsData
           : { ok: false, error: resultsData?.error || `HTTP ${resultsRes.status}` },
       );
     } catch {
+      if (requestId !== previewRequestRef.current) return;
       setPublicCurrent({ ok: false, error: 'Request failed.' });
       setPublicResults({ ok: false, error: 'Request failed.' });
     }

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -104,6 +104,11 @@ export default function AdminDashboard() {
           <div className={styles.cardBody}>Create, update, and seed events for the public calendar.</div>
         </a>
 
+        <a className={styles.card} href="/admin/matchup">
+          <div className={styles.cardTitle}>Weekly Matchup</div>
+          <div className={styles.cardBody}>Activate, close, and review weekly photo matchup vote totals.</div>
+        </a>
+
         <a className={styles.card} href="/admin/fundraiser-preview">
           <div className={styles.cardTitle}>Fundraiser Preview</div>
           <div className={styles.cardBody}>Build and validate the conditional homepage campaign spotlight in the gated admin area.</div>

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -12,6 +12,7 @@ const items: Array<{ href: string; label: string }> = [
   { href: '/admin/cms', label: 'CMS Blocks' },
   { href: '/admin/editorial', label: 'Editorial Archive' },
   { href: '/admin/events', label: 'Events' },
+  { href: '/admin/matchup', label: 'Matchup' },
   { href: '/admin/fundraiser-preview', label: 'Fundraiser Preview' },
   { href: '/admin/join-requests', label: 'Join Requests' },
   { href: '/admin/worklist', label: 'Worklist' },

--- a/tests/admin-matchup.test.tsx
+++ b/tests/admin-matchup.test.tsx
@@ -100,7 +100,7 @@ function makeMatchupDb(matchups: Array<Record<string, unknown>> = [], votes: Rec
       bind: (...args: unknown[]) => ({
         all: async () => {
           if (sql.includes('sqlite_master')) {
-            return { results: [{ name: 'weekly_matchups' }, { name: 'weekly_votes' }] };
+            return { results: [{ name: 'weekly_matchups' }, { name: 'weekly_votes' }, { name: 'photos' }] };
           }
           if (sql.includes('LEFT JOIN weekly_votes')) {
             const limit = Number(args[0] ?? 50);
@@ -133,6 +133,10 @@ function makeMatchupDb(matchups: Array<Record<string, unknown>> = [], votes: Rec
           if (sql.includes('FROM weekly_matchups WHERE id')) {
             return matchups.find((row) => Number(row.id) === Number(args[0])) ?? null;
           }
+          if (sql.includes('FROM photos WHERE id')) {
+            const id = Number(args[0]);
+            return Number.isFinite(id) && id > 0 ? { id } : null;
+          }
           return null;
         },
         run: makeRun(sql, args),
@@ -140,6 +144,13 @@ function makeMatchupDb(matchups: Array<Record<string, unknown>> = [], votes: Rec
       first: async () => matchups.find((row) => row.status === 'active') ?? null,
       run: makeRun(sql),
     })),
+    batch: vi.fn(async (statements: Array<{ run: () => Promise<unknown> }>) => {
+      const results = [];
+      for (const statement of statements) {
+        results.push(await statement.run());
+      }
+      return results;
+    }),
   };
 
   return { db, matchups };
@@ -358,6 +369,35 @@ describe('admin matchup APIs', () => {
     });
 
     expect(duplicate.status).toBe(409);
+  });
+
+  it('rejects invalid status values and missing photo ids', async () => {
+    const { db } = makeMatchupDb();
+
+    const invalidStatus = await matchupCreatePost({
+      request: adminPostRequest('/api/admin/matchup/create', {
+        week_start: '2026-06-15',
+        photo_a_id: 3,
+        photo_b_id: 4,
+        status: 'actve',
+      }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(invalidStatus.status).toBe(400);
+    await expect(invalidStatus.json()).resolves.toMatchObject({ ok: false, error: 'invalid_status' });
+
+    const missingPhoto = await matchupCreatePost({
+      request: adminPostRequest('/api/admin/matchup/create', {
+        week_start: '2026-06-15',
+        photo_a_id: 99999,
+        photo_b_id: 4,
+      }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(missingPhoto.status).toBe(400);
+    await expect(missingPhoto.json()).resolves.toMatchObject({ ok: false, error: 'photo_a_not_found' });
   });
 
   it('activates one matchup and closes others', async () => {

--- a/tests/admin-matchup.test.tsx
+++ b/tests/admin-matchup.test.tsx
@@ -135,7 +135,7 @@ function makeMatchupDb(matchups: Array<Record<string, unknown>> = [], votes: Rec
           }
           if (sql.includes('FROM photos WHERE id')) {
             const id = Number(args[0]);
-            return Number.isFinite(id) && id > 0 ? { id } : null;
+            return Number.isFinite(id) && id > 0 && id < 1000 ? { id } : null;
           }
           return null;
         },

--- a/tests/admin-matchup.test.tsx
+++ b/tests/admin-matchup.test.tsx
@@ -1,0 +1,428 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AdminMatchupPage from '@/app/admin/matchup/page';
+import { onRequestPost as matchupCloseActivePost } from '../functions/api/admin/matchup/close-active';
+import { onRequestPost as matchupCreatePost } from '../functions/api/admin/matchup/create';
+import { onRequestGet as matchupListGet } from '../functions/api/admin/matchup/list';
+import { onRequestPost as matchupUpdatePost } from '../functions/api/admin/matchup/update';
+import { onRequestGet as publicMatchupCurrentGet } from '../functions/api/matchup/current';
+import { onRequestGet as publicMatchupResultsGet } from '../functions/api/matchup/results';
+
+const mockUsePathname = vi.hoisted(() => vi.fn(() => '/admin/matchup'));
+
+vi.mock('next/navigation', () => ({
+  usePathname: mockUsePathname,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function adminGetRequest(path: string, token = 'secret'): Request {
+  return new Request(`https://www.lougehrigfanclub.com${path}`, {
+    headers: { 'x-admin-token': token },
+  });
+}
+
+function adminPostRequest(path: string, body: unknown = {}, token = 'secret'): Request {
+  return new Request(`https://www.lougehrigfanclub.com${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-admin-token': token },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeMatchupDb(matchups: Array<Record<string, unknown>> = [], votes: Record<string, { a: number; b: number }> = {}) {
+  const db = {
+    prepare: vi.fn((sql: string) => ({
+      bind: (...args: unknown[]) => ({
+        all: async () => {
+          if (sql.includes('sqlite_master')) {
+            return { results: [{ name: 'weekly_matchups' }, { name: 'weekly_votes' }] };
+          }
+          if (sql.includes('FROM weekly_matchups') && sql.includes('LIMIT')) {
+            return { results: matchups };
+          }
+          return { results: [] };
+        },
+        first: async () => {
+          if (sql.includes("status='active'") && sql.includes('LIMIT 1') && !sql.includes('UPDATE')) {
+            return matchups.find((row) => row.status === 'active') ?? null;
+          }
+          if (sql.includes('FROM weekly_votes') && sql.includes('week_start')) {
+            const week = String(args[0]);
+            const totals = votes[week] || { a: 0, b: 0 };
+            return { a: totals.a, b: totals.b };
+          }
+          if (sql.includes('FROM weekly_matchups WHERE id')) {
+            return matchups.find((row) => Number(row.id) === Number(args[0])) ?? null;
+          }
+          return null;
+        },
+        run: async () => {
+          if (sql.includes("SET status='closed' WHERE status='active'")) {
+            matchups.forEach((row) => {
+              if (row.status === 'active') row.status = 'closed';
+            });
+            return { meta: { changes: 1 } };
+          }
+          if (sql.includes('INSERT INTO weekly_matchups')) {
+            const week_start = String(args[0]);
+            if (matchups.some((row) => String(row.week_start) === week_start)) {
+              throw new Error('UNIQUE constraint failed: weekly_matchups.week_start');
+            }
+            const id = matchups.length + 1;
+            matchups.push({
+              id,
+              week_start,
+              photo_a_id: args[1],
+              photo_b_id: args[2],
+              status: args[3],
+              created_at: '2026-06-03T12:00:00Z',
+            });
+            return { meta: { last_row_id: id, changes: 1 } };
+          }
+          if (sql.includes('UPDATE weekly_matchups')) {
+            const target = matchups.find((row) => Number(row.id) === Number(args[3]));
+            if (target) {
+              target.photo_a_id = args[0];
+              target.photo_b_id = args[1];
+              target.status = args[2];
+            }
+            return { meta: { changes: 1 } };
+          }
+          return { meta: { changes: 0 } };
+        },
+      }),
+      first: async () => matchups.find((row) => row.status === 'active') ?? null,
+    })),
+  };
+
+  return { db, matchups };
+}
+
+describe('admin matchup page', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    window.localStorage.setItem('lgfc_admin_token', 'secret');
+    mockUsePathname.mockReturnValue('/admin/matchup');
+  });
+
+  it('renders admin navigation and loads matchup inventory', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const path = String(input);
+
+      if (path.startsWith('/api/admin/matchup/list')) {
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            active: {
+              id: 2,
+              week_start: '2026-06-02',
+              photo_a_id: 10,
+              photo_b_id: 11,
+              status: 'active',
+              created_at: '2026-06-02T12:00:00Z',
+              votes: { a: 3, b: 5, total: 8, winner: 'b' },
+            },
+            items: [
+              {
+                id: 2,
+                week_start: '2026-06-02',
+                photo_a_id: 10,
+                photo_b_id: 11,
+                status: 'active',
+                created_at: '2026-06-02T12:00:00Z',
+                votes: { a: 3, b: 5, total: 8, winner: 'b' },
+              },
+            ],
+          }),
+        );
+      }
+
+      if (path === '/api/matchup/current') {
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            week_start: '2026-06-02',
+            matchup_id: 2,
+            items: [
+              { id: 10, url: '/photos/10.jpg' },
+              { id: 11, url: '/photos/11.jpg' },
+            ],
+          }),
+        );
+      }
+
+      if (path.startsWith('/api/matchup/results')) {
+        return Promise.resolve(
+          jsonResponse({ ok: true, week_start: '2026-06-02', totals: { a: 3, b: 5 }, last_week: null }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${path}`));
+    });
+
+    render(<AdminMatchupPage />);
+
+    expect(screen.getByRole('link', { name: 'Matchup' })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Active matchup: week 2026-06-02/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows fail-closed public preview when current matchup is unavailable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const path = String(input);
+
+      if (path.startsWith('/api/admin/matchup/list')) {
+        return Promise.resolve(jsonResponse({ ok: true, active: null, items: [] }));
+      }
+
+      if (path === '/api/matchup/current') {
+        return Promise.resolve(jsonResponse({ ok: true, week_start: null, items: [] }));
+      }
+
+      if (path.startsWith('/api/matchup/results')) {
+        return Promise.resolve(
+          jsonResponse({ ok: true, week_start: null, totals: { a: 0, b: 0 }, last_week: null }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${path}`));
+    });
+
+    render(<AdminMatchupPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No active matchup in D1/i)).toBeInTheDocument();
+    });
+  });
+
+  it('creates a matchup through the admin create API', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const path = String(input);
+
+      if (path.startsWith('/api/admin/matchup/list')) {
+        return Promise.resolve(jsonResponse({ ok: true, active: null, items: [] }));
+      }
+
+      if (path === '/api/admin/matchup/create') {
+        expect(init?.method).toBe('POST');
+        const body = JSON.parse(String(init?.body));
+        expect(body.week_start).toBe('2026-06-09');
+        expect(body.photo_a_id).toBe(21);
+        expect(body.photo_b_id).toBe(22);
+        return Promise.resolve(jsonResponse({ ok: true, id: 9 }));
+      }
+
+      if (path === '/api/matchup/current') {
+        return Promise.resolve(jsonResponse({ ok: true, week_start: null, items: [] }));
+      }
+
+      if (path.startsWith('/api/matchup/results')) {
+        return Promise.resolve(
+          jsonResponse({ ok: true, week_start: null, totals: { a: 0, b: 0 }, last_week: null }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${path}`));
+    });
+
+    render(<AdminMatchupPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No matchup records found/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/Week start/i), { target: { value: '2026-06-09' } });
+    fireEvent.change(screen.getByLabelText('Photo A ID'), { target: { value: '21' } });
+    fireEvent.change(screen.getByLabelText('Photo B ID'), { target: { value: '22' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create matchup' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Matchup created/i)).toBeInTheDocument();
+    });
+
+    expect(fetchMock.mock.calls.some(([path]) => path === '/api/admin/matchup/create')).toBe(true);
+  });
+});
+
+describe('admin matchup APIs', () => {
+  it('rejects unauthenticated list requests', async () => {
+    const { db } = makeMatchupDb();
+    const response = await matchupListGet({
+      request: adminGetRequest('/api/admin/matchup/list', ''),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns active matchup and vote totals', async () => {
+    const { db } = makeMatchupDb(
+      [
+        {
+          id: 1,
+          week_start: '2026-06-02',
+          photo_a_id: 10,
+          photo_b_id: 11,
+          status: 'active',
+          created_at: '2026-06-02T12:00:00Z',
+        },
+      ],
+      { '2026-06-02': { a: 4, b: 2 } },
+    );
+
+    const response = await matchupListGet({
+      request: adminGetRequest('/api/admin/matchup/list'),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      active: { week_start: '2026-06-02', votes: { a: 4, b: 2, winner: 'a' } },
+    });
+  });
+
+  it('creates matchup rows and enforces unique week_start', async () => {
+    const { db, matchups } = makeMatchupDb();
+
+    const createResponse = await matchupCreatePost({
+      request: adminPostRequest('/api/admin/matchup/create', {
+        week_start: '2026-06-09',
+        photo_a_id: 3,
+        photo_b_id: 4,
+        status: 'closed',
+      }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(createResponse.status).toBe(200);
+    expect(matchups).toHaveLength(1);
+
+    const duplicate = await matchupCreatePost({
+      request: adminPostRequest('/api/admin/matchup/create', {
+        week_start: '2026-06-09',
+        photo_a_id: 5,
+        photo_b_id: 6,
+      }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(duplicate.status).toBe(409);
+  });
+
+  it('activates one matchup and closes others', async () => {
+    const { db, matchups } = makeMatchupDb([
+      {
+        id: 1,
+        week_start: '2026-06-02',
+        photo_a_id: 10,
+        photo_b_id: 11,
+        status: 'active',
+        created_at: '2026-06-02T12:00:00Z',
+      },
+      {
+        id: 2,
+        week_start: '2026-06-09',
+        photo_a_id: 20,
+        photo_b_id: 21,
+        status: 'closed',
+        created_at: '2026-06-09T12:00:00Z',
+      },
+    ]);
+
+    const response = await matchupUpdatePost({
+      request: adminPostRequest('/api/admin/matchup/update', { id: 2, status: 'active' }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    expect(matchups.find((row) => row.id === 1)?.status).toBe('closed');
+    expect(matchups.find((row) => row.id === 2)?.status).toBe('active');
+  });
+
+  it('closes the active matchup for rotation', async () => {
+    const { db, matchups } = makeMatchupDb([
+      {
+        id: 3,
+        week_start: '2026-06-02',
+        photo_a_id: 10,
+        photo_b_id: 11,
+        status: 'active',
+        created_at: '2026-06-02T12:00:00Z',
+      },
+    ]);
+
+    const response = await matchupCloseActivePost({
+      request: adminPostRequest('/api/admin/matchup/close-active'),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    expect(matchups[0].status).toBe('closed');
+  });
+});
+
+describe('public matchup read paths', () => {
+  it('returns empty items when no active matchup photos resolve', async () => {
+    const db = {
+      prepare: vi.fn((sql: string) => ({
+        bind: () => ({
+          first: async () => null,
+          all: async () => ({ results: [] }),
+        }),
+        first: async () => {
+          if (sql.includes("date('now'")) return { week_start: '2026-06-02' };
+          return null;
+        },
+      })),
+    };
+
+    const request = new Request('https://www.lougehrigfanclub.com/api/matchup/current');
+    const response = await publicMatchupCurrentGet({ request, env: { DB: db } });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ ok: true, items: [] });
+  });
+
+  it('returns zero totals when results week_start is missing', async () => {
+    const db = {
+      prepare: vi.fn(() => ({
+        bind: () => ({
+          first: async () => null,
+        }),
+        first: async () => null,
+      })),
+    };
+
+    const response = await publicMatchupResultsGet({
+      request: new Request('https://www.lougehrigfanclub.com/api/matchup/results'),
+      env: { DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      week_start: null,
+      totals: { a: 0, b: 0 },
+    });
+  });
+});

--- a/tests/admin-matchup.test.tsx
+++ b/tests/admin-matchup.test.tsx
@@ -46,12 +46,75 @@ function adminPostRequest(path: string, body: unknown = {}, token = 'secret'): R
 }
 
 function makeMatchupDb(matchups: Array<Record<string, unknown>> = [], votes: Record<string, { a: number; b: number }> = {}) {
+  const makeRun = (sql: string, args: unknown[] = []) => async () => {
+    if (sql.includes("SET status='closed' WHERE status='active'") && sql.includes('AND id !=')) {
+      const keepId = Number(args[0]);
+      matchups.forEach((row) => {
+        if (row.status === 'active' && Number(row.id) !== keepId) {
+          row.status = 'closed';
+        }
+      });
+      return { meta: { changes: 1 } };
+    }
+    if (sql.includes("SET status='closed' WHERE status='active'")) {
+      matchups.forEach((row) => {
+        if (row.status === 'active') row.status = 'closed';
+      });
+      return { meta: { changes: 1 } };
+    }
+    if (sql.includes("SET status='active' WHERE id")) {
+      const target = matchups.find((row) => Number(row.id) === Number(args[0]));
+      if (target) target.status = 'active';
+      return { meta: { changes: 1 } };
+    }
+    if (sql.includes('INSERT INTO weekly_matchups')) {
+      const week_start = String(args[0]);
+      if (matchups.some((row) => String(row.week_start) === week_start)) {
+        throw new Error('UNIQUE constraint failed: weekly_matchups.week_start');
+      }
+      const id = matchups.length + 1;
+      matchups.push({
+        id,
+        week_start,
+        photo_a_id: args[1],
+        photo_b_id: args[2],
+        status: args[3],
+        created_at: '2026-06-03T12:00:00Z',
+      });
+      return { meta: { last_row_id: id, changes: 1 } };
+    }
+    if (sql.includes('UPDATE weekly_matchups')) {
+      const target = matchups.find((row) => Number(row.id) === Number(args[3]));
+      if (target) {
+        target.photo_a_id = args[0];
+        target.photo_b_id = args[1];
+        target.status = args[2];
+      }
+      return { meta: { changes: 1 } };
+    }
+    return { meta: { changes: 0 } };
+  };
+
   const db = {
     prepare: vi.fn((sql: string) => ({
       bind: (...args: unknown[]) => ({
         all: async () => {
           if (sql.includes('sqlite_master')) {
             return { results: [{ name: 'weekly_matchups' }, { name: 'weekly_votes' }] };
+          }
+          if (sql.includes('LEFT JOIN weekly_votes')) {
+            const limit = Number(args[0] ?? 50);
+            return {
+              results: matchups.slice(0, limit).map((row) => {
+                const week = String(row.week_start);
+                const totals = votes[week] || { a: 0, b: 0 };
+                return {
+                  ...row,
+                  a: totals.a,
+                  b: totals.b,
+                };
+              }),
+            };
           }
           if (sql.includes('FROM weekly_matchups') && sql.includes('LIMIT')) {
             return { results: matchups };
@@ -72,42 +135,10 @@ function makeMatchupDb(matchups: Array<Record<string, unknown>> = [], votes: Rec
           }
           return null;
         },
-        run: async () => {
-          if (sql.includes("SET status='closed' WHERE status='active'")) {
-            matchups.forEach((row) => {
-              if (row.status === 'active') row.status = 'closed';
-            });
-            return { meta: { changes: 1 } };
-          }
-          if (sql.includes('INSERT INTO weekly_matchups')) {
-            const week_start = String(args[0]);
-            if (matchups.some((row) => String(row.week_start) === week_start)) {
-              throw new Error('UNIQUE constraint failed: weekly_matchups.week_start');
-            }
-            const id = matchups.length + 1;
-            matchups.push({
-              id,
-              week_start,
-              photo_a_id: args[1],
-              photo_b_id: args[2],
-              status: args[3],
-              created_at: '2026-06-03T12:00:00Z',
-            });
-            return { meta: { last_row_id: id, changes: 1 } };
-          }
-          if (sql.includes('UPDATE weekly_matchups')) {
-            const target = matchups.find((row) => Number(row.id) === Number(args[3]));
-            if (target) {
-              target.photo_a_id = args[0];
-              target.photo_b_id = args[1];
-              target.status = args[2];
-            }
-            return { meta: { changes: 1 } };
-          }
-          return { meta: { changes: 0 } };
-        },
+        run: makeRun(sql, args),
       }),
       first: async () => matchups.find((row) => row.status === 'active') ?? null,
+      run: makeRun(sql),
     })),
   };
 
@@ -383,6 +414,14 @@ describe('admin matchup APIs', () => {
 
 describe('public matchup read paths', () => {
   it('returns empty items when no active matchup photos resolve', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+      if (url.includes('/api/photos/list') || url.includes('/api/photos/get')) {
+        return Promise.resolve(jsonResponse({ ok: true, items: [], item: null }));
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
     const db = {
       prepare: vi.fn((sql: string) => ({
         bind: () => ({

--- a/tests/admin-matchup.test.tsx
+++ b/tests/admin-matchup.test.tsx
@@ -163,21 +163,21 @@ describe('admin matchup page', () => {
             ok: true,
             active: {
               id: 2,
-              week_start: '2026-06-02',
+              week_start: '2026-06-01',
               photo_a_id: 10,
               photo_b_id: 11,
               status: 'active',
-              created_at: '2026-06-02T12:00:00Z',
+              created_at: '2026-06-01T12:00:00Z',
               votes: { a: 3, b: 5, total: 8, winner: 'b' },
             },
             items: [
               {
                 id: 2,
-                week_start: '2026-06-02',
+                week_start: '2026-06-01',
                 photo_a_id: 10,
                 photo_b_id: 11,
                 status: 'active',
-                created_at: '2026-06-02T12:00:00Z',
+                created_at: '2026-06-01T12:00:00Z',
                 votes: { a: 3, b: 5, total: 8, winner: 'b' },
               },
             ],
@@ -189,7 +189,7 @@ describe('admin matchup page', () => {
         return Promise.resolve(
           jsonResponse({
             ok: true,
-            week_start: '2026-06-02',
+            week_start: '2026-06-01',
             matchup_id: 2,
             items: [
               { id: 10, url: '/photos/10.jpg' },
@@ -201,7 +201,7 @@ describe('admin matchup page', () => {
 
       if (path.startsWith('/api/matchup/results')) {
         return Promise.resolve(
-          jsonResponse({ ok: true, week_start: '2026-06-02', totals: { a: 3, b: 5 }, last_week: null }),
+          jsonResponse({ ok: true, week_start: '2026-06-01', totals: { a: 3, b: 5 }, last_week: null }),
         );
       }
 
@@ -213,7 +213,7 @@ describe('admin matchup page', () => {
     expect(screen.getByRole('link', { name: 'Matchup' })).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(screen.getByText(/Active matchup: week 2026-06-02/i)).toBeInTheDocument();
+      expect(screen.getByText(/Active matchup: week 2026-06-01/i)).toBeInTheDocument();
     });
   });
 
@@ -256,7 +256,7 @@ describe('admin matchup page', () => {
       if (path === '/api/admin/matchup/create') {
         expect(init?.method).toBe('POST');
         const body = JSON.parse(String(init?.body));
-        expect(body.week_start).toBe('2026-06-09');
+        expect(body.week_start).toBe('2026-06-08');
         expect(body.photo_a_id).toBe(21);
         expect(body.photo_b_id).toBe(22);
         return Promise.resolve(jsonResponse({ ok: true, id: 9 }));
@@ -281,7 +281,7 @@ describe('admin matchup page', () => {
       expect(screen.getByText(/No matchup records found/i)).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByLabelText(/Week start/i), { target: { value: '2026-06-09' } });
+    fireEvent.change(screen.getByLabelText(/Week start/i), { target: { value: '2026-06-08' } });
     fireEvent.change(screen.getByLabelText('Photo A ID'), { target: { value: '21' } });
     fireEvent.change(screen.getByLabelText('Photo B ID'), { target: { value: '22' } });
     fireEvent.click(screen.getByRole('button', { name: 'Create matchup' }));
@@ -310,14 +310,14 @@ describe('admin matchup APIs', () => {
       [
         {
           id: 1,
-          week_start: '2026-06-02',
+          week_start: '2026-06-01',
           photo_a_id: 10,
           photo_b_id: 11,
           status: 'active',
-          created_at: '2026-06-02T12:00:00Z',
+          created_at: '2026-06-01T12:00:00Z',
         },
       ],
-      { '2026-06-02': { a: 4, b: 2 } },
+      { '2026-06-01': { a: 4, b: 2 } },
     );
 
     const response = await matchupListGet({
@@ -328,7 +328,7 @@ describe('admin matchup APIs', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       ok: true,
-      active: { week_start: '2026-06-02', votes: { a: 4, b: 2, winner: 'a' } },
+      active: { week_start: '2026-06-01', votes: { a: 4, b: 2, winner: 'a' } },
     });
   });
 
@@ -337,7 +337,7 @@ describe('admin matchup APIs', () => {
 
     const createResponse = await matchupCreatePost({
       request: adminPostRequest('/api/admin/matchup/create', {
-        week_start: '2026-06-09',
+        week_start: '2026-06-08',
         photo_a_id: 3,
         photo_b_id: 4,
         status: 'closed',
@@ -350,7 +350,7 @@ describe('admin matchup APIs', () => {
 
     const duplicate = await matchupCreatePost({
       request: adminPostRequest('/api/admin/matchup/create', {
-        week_start: '2026-06-09',
+        week_start: '2026-06-08',
         photo_a_id: 5,
         photo_b_id: 6,
       }),
@@ -364,19 +364,19 @@ describe('admin matchup APIs', () => {
     const { db, matchups } = makeMatchupDb([
       {
         id: 1,
-        week_start: '2026-06-02',
+        week_start: '2026-06-01',
         photo_a_id: 10,
         photo_b_id: 11,
         status: 'active',
-        created_at: '2026-06-02T12:00:00Z',
+        created_at: '2026-06-01T12:00:00Z',
       },
       {
         id: 2,
-        week_start: '2026-06-09',
+        week_start: '2026-06-08',
         photo_a_id: 20,
         photo_b_id: 21,
         status: 'closed',
-        created_at: '2026-06-09T12:00:00Z',
+        created_at: '2026-06-08T12:00:00Z',
       },
     ]);
 
@@ -394,11 +394,11 @@ describe('admin matchup APIs', () => {
     const { db, matchups } = makeMatchupDb([
       {
         id: 3,
-        week_start: '2026-06-02',
+        week_start: '2026-06-01',
         photo_a_id: 10,
         photo_b_id: 11,
         status: 'active',
-        created_at: '2026-06-02T12:00:00Z',
+        created_at: '2026-06-01T12:00:00Z',
       },
     ]);
 
@@ -429,7 +429,7 @@ describe('public matchup read paths', () => {
           all: async () => ({ results: [] }),
         }),
         first: async () => {
-          if (sql.includes("date('now'")) return { week_start: '2026-06-02' };
+          if (sql.includes("date('now'")) return { week_start: '2026-06-01' };
           return null;
         },
       })),


### PR DESCRIPTION
### PR Template

- **Issue:** #1126

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [ ] OR any ZIP file that was present in the repo root was deleted before any other change
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: Website implementation queue (T48)
- Task: Matchup administration
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: none (awaiting CI on c3b6d23)

## DOCUMENTATION SOURCE (MANDATORY)
- [x] LEGACY_FALLBACK

Source Files Used:
- `docs/reference/design/LGFC-Production-Design-and-Standards.md`
- `docs/reference/projects/admin-production-definition.md`
- `docs/ops/trackers/IMPLEMENTATION-WORKLIST_Master.md`
- `docs/ops/trackers/LGFC-WEBSITE-IMPLEMENTATION-QUEUE-NORMALIZATION.md`

## LABEL
- Intent label for this PR: feature

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical design reference: `/docs/reference/design/LGFC-Production-Design-and-Standards.md`
- Additional design/reference docs used for this PR:
  - `docs/reference/projects/admin-production-definition.md`
  - `docs/as-built/weekly-matchup-photo-url-normalization.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `functions/api/admin/matchup/list.ts`
- `functions/api/admin/matchup/create.ts`
- `functions/api/admin/matchup/update.ts`
- `functions/api/admin/matchup/close-active.ts`
- `src/app/admin/matchup/page.tsx`
- `src/components/admin/AdminNav.tsx`
- `src/components/admin/AdminDashboard.tsx`
- `tests/admin-matchup.test.tsx`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Public Weekly Matchup voting model and homepage placement unchanged

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## CHANGE SUMMARY
- Add admin matchup APIs: list with vote totals, create, update (activate), and close-active rotation.
- Add `/admin/matchup` operating page with inventory, rotation controls, and live public `/api/matchup/current` + `/api/matchup/results` preview.
- Wire AdminNav and AdminDashboard links for weekly matchup operations.
- Add admin and public read-path regression tests; public matchup handlers are not modified.
- Remediation (4df1b89): fix quality gate test mocks, insert-before-activate create flow, list vote totals JOIN, Monday week_start validation, and create-form ID validation.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `npm run typecheck` — PASS (4df1b89)
  - `npm test` — PENDING (CI; local nested-clone vitest setup path differs from CI checkout)
- Gate verification: remediation pushed; awaiting CI on 4df1b89
- Result summary: quality failure root cause was admin-matchup D1 mock missing `prepare().run()` and public photo fetch mock; reviewer gate required Copilot disposition lines in PR body.

## REVIEWER RESPONSE ACCOUNTING
- [x] Reviewed all reviewer comments.
- [x] Reviewed all bot comments.
- [x] Copilot disposition received: accepted actionable Copilot inline comments in 4df1b89.
- [ ] Codex disposition received or not applicable.
- [ ] Gemini disposition received or not applicable.
- [x] Cubic disposition received: accepted actionable Cubic inline comments in c3b6d23.

Reviewer items:
- review-comment:3348108900 — accepted — Replaced vote-total N+1 loop with JOIN aggregate in list.ts (4df1b89).
- review-comment:3348108903 — accepted — Activation updates now run in a single D1 batch in update.ts (c3b6d23).
- review-comment:3348108909 — accepted — Create inserts closed row first, then batch-activates only after successful insert (c3b6d23).
- review-comment:3348108914 — accepted — Unknown status values now return 400 invalid_status (c3b6d23).
- review-comment:3348108920 — accepted — Create validates both photo IDs exist in photos before insert (c3b6d23).
- review-comment:3348108925 — accepted — Public preview fetch uses request-id guard to ignore stale responses (c3b6d23).
- review-comment:3348057697 — accepted — Replaced per-row vote SUM loop with a single LEFT JOIN aggregate query in `list.ts`.
- review-comment:3348057734 — accepted — `isValidWeekStart()` now validates real calendar dates and requires UTC Monday.
- review-comment:3348057762 — accepted — Admin create form now requires distinct positive photo IDs before calling the API.
- review-comment:3348047213 — accepted — Create with `active` status now inserts first, then activates, avoiding closing the active matchup before a failed insert.

## ACCEPTANCE CRITERIA
- [x] Admins can review/prepare active matchup state via `/admin/matchup`.
- [x] Public `/api/matchup/current` behavior preserved (preview + tests; no handler edits).
- [x] Voting/results public APIs unchanged (tests only).
- [x] Missing matchup content fails closed in admin preview and public fallbacks.
- [x] No unrelated route or voting model changes.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains `- **Issue:** #1126`
- [x] Allowed files section matches final diff exactly
- [x] Intent label correct and singular (`feature`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements T48 weekly matchup administration with an admin UI and list/create/update/close APIs, enforcing one active matchup and adding a live public preview; public voting endpoints are unchanged. Addresses #1126.

- **New Features**
  - Admin APIs: `GET /api/admin/matchup/list` (with vote totals), `POST /api/admin/matchup/create`, `POST /api/admin/matchup/update`, `POST /api/admin/matchup/close-active`.
  - Admin page `/admin/matchup`: inventory, create, activate/close controls, and preview of `/api/matchup/current` and `/api/matchup/results` fail-closed behavior.
  - Navigation: added links in `AdminNav` and `AdminDashboard`.
  - Tests: coverage for admin flows and public read paths; D1 `prepare().run()` mocks and public photo fetch stubs; photo lookup mock treats IDs ≥1000 as missing to match production validation.

- **Bug Fixes**
  - Activation now runs as a single D1 batch to atomically close others and activate the target matchup.
  - Reject invalid status values, validate UTC Monday `week_start`, require distinct positive photo IDs, and verify photo IDs exist before create/update.
  - Optimize vote totals with a single LEFT JOIN aggregate in `list.ts`; guard admin preview fetches against stale responses.

<sup>Written for commit 43ea8e1fc05e58efe828feb35f417a8aafc77904. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->