### PR TITLE
docs: record Bill sign-off for Program 2 launch gate (#1391)

### DIFF
--- a/docs/ops/reports/program-2-launch-gate.md
+++ b/docs/ops/reports/program-2-launch-gate.md
@@ -140,16 +140,16 @@ Bill sign-off.
 | Gate document | `docs/ops/reports/program-2-launch-gate.md` |
 | Source issue | `#1385` |
 | Assessment date | 2026-06-06 |
-| Program owner approver | **PENDING — Bill sign-off required** |
-| Sign-off date | **PENDING** |
-| Sign-off method | Record approver name and ISO date in this section or in `#1385` closeout comment |
+| Program owner approver | Bill Hunter |
+| Sign-off date | 2026-06-06 |
+| Sign-off method | Repo document update approved by Bill Hunter |
 
 **Checklist attestation (Cursor implementation):** Tasks 001–007 deliverables verified
 on `main`; no P0 findings waived; H-001–H-003 adopted with sequencing documented;
 authorized child projects listed; no workflow or runtime changes introduced by this task.
 
-**Effective authorization:** Program 2 activation is **not effective** until **Bill**
-replaces `PENDING` entries above.
+**Effective authorization:** Program 2 launch-gate sign-off is **effective** as of
+this recorded approval (source issue `#1391`).
 
 ## Validation
 


### PR DESCRIPTION
- **Issue:** #1391

## PROGRESS + READINESS (MANDATORY)
- Phase: Program 1 wrap-up / Program 2 authorization
- Task: Record Bill launch-gate sign-off
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO

## LABEL
- Intent label for this PR: docs-only

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- docs/ops/reports/program-2-launch-gate.md

All other files are out of scope

## DOCS-ONLY ASSERTION (REQUIRED FOR change-ops)
- [x] This PR contains documentation-only changes
- [x] No application code, config, or runtime behavior modified

## CHANGE SUMMARY
- Record Bill Hunter Program 2 launch-gate sign-off (2026-06-06) in `program-2-launch-gate.md`.
- Mark Program 2 authorization effective per source issue #1391.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `./scripts/ci/docs_check_headers.sh docs/ops/reports/program-2-launch-gate.md` — PASS
  - `./scripts/ci/docs_canonical_hashes_verify.sh .` — PASS
- Result summary: PASS

## ACCEPTANCE CRITERIA
- [x] Sign-off section no longer contains PENDING.
- [x] Bill Hunter and ISO date 2026-06-06 recorded.
- [x] Exactly one file changed; docs-only.
- [x] Source issue line: `- **Issue:** #1391`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recorded Bill Hunter’s approval for the Program 2 launch gate and marked authorization effective as of 2026-06-06 in `docs/ops/reports/program-2-launch-gate.md` (per `#1391`).

<sup>Written for commit 298b7782ff43952ba982f72702d1b9c74bcd2004. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

