### PR TITLE
ci: add workflow_dispatch to AI execution bridge

### DIFF
--- a/.github/workflows/ai-execution-bridge.yml
+++ b/.github/workflows/ai-execution-bridge.yml
@@ -3,6 +3,12 @@ name: AI Execution Bridge
 on:
   issues:
     types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to validate as an ai-build task (smoke test / operator rerun)
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -10,17 +16,39 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ai-execution-bridge-${{ github.event.issue.number }}
+  group: ai-execution-bridge-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: false
 
 jobs:
   bridge:
-    if: github.event.label.name == 'ai-build'
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ai-build'
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Build labeled event payload (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+        run: |
+          gh issue view "$ISSUE_NUMBER" --repo "${{ github.repository }}"             --json number,title,body > issue-payload.json
+          node <<'NODE'
+          const fs = require('node:fs');
+          const issue = JSON.parse(fs.readFileSync('issue-payload.json', 'utf8'));
+          const event = {
+            action: 'labeled',
+            label: { name: 'ai-build' },
+            issue: {
+              number: issue.number,
+              title: issue.title,
+              body: issue.body,
+            },
+          };
+          fs.writeFileSync('dispatch-event.json', JSON.stringify(event));
+          NODE
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -30,7 +58,7 @@ jobs:
       - name: Validate approved issue
         id: validate
         env:
-          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_EVENT_PATH: ${{ github.event_name == 'workflow_dispatch' && 'dispatch-event.json' || github.event_path }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           AI_EXECUTION_BRIDGE_RESULT_PATH: ai-execution-bridge-result.json
         run: node scripts/ci/ai_execution_bridge_validate.mjs
@@ -54,7 +82,7 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         run: |
           if [ ! -f ai-execution-bridge-result.json ]; then
             echo "No validation result artifact found."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #1288

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root

## LABEL
- Intent label for this PR: infra

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `.github/workflows/ai-execution-bridge.yml`

## CHANGE SUMMARY
- Add `workflow_dispatch` with `issue_number` input so operators can run the bridge without re-applying the `ai-build` label (supports smoke test #1288).

## BUILD / TEST / VERIFICATION
- YAML-only change; smoke test planned via `workflow_dispatch` after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40ffceb1-ebbf-468e-ba0e-d227d532f541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40ffceb1-ebbf-468e-ba0e-d227d532f541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual trigger to the execution bridge workflow so operators can run it against a specific issue by passing `issue_number`, without re-applying the `ai-build` label. Enables smoke verification for #1288.

- **New Features**
  - Added `workflow_dispatch` with required `issue_number` input for on-demand runs.
  - For manual runs, builds a synthetic labeled event so existing validation logic works unchanged.
  - Updated concurrency and result posting to use `github.event.issue.number || inputs.issue_number`.

<sup>Written for commit c60356f62c7a05cb6f7ccb4388bb7881a045346f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->