### PR TITLE
Automate post-merge PR body closeout on merged PRs to main

### DIFF
--- a/.github/workflows/post-merge-pr-body-closeout.yml
+++ b/.github/workflows/post-merge-pr-body-closeout.yml
@@ -1,6 +1,8 @@
 name: Post-Merge PR Body Closeout
 
 on:
+  pull_request_target:
+    types: [closed]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -8,7 +10,7 @@ on:
         required: false
         default: '1239'
       body_file:
-        description: Repo-relative path to remediated PR body markdown
+        description: Repo-relative path to remediated PR body markdown (manual single-PR mode)
         required: false
         default: scripts/ci/post-merge-closeout/pr-1239-body.md
       skip_body_apply:
@@ -20,13 +22,14 @@ on:
           - 'false'
           - 'true'
       run_batch:
-        description: Run batch closeout for scripts/ci/post-merge-closeout/targets.json
+        description: Run batch closeout manifest (manual backfill only)
         required: false
-        default: 'true'
+        default: 'false'
         type: choice
         options:
           - 'true'
           - 'false'
+
 permissions:
   actions: read
   contents: read
@@ -35,18 +38,25 @@ permissions:
 
 jobs:
   closeout:
+    if: |
+      (github.event_name == 'pull_request_target' &&
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.base.ref == 'main') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && 'main' || github.sha }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '22'
 
-      - name: Batch closeout for merged PRs 1239 and 1243
+      - name: Batch closeout for manual backfill manifest
         if: github.event_name == 'workflow_dispatch' && inputs.run_batch == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -56,7 +66,7 @@ jobs:
           CLOSEOUT_MANIFEST: scripts/ci/post-merge-closeout/targets.json
         run: node scripts/ci/run_batch_post_merge_closeout.mjs
 
-      - name: Upload post-merge closeout report
+      - name: Upload post-merge batch closeout report
         if: always() && github.event_name == 'workflow_dispatch' && inputs.run_batch == 'true'
         uses: actions/upload-artifact@v4
         with:
@@ -66,14 +76,50 @@ jobs:
             post-merge-result.json
           if-no-files-found: warn
 
-      - name: Apply body, validate, and sync orchestrator state
+      - name: Automatic post-merge closeout for merged PR
+        if: github.event_name == 'pull_request_target'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NAME: pull_request_target
+          GITHUB_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_PR_MERGED: ${{ github.event.pull_request.merged }}
+          EVENT_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          SKIP_BODY_APPLY: 'true'
+        run: node scripts/ci/run_post_merge_closeout.mjs
+
+      - name: Upload automatic post-merge closeout report
+        if: always() && github.event_name == 'pull_request_target'
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-merge-closeout-report
+          path: |
+            post-merge-result.json
+            post-merge-result.md
+          if-no-files-found: warn
+
+      - name: Manual single-PR closeout
         if: github.event_name == 'workflow_dispatch' && inputs.run_batch != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NAME: workflow_dispatch
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ github.event.inputs.pr_number || '1239' }}
           BODY_FILE: ${{ github.event.inputs.body_file || 'scripts/ci/post-merge-closeout/pr-1239-body.md' }}
           SKIP_BODY_APPLY: ${{ github.event.inputs.skip_body_apply || 'false' }}
         run: node scripts/ci/run_post_merge_closeout.mjs
+
+      - name: Upload manual single-PR closeout report
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.run_batch != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-merge-closeout-report
+          path: |
+            post-merge-result.json
+            post-merge-result.md
+          if-no-files-found: warn

--- a/scripts/ci/post_merge_closeout_trigger.mjs
+++ b/scripts/ci/post_merge_closeout_trigger.mjs
@@ -1,0 +1,31 @@
+/**
+ * Determines when Post-Merge PR Body Closeout should run.
+ */
+
+export function shouldRunAutomaticCloseout({
+	eventName = '',
+	merged = false,
+	baseRef = '',
+} = {}) {
+	return (
+		eventName === 'pull_request_target' &&
+		String(merged) === 'true' &&
+		baseRef === 'main'
+	);
+}
+
+export function isManualBatchCloseout({ eventName = '', runBatch = false } = {}) {
+	return eventName === 'workflow_dispatch' && String(runBatch) === 'true';
+}
+
+export function isManualSingleCloseout({ eventName = '', runBatch = false } = {}) {
+	return eventName === 'workflow_dispatch' && String(runBatch) !== 'true';
+}
+
+export function shouldRunCloseoutJob({
+	eventName = '',
+	merged = false,
+	baseRef = '',
+} = {}) {
+	return shouldRunAutomaticCloseout({ eventName, merged, baseRef }) || eventName === 'workflow_dispatch';
+}

--- a/scripts/ci/post_merge_remediation_issue.mjs
+++ b/scripts/ci/post_merge_remediation_issue.mjs
@@ -85,13 +85,14 @@ function request(args) {
 	return githubRepoRequest({ ...args, userAgent: 'lgfc-post-merge-remediation' });
 }
 
-export async function upsertRemediationIssue({ token, repository, result }) {
-	if (result.status !== 'fail') {
-		return { action: 'skipped', issue: null, reason: 'validation-passed-or-skipped' };
-	}
+export function shouldUpsertRemediationIssue(result = {}) {
+	if (result.status === 'skipped') return false;
+	return result.status === 'fail' || result.remediation_required === true;
+}
 
-	if (!result.remediation_required) {
-		return { action: 'skipped', issue: null, reason: 'no-remediation-required' };
+export async function upsertRemediationIssue({ token, repository, result }) {
+	if (!shouldUpsertRemediationIssue(result)) {
+		return { action: 'skipped', issue: null, reason: 'validation-passed-or-skipped' };
 	}
 
 	const title = remediationTitle(result);

--- a/scripts/ci/run_post_merge_closeout.mjs
+++ b/scripts/ci/run_post_merge_closeout.mjs
@@ -7,8 +7,16 @@ import { pathToFileURL } from 'node:url';
 import { applyMergedPrBody } from './apply_merged_pr_body.mjs';
 import { closeDuplicateRemediationIssues } from './close_duplicate_remediation_issues.mjs';
 import { closeRemediationIssuesForPr } from './close_remediation_issues_for_pr.mjs';
+import {
+	shouldUpsertRemediationIssue,
+	upsertRemediationIssue,
+} from './post_merge_remediation_issue.mjs';
 import { runValidator, WORKFLOW_RUN_SCOPE_MERGE_ONLY } from './post_merge_validator.mjs';
 import { githubRepoRequest } from './github_issue_api.mjs';
+import { shouldRunAutomaticCloseout } from './post_merge_closeout_trigger.mjs';
+
+export const POST_MERGE_RESULT_PATH = 'post-merge-result.json';
+export const POST_MERGE_RESULT_MD_PATH = 'post-merge-result.md';
 
 function runSync({ repository, prNumber, syncAction }) {
 	execFileSync('node', ['scripts/orchestrator/sync-pr-state.mjs'], {
@@ -18,7 +26,7 @@ function runSync({ repository, prNumber, syncAction }) {
 			GITHUB_REPOSITORY: repository,
 			PR_NUMBER: String(prNumber),
 			SYNC_ACTION: syncAction,
-			POST_MERGE_RESULT_PATH: 'post-merge-result.json',
+			POST_MERGE_RESULT_PATH,
 			GH_TOKEN: process.env.GITHUB_TOKEN || process.env.GH_TOKEN,
 		},
 	});
@@ -33,6 +41,62 @@ async function fetchMergedPr({ token, repository, prNumber }) {
 	});
 }
 
+export function resolveCloseoutEventContext({
+	eventName = process.env.GITHUB_EVENT_NAME || '',
+	inputPrNumber = process.env.PR_NUMBER || '',
+	eventPrNumber = process.env.EVENT_PR_NUMBER || '',
+	eventPrMerged = process.env.EVENT_PR_MERGED || '',
+	eventPrBaseRef = process.env.EVENT_PR_BASE_REF || '',
+	skipBodyApply = process.env.SKIP_BODY_APPLY || '',
+	bodyFile = process.env.BODY_FILE || '',
+} = {}) {
+	const automatic = shouldRunAutomaticCloseout({
+		eventName,
+		merged: eventPrMerged,
+		baseRef: eventPrBaseRef,
+	});
+
+	return {
+		eventName,
+		prNumber: String(inputPrNumber || eventPrNumber || ''),
+		automatic,
+		skipBodyApply: automatic ? true : skipBodyApply === 'true',
+		bodyFile: automatic ? '' : bodyFile,
+		eventPrMerged,
+		eventPrBaseRef,
+	};
+}
+
+export async function writePostMergeResultArtifactsAsync(result) {
+	const { commentBody } = await import('./post_merge_validator.mjs');
+	fs.writeFileSync(POST_MERGE_RESULT_PATH, `${JSON.stringify(result, null, 2)}\n`);
+	fs.writeFileSync(POST_MERGE_RESULT_MD_PATH, commentBody(result));
+}
+
+export function buildCloseoutErrorResult({ prNumber, mergeSha = '', message = '' } = {}) {
+	return {
+		status: 'fail',
+		pr: prNumber ? Number(prNumber) : null,
+		merge_sha: mergeSha,
+		source_issue: null,
+		late_findings: 0,
+		workflow_failures: [],
+		metadata_failures: [{ code: 'closeout_runtime_error', message: message || 'Post-merge closeout failed.' }],
+		implementation_failures: [],
+		diataxis_failures: [],
+		reviewer_findings: [],
+		remediation_required: true,
+		sync_action: 'post_merge_failure',
+	};
+}
+
+export async function ensureCloseoutRemediationEvidence({ token, repository, result }) {
+	if (!shouldUpsertRemediationIssue(result)) {
+		return { action: 'skipped', issue: null, reason: 'no-remediation-required' };
+	}
+	return upsertRemediationIssue({ token, repository, result });
+}
+
 export async function runPostMergeCloseout({
 	token,
 	repository,
@@ -42,7 +106,10 @@ export async function runPostMergeCloseout({
 	runId = '',
 	skipBodyApply = false,
 	workflowRunScope = WORKFLOW_RUN_SCOPE_MERGE_ONLY,
-}) {
+	eventName = 'workflow_dispatch',
+	eventPrMerged = '',
+	eventPrBaseRef = '',
+} = {}) {
 	const pr = await fetchMergedPr({ token, repository, prNumber });
 	if (!pr.merged_at) {
 		throw new Error(`PR #${prNumber} is not merged; refusing post-merge closeout.`);
@@ -51,20 +118,26 @@ export async function runPostMergeCloseout({
 	const mergeSha = sha || pr.merge_commit_sha || '';
 
 	if (!skipBodyApply) {
+		if (!bodyFile) {
+			throw new Error('BODY_FILE is required unless SKIP_BODY_APPLY=true.');
+		}
 		await applyMergedPrBody({ token, repository, prNumber, bodyFile });
 	}
 
 	const result = await runValidator({
 		token,
 		repository,
-		eventName: 'workflow_dispatch',
+		eventName,
 		inputPrNumber: String(prNumber),
+		eventPrNumber: String(prNumber),
+		eventPrMerged: eventPrMerged || 'true',
+		eventPrBaseRef: eventPrBaseRef || pr.base?.ref || 'main',
 		sha: mergeSha,
 		runId,
 		workflowRunScope,
 	});
 
-	fs.writeFileSync('post-merge-result.json', `${JSON.stringify(result, null, 2)}\n`);
+	await writePostMergeResultArtifactsAsync(result);
 
 	if (result.sync_action && result.sync_action !== 'skipped') {
 		runSync({ repository, prNumber, syncAction: result.sync_action });
@@ -81,41 +154,81 @@ export async function runPostMergeCloseout({
 		await closeDuplicateRemediationIssues({ token, repository, dryRun: false });
 	}
 
+	await ensureCloseoutRemediationEvidence({ token, repository, result });
+
 	return result;
 }
 
 export async function main() {
 	const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 	const repository = process.env.GITHUB_REPOSITORY;
-	const prNumber = process.env.PR_NUMBER || process.env.INPUT_PR_NUMBER;
-	const bodyFile = process.env.BODY_FILE;
-	const skipBodyApply = process.env.SKIP_BODY_APPLY === 'true';
+	const context = resolveCloseoutEventContext();
 
-	if (!token || !repository || !prNumber) {
+	if (!token || !repository) {
 		throw new Error('GITHUB_TOKEN, GITHUB_REPOSITORY, and PR_NUMBER are required.');
 	}
 
-	if (!skipBodyApply && !bodyFile) {
-		throw new Error('BODY_FILE is required unless SKIP_BODY_APPLY=true.');
+	if (!context.prNumber) {
+		console.log(
+			JSON.stringify({
+				status: 'skipped',
+				reason: 'closeout_not_applicable',
+				event: context.eventName,
+			}),
+		);
+		return;
 	}
 
-	const result = await runPostMergeCloseout({
-		token,
-		repository,
-		prNumber,
-		bodyFile,
-		sha: process.env.GITHUB_SHA || '',
-		runId: process.env.GITHUB_RUN_ID || '',
-		skipBodyApply,
-	});
+	let result;
+	try {
+		result = await runPostMergeCloseout({
+			token,
+			repository,
+			prNumber: context.prNumber,
+			bodyFile: context.bodyFile,
+			sha: process.env.GITHUB_SHA || '',
+			runId: process.env.GITHUB_RUN_ID || '',
+			skipBodyApply: context.skipBodyApply,
+			eventName: context.eventName,
+			eventPrMerged: context.eventPrMerged,
+			eventPrBaseRef: context.eventPrBaseRef,
+		});
+	} catch (error) {
+		console.error(error);
+		result = buildCloseoutErrorResult({
+			prNumber: context.prNumber,
+			mergeSha: process.env.GITHUB_SHA || '',
+			message: error instanceof Error ? error.message : String(error),
+		});
+		await writePostMergeResultArtifactsAsync(result);
+		await ensureCloseoutRemediationEvidence({ token, repository, result });
+		process.exitCode = 1;
+		return;
+	}
 
 	console.log(JSON.stringify(result, null, 2));
-	if (result.status === 'fail') process.exit(1);
+	if (result.status === 'fail') process.exitCode = 1;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-	main().catch((error) => {
+	main().catch(async (error) => {
 		console.error(error);
+		const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+		const repository = process.env.GITHUB_REPOSITORY;
+		const prNumber = process.env.PR_NUMBER || process.env.EVENT_PR_NUMBER || '';
+		const result = buildCloseoutErrorResult({
+			prNumber,
+			mergeSha: process.env.GITHUB_SHA || '',
+			message: error instanceof Error ? error.message : String(error),
+		});
+		try {
+			await writePostMergeResultArtifactsAsync(result);
+			if (token && repository) {
+				await ensureCloseoutRemediationEvidence({ token, repository, result });
+			}
+		} catch (writeError) {
+			console.error(writeError);
+		}
 		process.exit(1);
 	});
 }

--- a/tests/post-merge-closeout-automatic.test.mjs
+++ b/tests/post-merge-closeout-automatic.test.mjs
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+	isManualBatchCloseout,
+	isManualSingleCloseout,
+	shouldRunAutomaticCloseout,
+	shouldRunCloseoutJob,
+} from '../scripts/ci/post_merge_closeout_trigger.mjs';
+import {
+	buildCloseoutErrorResult,
+	resolveCloseoutEventContext,
+} from '../scripts/ci/run_post_merge_closeout.mjs';
+import { shouldUpsertRemediationIssue } from '../scripts/ci/post_merge_remediation_issue.mjs';
+import { resolvePrNumber } from '../scripts/ci/post_merge_validator.mjs';
+
+describe('automatic post-merge closeout triggers', () => {
+	it('runs automatic closeout only for merged PRs into main', () => {
+		expect(
+			shouldRunAutomaticCloseout({
+				eventName: 'pull_request_target',
+				merged: true,
+				baseRef: 'main',
+			}),
+		).toBe(true);
+	});
+
+	it('does not run automatic closeout for closed but unmerged PRs', () => {
+		expect(
+			shouldRunAutomaticCloseout({
+				eventName: 'pull_request_target',
+				merged: false,
+				baseRef: 'main',
+			}),
+		).toBe(false);
+	});
+
+	it('does not run automatic closeout for merged PRs outside main', () => {
+		expect(
+			shouldRunAutomaticCloseout({
+				eventName: 'pull_request_target',
+				merged: true,
+				baseRef: 'develop',
+			}),
+		).toBe(false);
+	});
+
+	it('keeps manual batch mode explicit to workflow_dispatch', () => {
+		expect(isManualBatchCloseout({ eventName: 'workflow_dispatch', runBatch: true })).toBe(true);
+		expect(isManualBatchCloseout({ eventName: 'pull_request_target', runBatch: true })).toBe(false);
+	});
+
+	it('keeps manual single-PR mode on workflow_dispatch when batch is false', () => {
+		expect(isManualSingleCloseout({ eventName: 'workflow_dispatch', runBatch: false })).toBe(true);
+		expect(isManualSingleCloseout({ eventName: 'workflow_dispatch', runBatch: true })).toBe(false);
+	});
+
+	it('allows workflow_dispatch jobs regardless of merge state', () => {
+		expect(shouldRunCloseoutJob({ eventName: 'workflow_dispatch', merged: false, baseRef: 'main' })).toBe(
+			true,
+		);
+	});
+});
+
+describe('automatic closeout runtime context', () => {
+	it('uses merged PR number and skips body apply on pull_request_target', () => {
+		const context = resolveCloseoutEventContext({
+			eventName: 'pull_request_target',
+			inputPrNumber: '1188',
+			eventPrNumber: '1188',
+			eventPrMerged: 'true',
+			eventPrBaseRef: 'main',
+			bodyFile: 'scripts/ci/post-merge-closeout/pr-1239-body.md',
+			skipBodyApply: 'false',
+		});
+
+		expect(context).toMatchObject({
+			automatic: true,
+			prNumber: '1188',
+			skipBodyApply: true,
+			bodyFile: '',
+		});
+	});
+
+	it('requires body file for manual single-PR closeout unless skip is set', () => {
+		const context = resolveCloseoutEventContext({
+			eventName: 'workflow_dispatch',
+			inputPrNumber: '1239',
+			bodyFile: 'scripts/ci/post-merge-closeout/pr-1239-body.md',
+			skipBodyApply: 'false',
+		});
+
+		expect(context).toMatchObject({
+			automatic: false,
+			skipBodyApply: false,
+			bodyFile: 'scripts/ci/post-merge-closeout/pr-1239-body.md',
+		});
+	});
+
+	it('resolves pull_request_target PR numbers through the validator', () => {
+		expect(
+			resolvePrNumber({
+				eventName: 'pull_request_target',
+				eventPrNumber: '1239',
+				eventPrMerged: 'true',
+				eventPrBaseRef: 'main',
+			}),
+		).toEqual({ pr: '1239', method: 'pull_request_target', skip_reason: 'none' });
+
+		expect(
+			resolvePrNumber({
+				eventName: 'pull_request_target',
+				eventPrNumber: '1239',
+				eventPrMerged: 'false',
+				eventPrBaseRef: 'main',
+			}),
+		).toMatchObject({ pr: '', skip_reason: 'closed PR was not merged into main' });
+	});
+});
+
+describe('closeout fail-safe remediation evidence', () => {
+	it('upserts remediation issues for failed closeout and remediation-required passes', () => {
+		expect(shouldUpsertRemediationIssue({ status: 'fail', remediation_required: true })).toBe(true);
+		expect(shouldUpsertRemediationIssue({ status: 'pass', remediation_required: true })).toBe(true);
+		expect(shouldUpsertRemediationIssue({ status: 'pass', remediation_required: false })).toBe(false);
+	});
+
+	it('builds a fail-closeout result with remediation_required set', () => {
+		const result = buildCloseoutErrorResult({
+			prNumber: '1239',
+			mergeSha: 'abc123',
+			message: 'network failure',
+		});
+
+		expect(result).toMatchObject({
+			status: 'fail',
+			pr: 1239,
+			remediation_required: true,
+			sync_action: 'post_merge_failure',
+		});
+	});
+});

--- a/tests/post-merge-closeout-batch.test.mjs
+++ b/tests/post-merge-closeout-batch.test.mjs
@@ -147,15 +147,18 @@ describe('post-merge closeout batch', () => {
 			closeDuplicateRemediationIssuesFn: vi.fn().mockResolvedValue({ closed: [] }),
 		});
 
-		expect(outcome.results).toEqual([
-			{ pr: '1', status: 'error', message: 'PR #1 closeout failed' },
-			{
-				pr: '2',
-				status: 'pass',
-				sync_action: 'post_merge_success',
-				source_issue: '2',
-				remediation_required: false,
-			},
-		]);
+		expect(outcome.results[0]).toMatchObject({
+			pr: '1',
+			status: 'error',
+			phase: 'closeout',
+			failure_reason: 'PR #1 closeout failed',
+		});
+		expect(outcome.results[1]).toMatchObject({
+			pr: '2',
+			status: 'pass',
+			sync_action: 'post_merge_success',
+			source_issue: '2',
+			remediation_required: false,
+		});
 	});
 });

--- a/tests/post-merge-source-issue-closeout.test.mjs
+++ b/tests/post-merge-source-issue-closeout.test.mjs
@@ -96,7 +96,14 @@ describe('source issue closeout decision', () => {
 		const result = buildResult({
 			pr: { body: baseBody },
 			resolution: { pr: '1239' },
-			metadata: [{ code: 'missing_advisory_section', severity: 'advisory', message: 'advisory' }],
+			failures: [
+				{
+					workflow: 'Auto-Sync Documentation',
+					classification: 'secret-access/configuration',
+					required: false,
+					conclusion: 'failure',
+				},
+			],
 		});
 
 		expect(result).toMatchObject({ status: 'pass', sync_action: 'post_merge_remediation', remediation_required: true });


### PR DESCRIPTION
- **Issue:** #1281

## PRE-OPEN GATE PREFLIGHT (MANDATORY)
- [x] Confirm exactly one same-repository, open, non-PR source issue exists.
- [x] Confirm one accepted issue-accounting line is present before opening or updating the PR.
- [x] Read the workflow files that will run for this PR's touched paths before opening the PR.
- [x] Read `docs/reference/governance/troubleshooting-data-surface-requirements.md` before making any merge-readiness claim.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## PROGRESS + READINESS (MANDATORY)
- Phase: CI post-merge closeout automation
- Task: Automatic closeout on merged PRs to main
- Status: MERGED
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: none
- Notes: Merged as #1282. Automatic `pull_request_target` closeout path enabled; manual batch backfill remains explicit.

## LABEL
- Intent label for this PR: infra

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `.github/workflows/post-merge-pr-body-closeout.yml`
- `scripts/ci/post_merge_closeout_trigger.mjs`
- `scripts/ci/post_merge_remediation_issue.mjs`
- `scripts/ci/run_post_merge_closeout.mjs`
- `tests/post-merge-closeout-automatic.test.mjs`
- `tests/post-merge-closeout-batch.test.mjs`
- `tests/post-merge-source-issue-closeout.test.mjs`

All other files are out of scope

## CHANGE SUMMARY
- Trigger `Post-Merge PR Body Closeout` on `pull_request_target` closed when PR merges to `main`.
- Preserve manual `workflow_dispatch` for single-PR remediation and explicit `run_batch: true` backfill.
- Add fail-safe remediation issue upsert and closeout report artifacts on failure.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `npx vitest run --config tests/vitest.node.config.ts tests/post-merge-closeout-automatic.test.mjs tests/post-merge-closeout-batch.test.mjs tests/batch-post-merge-closeout.test.mjs tests/post-merge-source-issue-closeout.test.mjs tests/post-merge-validator.test.mjs` — PASS (49 tests)
- Gate verification:
  - Commit-level workflow runs inspected: YES
  - PR-level governance/accounting workflows inspected: YES
  - Failed job logs inspected for every failing gate: YES
  - Required gates rerun or re-evaluated after fixes: YES
- Result summary: PASS

## ACCEPTANCE CRITERIA
- [x] Automatic closeout runs only for merged PRs into `main`.
- [x] Manual batch closeout does not run on every merge.
- [x] Closeout failures produce diagnostics and remediation evidence.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] PR body contains one accepted source-issue accounting line
- [x] Allowed files section matches final diff exactly
- [x] ZIP safety confirmed
- [x] Local checks executed and passed

## POST-MERGE VERIFICATION REQUIREMENTS
- Confirm automatic closeout workflow runs on the next merged PR to `main`.
- Confirm fail-safe remediation issue is created when validation fails.

<!-- closeout-trigger: 2026-06-04 -->
