### PR TITLE
Task 003: Submission workflow implementation delta

### DIFF
--- a/functions/api/admin/editorial/list.ts
+++ b/functions/api/admin/editorial/list.ts
@@ -4,7 +4,16 @@
 import { requireAdmin } from "../../../_lib/auth";
 import { jsonResponse, requireD1, requireTables } from "../../../_lib/d1";
 
-const VALID_SUBMISSION_STATUSES = new Set(["pending", "approved", "rejected_auto", "rejected_manual", "all"]);
+const VALID_SUBMISSION_STATUSES = new Set([
+  "pending",
+  "triaged",
+  "under_review",
+  "approved",
+  "rejected",
+  "merged",
+  "purged",
+  "all",
+]);
 const VALID_INVENTORY_STATUSES = new Set(["draft", "published", "archived", "all"]);
 
 function parseLimit(raw: string | null): number {
@@ -43,8 +52,11 @@ export const onRequestGet = async (context: any): Promise<Response> => {
       submissionStatus === "all"
         ? await d1.db
             .prepare(
-              `SELECT submission_id, submitted_by, title, description, source_url, proposed_tag, media_url,
-                      status, review_notes, purge_flag, created_at, updated_at, reviewed_at, reviewer
+              `SELECT submission_id, submitted_by, payload, title, description, source_name, source_url,
+                      credit_line, proposed_tag, media_url, media_reference, status, triage_flags,
+                      duplicate_candidate, review_notes, decision_by, decision_at, rejected_at,
+                      purge_eligible_at, retention_reason, purge_flag, created_at, updated_at,
+                      reviewed_at, reviewer
                  FROM submission_queue
                  ORDER BY created_at DESC, submission_id DESC
                  LIMIT ?`,
@@ -53,8 +65,11 @@ export const onRequestGet = async (context: any): Promise<Response> => {
             .all()
         : await d1.db
             .prepare(
-              `SELECT submission_id, submitted_by, title, description, source_url, proposed_tag, media_url,
-                      status, review_notes, purge_flag, created_at, updated_at, reviewed_at, reviewer
+              `SELECT submission_id, submitted_by, payload, title, description, source_name, source_url,
+                      credit_line, proposed_tag, media_url, media_reference, status, triage_flags,
+                      duplicate_candidate, review_notes, decision_by, decision_at, rejected_at,
+                      purge_eligible_at, retention_reason, purge_flag, created_at, updated_at,
+                      reviewed_at, reviewer
                  FROM submission_queue
                  ${submissionWhere}
                  ORDER BY created_at DESC, submission_id DESC

--- a/functions/api/admin/editorial/review.ts
+++ b/functions/api/admin/editorial/review.ts
@@ -32,6 +32,7 @@ type ReviewBody = {
 };
 
 const STORY_TYPES = new Set(["primary", "secondary", "brief"]);
+const TRIAGE_STATUSES = new Set(["pending", "triaged"]);
 const REVIEWABLE_STATUSES = new Set(["pending", "triaged", "under_review"]);
 const ACTIONS = new Set(["triage", "start_review", "approve", "merge", "reject", "purge"]);
 
@@ -85,12 +86,19 @@ function jsonText(value: unknown, fallback: unknown): string {
 
 function normalizeOptionalDate(value: unknown): string | null {
   const text = asString(value);
-  return text || null;
+  if (!text) return null;
+  const parsed = Date.parse(text);
+  return Number.isNaN(parsed) ? null : new Date(parsed).toISOString();
 }
 
 function appendText(existing: unknown, addition: string): string {
   const current = String(existing || "").trim();
   return [current, addition.trim()].filter(Boolean).join("\n\n");
+}
+
+function defaultCreditFromSubmitter(value: unknown): string {
+  const submittedBy = String(value || "").trim();
+  return submittedBy.includes("<") ? submittedBy.split("<")[0].trim() : submittedBy;
 }
 
 export const onRequestPost = async (context: any): Promise<Response> => {
@@ -141,7 +149,7 @@ export const onRequestPost = async (context: any): Promise<Response> => {
     const currentStatus = String((submission as any).status || "");
 
     if (action === "triage") {
-      if (!REVIEWABLE_STATUSES.has(currentStatus)) {
+      if (!TRIAGE_STATUSES.has(currentStatus)) {
         return jsonResponse({ ok: false, error: "Only open submissions can be triaged." }, 409);
       }
 
@@ -289,7 +297,10 @@ export const onRequestPost = async (context: any): Promise<Response> => {
     const storyType = STORY_TYPES.has(asString(body?.story_type)) ? asString(body?.story_type) : "brief";
     const sourceUrl = asString(body?.source_url) || String((submission as any).source_url || "").trim() || null;
     const sourceName = asString(body?.source_name) || String((submission as any).source_name || "").trim() || "Member submission";
-    const creditLine = asString(body?.credit_line) || String((submission as any).credit_line || "").trim() || String((submission as any).submitted_by || "").trim();
+    const creditLine =
+      asString(body?.credit_line) ||
+      String((submission as any).credit_line || "").trim() ||
+      defaultCreditFromSubmitter((submission as any).submitted_by);
     const allowedSections = jsonText(body?.allowed_sections, ["library"]);
     const media = jsonText(
       body?.media,

--- a/functions/api/admin/editorial/review.ts
+++ b/functions/api/admin/editorial/review.ts
@@ -1,5 +1,5 @@
 // POST /api/admin/editorial/review
-// Approves or rejects submission_queue rows. Approved submissions become draft content_inventory records.
+// Moves submission_queue rows through manual editorial review states.
 
 import { requireAdmin } from "../../../_lib/auth";
 import { jsonResponse, requireD1, requireTables } from "../../../_lib/d1";
@@ -24,9 +24,16 @@ type ReviewBody = {
   feature_weight?: unknown;
   review_notes?: unknown;
   reviewer?: unknown;
+  triage_flags?: unknown;
+  duplicate_candidate?: unknown;
+  retention_reason?: unknown;
+  purge_eligible_at?: unknown;
+  target_inventory_id?: unknown;
 };
 
 const STORY_TYPES = new Set(["primary", "secondary", "brief"]);
+const REVIEWABLE_STATUSES = new Set(["pending", "triaged", "under_review"]);
+const ACTIONS = new Set(["triage", "start_review", "approve", "merge", "reject", "purge"]);
 
 function asString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -76,6 +83,16 @@ function jsonText(value: unknown, fallback: unknown): string {
   return JSON.stringify(fallback);
 }
 
+function normalizeOptionalDate(value: unknown): string | null {
+  const text = asString(value);
+  return text || null;
+}
+
+function appendText(existing: unknown, addition: string): string {
+  const current = String(existing || "").trim();
+  return [current, addition.trim()].filter(Boolean).join("\n\n");
+}
+
 export const onRequestPost = async (context: any): Promise<Response> => {
   const { request, env } = context;
 
@@ -93,13 +110,15 @@ export const onRequestPost = async (context: any): Promise<Response> => {
     const submissionId = asInt(body?.submission_id, 0);
     const action = asString(body?.action);
 
-    if (!submissionId || !["approve", "reject"].includes(action)) {
-      return jsonResponse({ ok: false, error: "submission_id and action are required." }, 400);
+    if (!submissionId || !ACTIONS.has(action)) {
+      return jsonResponse({ ok: false, error: "submission_id and valid action are required." }, 400);
     }
 
     const submission = await d1.db
       .prepare(
-        `SELECT submission_id, submitted_by, title, description, source_url, proposed_tag, media_url, status
+        `SELECT submission_id, submitted_by, payload, title, description, source_name, source_url,
+                credit_line, proposed_tag, media_url, media_reference, status, triage_flags,
+                duplicate_candidate, review_notes, retention_reason
            FROM submission_queue
           WHERE submission_id = ?`,
       )
@@ -110,26 +129,156 @@ export const onRequestPost = async (context: any): Promise<Response> => {
       return jsonResponse({ ok: false, error: "Submission not found." }, 404);
     }
 
-    if ((submission as any).status !== "pending") {
-      return jsonResponse({ ok: false, error: "Submission has already been reviewed." }, 409);
-    }
-
-    const nowRow = await d1.db.prepare("SELECT datetime('now') AS now").first();
+    const nowRow = await d1.db
+      .prepare("SELECT datetime('now') AS now, datetime('now', '+90 days') AS purge_eligible_at")
+      .first();
     const now = String((nowRow as any)?.now || new Date().toISOString());
+    const defaultPurgeEligibleAt = String((nowRow as any)?.purge_eligible_at || now);
     const reviewNotes = asString(body?.review_notes) || null;
     const reviewer = asString(body?.reviewer) || "admin-ui";
+    const duplicateCandidate = asString(body?.duplicate_candidate) || null;
+    const triageFlags = jsonText(body?.triage_flags, []);
+    const currentStatus = String((submission as any).status || "");
 
-    if (action === "reject") {
+    if (action === "triage") {
+      if (!REVIEWABLE_STATUSES.has(currentStatus)) {
+        return jsonResponse({ ok: false, error: "Only open submissions can be triaged." }, 409);
+      }
+
       await d1.db
         .prepare(
           `UPDATE submission_queue
-              SET status = 'rejected_manual', review_notes = ?, updated_at = ?, reviewed_at = ?, reviewer = ?
+              SET status = 'triaged', triage_flags = ?, duplicate_candidate = ?, review_notes = ?,
+                  updated_at = ?, reviewer = ?
             WHERE submission_id = ?`,
         )
-        .bind(reviewNotes, now, now, reviewer, submissionId)
+        .bind(triageFlags, duplicateCandidate, reviewNotes, now, reviewer, submissionId)
+        .run();
+
+      return jsonResponse({ ok: true, action: "triage", submission_id: submissionId }, 200);
+    }
+
+    if (action === "start_review") {
+      if (!REVIEWABLE_STATUSES.has(currentStatus)) {
+        return jsonResponse({ ok: false, error: "Only open submissions can enter review." }, 409);
+      }
+
+      await d1.db
+        .prepare(
+          `UPDATE submission_queue
+              SET status = 'under_review', review_notes = ?, updated_at = ?, reviewer = ?
+            WHERE submission_id = ?`,
+        )
+        .bind(reviewNotes, now, reviewer, submissionId)
+        .run();
+
+      return jsonResponse({ ok: true, action: "start_review", submission_id: submissionId }, 200);
+    }
+
+    if (action === "purge") {
+      if (currentStatus !== "rejected") {
+        return jsonResponse({ ok: false, error: "Only rejected submissions can be marked purged." }, 409);
+      }
+      if (String((submission as any).retention_reason || "").trim()) {
+        return jsonResponse({ ok: false, error: "Retained rejected submissions cannot be purged." }, 409);
+      }
+
+      await d1.db
+        .prepare(
+          `UPDATE submission_queue
+              SET status = 'purged', review_notes = ?, decision_by = ?, decision_at = ?,
+                  updated_at = ?, reviewed_at = ?, reviewer = ?, purge_flag = 0
+            WHERE submission_id = ?`,
+        )
+        .bind(reviewNotes, reviewer, now, now, now, reviewer, submissionId)
+        .run();
+
+      return jsonResponse({ ok: true, action: "purge", submission_id: submissionId }, 200);
+    }
+
+    if (!REVIEWABLE_STATUSES.has(currentStatus)) {
+      return jsonResponse({ ok: false, error: "Submission has already reached a terminal review state." }, 409);
+    }
+
+    if (action === "reject") {
+      const retentionReason = asString(body?.retention_reason) || null;
+      const purgeEligibleAt = retentionReason
+        ? null
+        : normalizeOptionalDate(body?.purge_eligible_at) || defaultPurgeEligibleAt;
+
+      await d1.db
+        .prepare(
+          `UPDATE submission_queue
+              SET status = 'rejected', review_notes = ?, duplicate_candidate = ?,
+                  retention_reason = ?, rejected_at = ?, purge_eligible_at = ?, purge_flag = ?,
+                  decision_by = ?, decision_at = ?, updated_at = ?, reviewed_at = ?, reviewer = ?
+            WHERE submission_id = ?`,
+        )
+        .bind(
+          reviewNotes,
+          duplicateCandidate,
+          retentionReason,
+          now,
+          purgeEligibleAt,
+          purgeEligibleAt ? 1 : 0,
+          reviewer,
+          now,
+          now,
+          now,
+          reviewer,
+          submissionId,
+        )
         .run();
 
       return jsonResponse({ ok: true, action: "reject", submission_id: submissionId }, 200);
+    }
+
+    if (action === "merge") {
+      const targetInventoryId = asInt(body?.target_inventory_id, 0);
+      if (!targetInventoryId) {
+        return jsonResponse({ ok: false, error: "target_inventory_id is required for merge." }, 400);
+      }
+
+      const target = await d1.db
+        .prepare("SELECT id, title, review_notes, search_text FROM content_inventory WHERE id = ?")
+        .bind(targetInventoryId)
+        .first();
+
+      if (!target) {
+        return jsonResponse({ ok: false, error: "Target content record not found." }, 404);
+      }
+
+      const title = String((submission as any).title || "").trim();
+      const text = String((submission as any).description || "").trim();
+      const mergeNote = appendText(
+        reviewNotes,
+        `Merged submission #${submissionId} (${title || "untitled"}) into content_inventory #${targetInventoryId} by ${reviewer}.`,
+      );
+      const nextNotes = appendText((target as any).review_notes, mergeNote);
+      const nextSearchText = [String((target as any).search_text || ""), title, text]
+        .filter(Boolean)
+        .join(" ")
+        .trim();
+
+      await d1.db
+        .prepare("UPDATE content_inventory SET review_notes = ?, search_text = ?, updated_at = ? WHERE id = ?")
+        .bind(nextNotes, nextSearchText, now, targetInventoryId)
+        .run();
+
+      await d1.db
+        .prepare(
+          `UPDATE submission_queue
+              SET status = 'merged', review_notes = ?, duplicate_candidate = ?, decision_by = ?,
+                  decision_at = ?, updated_at = ?, reviewed_at = ?, reviewer = ?, purge_flag = 0
+            WHERE submission_id = ?`,
+        )
+        .bind(mergeNote, duplicateCandidate || String(targetInventoryId), reviewer, now, now, now, reviewer, submissionId)
+        .run();
+
+      return jsonResponse(
+        { ok: true, action: "merge", submission_id: submissionId, inventory_id: targetInventoryId },
+        200,
+      );
     }
 
     const title = String((submission as any).title || "").trim();
@@ -139,10 +288,15 @@ export const onRequestPost = async (context: any): Promise<Response> => {
     const perspectiveLabel = asString(body?.perspective_label) || null;
     const storyType = STORY_TYPES.has(asString(body?.story_type)) ? asString(body?.story_type) : "brief";
     const sourceUrl = asString(body?.source_url) || String((submission as any).source_url || "").trim() || null;
-    const sourceName = asString(body?.source_name) || "Member submission";
-    const creditLine = asString(body?.credit_line) || String((submission as any).submitted_by || "").trim();
+    const sourceName = asString(body?.source_name) || String((submission as any).source_name || "").trim() || "Member submission";
+    const creditLine = asString(body?.credit_line) || String((submission as any).credit_line || "").trim() || String((submission as any).submitted_by || "").trim();
     const allowedSections = jsonText(body?.allowed_sections, ["library"]);
-    const media = jsonText(body?.media, (submission as any).media_url ? [{ url: (submission as any).media_url }] : []);
+    const media = jsonText(
+      body?.media,
+      (submission as any).media_reference || (submission as any).media_url
+        ? [{ url: (submission as any).media_reference || (submission as any).media_url }]
+        : [],
+    );
     const priority = asInt(body?.priority, 0);
     const canonical = body?.canonical === false || body?.canonical === 0 ? 0 : 1;
     const eventDate = asString(body?.event_date) || null;
@@ -204,10 +358,11 @@ export const onRequestPost = async (context: any): Promise<Response> => {
     await d1.db
       .prepare(
         `UPDATE submission_queue
-            SET status = 'approved', review_notes = ?, updated_at = ?, reviewed_at = ?, reviewer = ?
+            SET status = 'approved', review_notes = ?, duplicate_candidate = ?, decision_by = ?,
+                decision_at = ?, updated_at = ?, reviewed_at = ?, reviewer = ?, purge_flag = 0
           WHERE submission_id = ?`,
       )
-      .bind(reviewNotes, now, now, reviewer, submissionId)
+      .bind(reviewNotes, duplicateCandidate, reviewer, now, now, now, reviewer, submissionId)
       .run();
 
     const inventoryId = (insert as any)?.meta?.last_row_id ?? (insert as any)?.meta?.lastRowId ?? null;

--- a/functions/api/library/submit.ts
+++ b/functions/api/library/submit.ts
@@ -34,8 +34,11 @@ export const onRequestPost = async (context: any): Promise<Response> => {
     const name = String((body as any).name ?? "").trim();
     const title = String((body as any).title ?? "").trim();
     const content = String((body as any).content ?? "").trim();
+    const sourceName = String((body as any).source_name ?? "").trim() || null;
     const sourceUrl = String((body as any).source_url ?? "").trim() || null;
+    const creditLine = String((body as any).credit_line ?? "").trim() || null;
     const mediaUrl = String((body as any).media_url ?? "").trim() || null;
+    const mediaReference = String((body as any).media_reference ?? mediaUrl ?? "").trim() || null;
     const proposedTag = slugifyTag(String((body as any).proposed_tag ?? title).trim());
 
     // email is derived from the authenticated session — never trust client input
@@ -55,12 +58,36 @@ export const onRequestPost = async (context: any): Promise<Response> => {
       );
     }
 
+    const submittedBy = `${name} <${email}>`;
+    const payload = JSON.stringify({
+      submitted_by: submittedBy,
+      title,
+      description: content,
+      source_name: sourceName,
+      source_url: sourceUrl,
+      credit_line: creditLine,
+      proposed_tag: proposedTag || null,
+      media_reference: mediaReference,
+    });
+
     const result = await auth.db.prepare(
       `INSERT INTO submission_queue
-        (submitted_by, title, description, source_url, proposed_tag, media_url, status)
-       VALUES (?, ?, ?, ?, ?, ?, 'pending');`
+        (submitted_by, payload, title, description, source_name, source_url, credit_line,
+         proposed_tag, media_url, media_reference, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending');`
     )
-      .bind(`${name} <${email}>`, title, content, sourceUrl, proposedTag || null, mediaUrl)
+      .bind(
+        submittedBy,
+        payload,
+        title,
+        content,
+        sourceName,
+        sourceUrl,
+        creditLine,
+        proposedTag || null,
+        mediaUrl,
+        mediaReference,
+      )
       .run();
 
     const insertedId =

--- a/migrations/0037_submission_queue_workflow_delta.sql
+++ b/migrations/0037_submission_queue_workflow_delta.sql
@@ -75,7 +75,10 @@ SELECT
   END,
   review_notes,
   reviewer,
-  reviewed_at,
+  CASE
+    WHEN status IN ('approved', 'rejected_auto', 'rejected_manual') THEN COALESCE(reviewed_at, updated_at)
+    ELSE reviewed_at
+  END,
   CASE WHEN status IN ('rejected_auto', 'rejected_manual') THEN COALESCE(reviewed_at, updated_at) ELSE NULL END,
   CASE WHEN purge_flag = 1 THEN updated_at ELSE NULL END,
   purge_flag,

--- a/migrations/0037_submission_queue_workflow_delta.sql
+++ b/migrations/0037_submission_queue_workflow_delta.sql
@@ -1,0 +1,99 @@
+-- 0037_submission_queue_workflow_delta.sql
+-- Task 003: reconcile submission_queue review states, decision metadata, and purge readiness.
+
+CREATE TABLE submission_queue_next (
+  submission_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  submitted_by TEXT NOT NULL,
+  payload TEXT NOT NULL DEFAULT '{}',
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+  source_name TEXT,
+  source_url TEXT,
+  credit_line TEXT,
+  proposed_tag TEXT,
+  media_url TEXT,
+  media_reference TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'triaged', 'under_review', 'approved', 'rejected', 'merged', 'purged')),
+  triage_flags TEXT NOT NULL DEFAULT '[]',
+  duplicate_candidate TEXT,
+  review_notes TEXT,
+  decision_by TEXT,
+  decision_at TEXT,
+  rejected_at TEXT,
+  purge_eligible_at TEXT,
+  retention_reason TEXT,
+  purge_flag INTEGER NOT NULL DEFAULT 0 CHECK (purge_flag IN (0, 1)),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  reviewed_at TEXT,
+  reviewer TEXT
+);
+
+INSERT INTO submission_queue_next (
+  submission_id,
+  submitted_by,
+  payload,
+  title,
+  description,
+  source_url,
+  proposed_tag,
+  media_url,
+  media_reference,
+  status,
+  review_notes,
+  decision_by,
+  decision_at,
+  rejected_at,
+  purge_eligible_at,
+  purge_flag,
+  created_at,
+  updated_at,
+  reviewed_at,
+  reviewer
+)
+SELECT
+  submission_id,
+  submitted_by,
+  json_object(
+    'submitted_by', submitted_by,
+    'title', title,
+    'description', description,
+    'source_url', source_url,
+    'proposed_tag', proposed_tag,
+    'media_url', media_url
+  ),
+  title,
+  description,
+  source_url,
+  proposed_tag,
+  media_url,
+  media_url,
+  CASE
+    WHEN status IN ('rejected_auto', 'rejected_manual') THEN 'rejected'
+    WHEN status IN ('pending', 'approved') THEN status
+    ELSE 'pending'
+  END,
+  review_notes,
+  reviewer,
+  reviewed_at,
+  CASE WHEN status IN ('rejected_auto', 'rejected_manual') THEN COALESCE(reviewed_at, updated_at) ELSE NULL END,
+  CASE WHEN purge_flag = 1 THEN updated_at ELSE NULL END,
+  purge_flag,
+  created_at,
+  updated_at,
+  reviewed_at,
+  reviewer
+FROM submission_queue;
+
+DROP TABLE submission_queue;
+
+ALTER TABLE submission_queue_next RENAME TO submission_queue;
+
+CREATE INDEX IF NOT EXISTS idx_submission_queue_status_created
+  ON submission_queue(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_submission_queue_decision_at
+  ON submission_queue(decision_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_submission_queue_purge_eligible
+  ON submission_queue(status, purge_eligible_at);

--- a/src/app/admin/editorial/page.tsx
+++ b/src/app/admin/editorial/page.tsx
@@ -9,15 +9,41 @@ import { adminJson } from '@/lib/adminClient';
 type Submission = {
   submission_id: number;
   submitted_by: string;
+  payload?: string | null;
   title: string;
   description: string;
+  source_name?: string | null;
   source_url?: string | null;
+  credit_line?: string | null;
   proposed_tag?: string | null;
   media_url?: string | null;
-  status: 'pending' | 'approved' | 'rejected_auto' | 'rejected_manual';
+  media_reference?: string | null;
+  status: SubmissionStatus;
+  triage_flags?: string | null;
+  duplicate_candidate?: string | null;
   review_notes?: string | null;
+  decision_by?: string | null;
+  decision_at?: string | null;
+  rejected_at?: string | null;
+  purge_eligible_at?: string | null;
+  retention_reason?: string | null;
   created_at?: string | null;
 };
+
+type SubmissionStatus = 'pending' | 'triaged' | 'under_review' | 'approved' | 'rejected' | 'merged' | 'purged';
+type SubmissionFilter = SubmissionStatus | 'all';
+type ReviewAction = 'triage' | 'start_review' | 'approve' | 'merge' | 'reject' | 'purge';
+
+const SUBMISSION_FILTERS: Array<{ value: SubmissionFilter; label: string }> = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'triaged', label: 'Triaged' },
+  { value: 'under_review', label: 'Under review' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'merged', label: 'Merged' },
+  { value: 'purged', label: 'Purged' },
+  { value: 'all', label: 'All submissions' },
+];
 
 type InventoryRecord = {
   id: number;
@@ -68,12 +94,15 @@ export default function AdminEditorialArchivePage() {
   const [loading, setLoading] = useState(false);
   const [submissions, setSubmissions] = useState<Submission[]>([]);
   const [inventory, setInventory] = useState<InventoryRecord[]>([]);
+  const [submissionFilter, setSubmissionFilter] = useState<SubmissionFilter>('pending');
 
   const load = useCallback(async () => {
     setLoading(true);
     setStatus('Loading editorial queue…');
 
-    const result = await adminJson<EditorialListResponse>('/api/admin/editorial/list?limit=100');
+    const result = await adminJson<EditorialListResponse>(
+      `/api/admin/editorial/list?limit=100&submission_status=${submissionFilter}`,
+    );
 
     if (!result.ok) {
       setSubmissions([]);
@@ -88,15 +117,24 @@ export default function AdminEditorialArchivePage() {
     setSubmissions(nextSubmissions);
     setInventory(nextInventory);
     setStatus(
-      `Loaded ${nextSubmissions.length} pending submission(s) and ${nextInventory.length} archive record(s).`,
+      `Loaded ${nextSubmissions.length} ${submissionFilter} submission(s) and ${nextInventory.length} archive record(s).`,
     );
     setLoading(false);
-  }, []);
+  }, [submissionFilter]);
 
   const reviewSubmission = useCallback(
-    async (submission: Submission, action: 'approve' | 'reject', form: HTMLFormElement) => {
+    async (
+      submission: Submission,
+      action: ReviewAction,
+      form: HTMLFormElement,
+      options: { retentionReason?: string } = {},
+    ) => {
       const formData = new FormData(form);
-      setStatus(action === 'approve' ? `Approving "${submission.title}"…` : `Rejecting "${submission.title}"…`);
+      setStatus(`Recording ${action.replace('_', ' ')} for "${submission.title}"…`);
+
+      const targetInventoryId = Number(formData.get('target_inventory_id') || 0);
+      const retentionReason = options.retentionReason ?? String(formData.get('retention_reason') || '');
+      const purgeEligibleAt = String(formData.get('purge_eligible_at') || '');
 
       const result = await adminJson<{ ok: true }>('/api/admin/editorial/review', {
         method: 'POST',
@@ -104,13 +142,18 @@ export default function AdminEditorialArchivePage() {
           submission_id: submission.submission_id,
           action,
           tag: String(formData.get('tag') || submission.proposed_tag || ''),
-          source_name: String(formData.get('source_name') || 'Member submission'),
+          source_name: String(formData.get('source_name') || submission.source_name || 'Member submission'),
           source_url: String(formData.get('source_url') || submission.source_url || ''),
-          credit_line: String(formData.get('credit_line') || submission.submitted_by || ''),
+          credit_line: String(formData.get('credit_line') || submission.credit_line || submission.submitted_by || ''),
           story_type: String(formData.get('story_type') || 'brief'),
           allowed_sections: ['library'],
           priority: Number(formData.get('priority') || 0),
           review_notes: String(formData.get('review_notes') || ''),
+          triage_flags: String(formData.get('triage_flags') || '[]'),
+          duplicate_candidate: String(formData.get('duplicate_candidate') || ''),
+          retention_reason: retentionReason,
+          purge_eligible_at: retentionReason ? '' : purgeEligibleAt,
+          target_inventory_id: Number.isFinite(targetInventoryId) ? targetInventoryId : 0,
         }),
       });
 
@@ -119,7 +162,7 @@ export default function AdminEditorialArchivePage() {
         return;
       }
 
-      setStatus(action === 'approve' ? 'Approved into content inventory draft.' : 'Rejected submission.');
+      setStatus(`Submission workflow action recorded: ${action.replace('_', ' ')}.`);
       await load();
     },
     [load],
@@ -162,17 +205,31 @@ export default function AdminEditorialArchivePage() {
           <button type="button" onClick={() => void load()} disabled={loading} style={buttonStyle(loading)}>
             {loading ? 'Loading…' : 'Refresh'}
           </button>
+          <label style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            Queue status
+            <select
+              value={submissionFilter}
+              onChange={(event) => setSubmissionFilter(event.target.value as SubmissionFilter)}
+              style={{ ...fieldStyle(), width: 'auto' }}
+            >
+              {SUBMISSION_FILTERS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
           <span style={{ opacity: 0.85 }}>{status}</span>
         </div>
 
         <section style={{ border: '1px solid rgba(0,0,0,0.12)', borderRadius: 14, padding: 14 }}>
           <h2 style={{ marginTop: 0 }}>Submission Review Queue</h2>
           <p style={{ opacity: 0.8 }}>
-            Pending member submissions stay here until a human approves or rejects them.
+            Member submissions stay here until a human triages, reviews, approves, merges, rejects, retains, or purges them.
           </p>
 
           {submissions.length === 0 ? (
-            <p>No pending submissions.</p>
+            <p>No {submissionFilter} submissions.</p>
           ) : (
             <div style={{ display: 'grid', gap: 14 }}>
               {submissions.map((submission) => (
@@ -249,9 +306,16 @@ export default function AdminEditorialArchivePage() {
 
 function SubmissionCard(props: {
   submission: Submission;
-  onReview: (submission: Submission, action: 'approve' | 'reject', form: HTMLFormElement) => Promise<void>;
+  onReview: (
+    submission: Submission,
+    action: ReviewAction,
+    form: HTMLFormElement,
+    options?: { retentionReason?: string },
+  ) => Promise<void>;
 }) {
   const { submission, onReview } = props;
+  const canPurge = submission.status === 'rejected' && !submission.retention_reason;
+  const retainedDefault = submission.retention_reason || 'Retained for editorial follow-up.';
 
   return (
     <form
@@ -261,11 +325,26 @@ function SubmissionCard(props: {
       <div>
         <h3 style={{ margin: 0 }}>{submission.title}</h3>
         <div style={{ opacity: 0.75, fontSize: 13 }}>
-          submitted by {submission.submitted_by} · {submission.created_at || 'date unavailable'}
+          submitted by {submission.submitted_by} · status: {submission.status} · {submission.created_at || 'date unavailable'}
         </div>
       </div>
 
       <p style={{ whiteSpace: 'pre-wrap', margin: 0 }}>{submission.description}</p>
+      <div style={{ opacity: 0.78, fontSize: 13 }}>
+        source: {submission.source_name || '—'} · credit: {submission.credit_line || '—'} · media:{' '}
+        {submission.media_reference || submission.media_url || '—'}
+      </div>
+      {(submission.duplicate_candidate ||
+        submission.triage_flags ||
+        submission.decision_at ||
+        submission.purge_eligible_at ||
+        submission.retention_reason) && (
+        <div style={{ opacity: 0.78, fontSize: 13 }}>
+          duplicate: {submission.duplicate_candidate || '—'} · triage: {submission.triage_flags || '[]'} · decision:{' '}
+          {submission.decision_by || '—'} {submission.decision_at || ''} · purge eligible:{' '}
+          {submission.purge_eligible_at || '—'} · retention: {submission.retention_reason || '—'}
+        </div>
+      )}
 
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10 }}>
         <label style={{ display: 'grid', gap: 6 }}>
@@ -274,7 +353,7 @@ function SubmissionCard(props: {
         </label>
         <label style={{ display: 'grid', gap: 6 }}>
           Source name
-          <input name="source_name" defaultValue="Member submission" style={fieldStyle()} />
+          <input name="source_name" defaultValue={submission.source_name || 'Member submission'} style={fieldStyle()} />
         </label>
         <label style={{ display: 'grid', gap: 6 }}>
           Source URL
@@ -282,7 +361,7 @@ function SubmissionCard(props: {
         </label>
         <label style={{ display: 'grid', gap: 6 }}>
           Credit line
-          <input name="credit_line" defaultValue={submission.submitted_by} style={fieldStyle()} />
+          <input name="credit_line" defaultValue={submission.credit_line || submission.submitted_by} style={fieldStyle()} />
         </label>
         <label style={{ display: 'grid', gap: 6 }}>
           Story type
@@ -296,14 +375,48 @@ function SubmissionCard(props: {
           Priority
           <input name="priority" type="number" defaultValue={0} style={fieldStyle()} />
         </label>
+        <label style={{ display: 'grid', gap: 6 }}>
+          Duplicate candidate / merge target note
+          <input name="duplicate_candidate" defaultValue={submission.duplicate_candidate || ''} style={fieldStyle()} />
+        </label>
+        <label style={{ display: 'grid', gap: 6 }}>
+          Target inventory ID for merge
+          <input name="target_inventory_id" type="number" min={1} style={fieldStyle()} />
+        </label>
+        <label style={{ display: 'grid', gap: 6 }}>
+          Purge eligible at
+          <input name="purge_eligible_at" placeholder="YYYY-MM-DD or ISO timestamp" style={fieldStyle()} />
+        </label>
       </div>
 
       <label style={{ display: 'grid', gap: 6 }}>
         Review notes
         <textarea name="review_notes" rows={3} style={fieldStyle()} />
       </label>
+      <label style={{ display: 'grid', gap: 6 }}>
+        Objective triage flags JSON
+        <textarea name="triage_flags" rows={2} defaultValue={submission.triage_flags || '[]'} style={fieldStyle()} />
+      </label>
+      <label style={{ display: 'grid', gap: 6 }}>
+        Retention reason
+        <textarea name="retention_reason" rows={2} defaultValue={submission.retention_reason || ''} style={fieldStyle()} />
+      </label>
 
       <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+        <button
+          type="button"
+          onClick={(event) => void onReview(submission, 'triage', event.currentTarget.form as HTMLFormElement)}
+          style={buttonStyle()}
+        >
+          Mark Triaged
+        </button>
+        <button
+          type="button"
+          onClick={(event) => void onReview(submission, 'start_review', event.currentTarget.form as HTMLFormElement)}
+          style={buttonStyle()}
+        >
+          Start Review
+        </button>
         <button
           type="button"
           onClick={(event) => void onReview(submission, 'approve', event.currentTarget.form as HTMLFormElement)}
@@ -313,10 +426,36 @@ function SubmissionCard(props: {
         </button>
         <button
           type="button"
+          onClick={(event) => void onReview(submission, 'merge', event.currentTarget.form as HTMLFormElement)}
+          style={buttonStyle()}
+        >
+          Mark Merged
+        </button>
+        <button
+          type="button"
           onClick={(event) => void onReview(submission, 'reject', event.currentTarget.form as HTMLFormElement)}
           style={buttonStyle()}
         >
-          Reject
+          Reject + Purge Eligible
+        </button>
+        <button
+          type="button"
+          onClick={(event) =>
+            void onReview(submission, 'reject', event.currentTarget.form as HTMLFormElement, {
+              retentionReason: retainedDefault,
+            })
+          }
+          style={buttonStyle()}
+        >
+          Retain Rejected
+        </button>
+        <button
+          type="button"
+          onClick={(event) => void onReview(submission, 'purge', event.currentTarget.form as HTMLFormElement)}
+          disabled={!canPurge}
+          style={buttonStyle(!canPurge)}
+        >
+          Mark Purged
         </button>
       </div>
     </form>

--- a/src/app/admin/editorial/page.tsx
+++ b/src/app/admin/editorial/page.tsx
@@ -89,6 +89,10 @@ function buttonStyle(disabled = false): React.CSSProperties {
   };
 }
 
+function defaultCreditFromSubmitter(value: string): string {
+  return value.includes('<') ? value.split('<')[0].trim() : value;
+}
+
 export default function AdminEditorialArchivePage() {
   const [status, setStatus] = useState('Idle.');
   const [loading, setLoading] = useState(false);
@@ -133,7 +137,7 @@ export default function AdminEditorialArchivePage() {
       setStatus(`Recording ${action.replace('_', ' ')} for "${submission.title}"…`);
 
       const targetInventoryId = Number(formData.get('target_inventory_id') || 0);
-      const retentionReason = options.retentionReason ?? String(formData.get('retention_reason') || '');
+      const retentionReason = String(formData.get('retention_reason') || '').trim() || options.retentionReason || '';
       const purgeEligibleAt = String(formData.get('purge_eligible_at') || '');
 
       const result = await adminJson<{ ok: true }>('/api/admin/editorial/review', {
@@ -144,7 +148,12 @@ export default function AdminEditorialArchivePage() {
           tag: String(formData.get('tag') || submission.proposed_tag || ''),
           source_name: String(formData.get('source_name') || submission.source_name || 'Member submission'),
           source_url: String(formData.get('source_url') || submission.source_url || ''),
-          credit_line: String(formData.get('credit_line') || submission.credit_line || submission.submitted_by || ''),
+          credit_line: String(
+            formData.get('credit_line') ||
+              submission.credit_line ||
+              defaultCreditFromSubmitter(submission.submitted_by) ||
+              '',
+          ),
           story_type: String(formData.get('story_type') || 'brief'),
           allowed_sections: ['library'],
           priority: Number(formData.get('priority') || 0),
@@ -314,7 +323,7 @@ function SubmissionCard(props: {
   ) => Promise<void>;
 }) {
   const { submission, onReview } = props;
-  const canPurge = submission.status === 'rejected' && !submission.retention_reason;
+  const canPurge = submission.status === 'rejected' && !String(submission.retention_reason || '').trim();
   const retainedDefault = submission.retention_reason || 'Retained for editorial follow-up.';
 
   return (
@@ -361,7 +370,11 @@ function SubmissionCard(props: {
         </label>
         <label style={{ display: 'grid', gap: 6 }}>
           Credit line
-          <input name="credit_line" defaultValue={submission.credit_line || submission.submitted_by} style={fieldStyle()} />
+          <input
+            name="credit_line"
+            defaultValue={submission.credit_line || defaultCreditFromSubmitter(submission.submitted_by)}
+            style={fieldStyle()}
+          />
         </label>
         <label style={{ display: 'grid', gap: 6 }}>
           Story type
@@ -391,7 +404,7 @@ function SubmissionCard(props: {
 
       <label style={{ display: 'grid', gap: 6 }}>
         Review notes
-        <textarea name="review_notes" rows={3} style={fieldStyle()} />
+        <textarea name="review_notes" rows={3} defaultValue={submission.review_notes || ''} style={fieldStyle()} />
       </label>
       <label style={{ display: 'grid', gap: 6 }}>
         Objective triage flags JSON

--- a/tests/admin-editorial-archive.test.tsx
+++ b/tests/admin-editorial-archive.test.tsx
@@ -119,7 +119,9 @@ function makeEditorialDb(options?: {
           return tableNames.includes(table) ? { name: table } : null;
         }
         if (sql.includes('FROM member_sessions')) return { email: sessionEmail };
-        if (sql.includes("SELECT datetime('now')")) return { now: '2026-06-02T12:00:00Z' };
+        if (sql.includes("SELECT datetime('now')")) {
+          return { now: '2026-06-02T12:00:00Z', purge_eligible_at: '2026-08-31T12:00:00Z' };
+        }
         if (sql.includes('COUNT(1)') && sql.includes('FROM content_inventory')) {
           return { n: filterRows(sql, inventory, args).length };
         }
@@ -281,6 +283,99 @@ describe('admin editorial archive page', () => {
     });
   });
 
+  it('uses submitter names without email addresses as default credit values', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        ok: true,
+        submissions: [
+          {
+            submission_id: 11,
+            submitted_by: 'Member Name <member@example.com>',
+            title: 'PII-safe credit',
+            description: 'A queue item with submitter email hidden from credit defaults.',
+            proposed_tag: 'pii-safe-credit',
+            status: 'pending',
+          },
+        ],
+        inventory: [],
+      }),
+    );
+
+    render(<AdminEditorialArchivePage />);
+
+    await screen.findByRole('heading', { name: 'PII-safe credit' });
+    expect(screen.getByDisplayValue('Member Name')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Member Name <member@example.com>')).not.toBeInTheDocument();
+  });
+
+  it('preserves existing review notes in the queue form', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        ok: true,
+        submissions: [
+          {
+            submission_id: 12,
+            submitted_by: 'Member <member@example.com>',
+            title: 'Existing notes',
+            description: 'A queue item with notes.',
+            proposed_tag: 'existing-notes',
+            status: 'triaged',
+            review_notes: 'Existing editorial note.',
+          },
+        ],
+        inventory: [],
+      }),
+    );
+
+    render(<AdminEditorialArchivePage />);
+
+    await screen.findByRole('heading', { name: 'Existing notes' });
+    expect(screen.getByDisplayValue('Existing editorial note.')).toBeInTheDocument();
+  });
+
+  it('prefers custom retention reasons typed by editors', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const path = String(input);
+      if (path.startsWith('/api/admin/editorial/list')) {
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            submissions: [
+              {
+                submission_id: 13,
+                submitted_by: 'Member <member@example.com>',
+                title: 'Retain with custom reason',
+                description: 'A queue item that should be retained.',
+                proposed_tag: 'retain-custom',
+                status: 'pending',
+              },
+            ],
+            inventory: [],
+          }),
+        );
+      }
+      expect(path).toBe('/api/admin/editorial/review');
+      expect(init?.method).toBe('POST');
+      return Promise.resolve(jsonResponse({ ok: true }));
+    });
+
+    render(<AdminEditorialArchivePage />);
+
+    await screen.findByRole('heading', { name: 'Retain with custom reason' });
+    fireEvent.change(screen.getByLabelText('Retention reason'), {
+      target: { value: 'Custom legal hold.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Retain Rejected' }));
+
+    await waitFor(() => {
+      const reviewCall = fetchMock.mock.calls.find(([path]) => path === '/api/admin/editorial/review');
+      expect(JSON.parse(String(reviewCall?.[1]?.body))).toMatchObject({
+        action: 'reject',
+        retention_reason: 'Custom legal hold.',
+      });
+    });
+  });
+
   it('records triage actions from the review queue', async () => {
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
       const path = String(input);
@@ -437,6 +532,32 @@ describe('editorial archive APIs', () => {
     expect(runs.some((run) => run.sql.includes('decision_at'))).toBe(false);
   });
 
+  it('does not move under-review submissions backward to triaged', async () => {
+    const { db, runs } = makeEditorialDb({
+      submissions: [
+        {
+          submission_id: 7,
+          submitted_by: 'Member <member@example.com>',
+          title: 'Submitted story',
+          description: 'Story text for editorial review.',
+          proposed_tag: 'submitted-story',
+          status: 'under_review',
+        },
+      ],
+    });
+
+    const response = await editorialReviewPost({
+      request: adminPostRequest('/api/admin/editorial/review', {
+        submission_id: 7,
+        action: 'triage',
+      }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(409);
+    expect(runs.some((run) => run.sql.includes("status = 'triaged'"))).toBe(false);
+  });
+
   it('merges reviewed submissions into an existing content_inventory record', async () => {
     const { db, runs } = makeEditorialDb({
       submissions: [
@@ -503,7 +624,7 @@ describe('editorial archive APIs', () => {
     });
     const updateRun = runs.find((run) => run.sql.includes("status = 'rejected'"));
     expect(updateRun?.args[2]).toBeNull();
-    expect(updateRun?.args[4]).toBe('2026-06-02T12:00:00Z');
+    expect(updateRun?.args[4]).toBe('2026-08-31T12:00:00Z');
     expect(updateRun?.args[5]).toBe(1);
   });
 
@@ -595,6 +716,35 @@ describe('editorial archive APIs', () => {
     expect(response.status).toBe(200);
     const insertRun = runs.find((run) => run.sql.includes('INSERT INTO content_inventory'));
     expect(insertRun?.args[15]).toBeNull();
+  });
+
+  it('uses submitter names without email addresses as server-side default credit lines', async () => {
+    const { db, runs } = makeEditorialDb({
+      submissions: [
+        {
+          submission_id: 7,
+          submitted_by: 'Member Name <member@example.com>',
+          title: 'Submitted story',
+          description: 'Story text for editorial review.',
+          proposed_tag: 'submitted-story',
+          status: 'pending',
+        },
+      ],
+    });
+
+    const response = await editorialReviewPost({
+      request: adminPostRequest('/api/admin/editorial/review', {
+        submission_id: 7,
+        action: 'approve',
+        source_name: 'Member interview',
+      }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    const insertRun = runs.find((run) => run.sql.includes('INSERT INTO content_inventory'));
+    expect(insertRun?.args[9]).not.toContain('member@example.com');
+    expect(insertRun?.args[13]).toBe('Member Name');
   });
 
   it('updates publication state for archive records', async () => {

--- a/tests/admin-editorial-archive.test.tsx
+++ b/tests/admin-editorial-archive.test.tsx
@@ -8,6 +8,7 @@ import { onRequestPost as editorialReviewPost } from '../functions/api/admin/edi
 import { onRequestPost as editorialPublishPost } from '../functions/api/admin/editorial/publish';
 import { onRequestPost as librarySubmitPost } from '../functions/api/library/submit';
 import { onRequestGet as fanclubLibraryGet } from '../functions/api/fanclub/library';
+import { onRequestGet as searchGet } from '../functions/api/search';
 
 const mockUsePathname = vi.hoisted(() => vi.fn(() => '/admin/editorial'));
 
@@ -92,6 +93,13 @@ function makeEditorialDb(options?: {
     return filtered;
   }
 
+  function filterSubmissions(sql: string, rows: Array<Record<string, unknown>>, args: unknown[]) {
+    if (sql.includes('WHERE status = ?') && typeof args[0] === 'string') {
+      return rows.filter((row) => row.status === args[0]);
+    }
+    return rows;
+  }
+
   const db = {
     prepare: vi.fn((sql: string) => {
       const allFn = async (args: unknown[] = []) => {
@@ -99,7 +107,7 @@ function makeEditorialDb(options?: {
           const requested = args.length ? tableNames.filter((name) => args.includes(name)) : tableNames;
           return { results: requested.map((name) => ({ name })) };
         }
-        if (sql.includes('FROM submission_queue')) return { results: submissions };
+        if (sql.includes('FROM submission_queue')) return { results: filterSubmissions(sql, submissions, args) };
         if (sql.includes('FROM content_inventory')) return { results: filterRows(sql, inventory, args) };
         if (sql.includes('FROM library_entries')) return { results: filterRows(sql, library, args) };
         return { results: [] };
@@ -118,7 +126,13 @@ function makeEditorialDb(options?: {
         if (sql.includes('COUNT(1)') && sql.includes('FROM library_entries')) {
           return { n: filterRows(sql, library, args).length };
         }
+        if (sql.includes('FROM submission_queue') && sql.includes('WHERE submission_id = ?')) {
+          return submissions.find((row) => row.submission_id === args[0]) ?? null;
+        }
         if (sql.includes('FROM submission_queue')) return submissions[0] ?? null;
+        if (sql.includes('FROM content_inventory') && sql.includes('WHERE id = ?')) {
+          return inventory.find((row) => row.id === args[0]) ?? null;
+        }
         if (sql.includes('FROM content_inventory')) return inventory[0] ?? null;
         return null;
       };
@@ -191,7 +205,7 @@ describe('admin editorial archive page', () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      '/api/admin/editorial/list?limit=100',
+      '/api/admin/editorial/list?limit=100&submission_status=pending',
       expect.objectContaining({ cache: 'no-store' }),
     );
   });
@@ -235,6 +249,76 @@ describe('admin editorial archive page', () => {
         action: 'approve',
         tag: 'gehrig-memory',
         allowed_sections: ['library'],
+      });
+    });
+  });
+
+  it('loads queue records by selected submission status', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        ok: true,
+        submissions: [],
+        inventory: [],
+      }),
+    );
+
+    render(<AdminEditorialArchivePage />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/admin/editorial/list?limit=100&submission_status=pending',
+        expect.objectContaining({ cache: 'no-store' }),
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText('Queue status'), { target: { value: 'rejected' } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/admin/editorial/list?limit=100&submission_status=rejected',
+        expect.objectContaining({ cache: 'no-store' }),
+      );
+    });
+  });
+
+  it('records triage actions from the review queue', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const path = String(input);
+      if (path.startsWith('/api/admin/editorial/list')) {
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            submissions: [
+              {
+                submission_id: 10,
+                submitted_by: 'Member <member@example.com>',
+                title: 'Possible duplicate',
+                description: 'A queue item that needs objective triage.',
+                proposed_tag: 'possible-duplicate',
+                status: 'pending',
+              },
+            ],
+            inventory: [],
+          }),
+        );
+      }
+      expect(path).toBe('/api/admin/editorial/review');
+      expect(init?.method).toBe('POST');
+      return Promise.resolve(jsonResponse({ ok: true }));
+    });
+
+    render(<AdminEditorialArchivePage />);
+
+    await screen.findByRole('heading', { name: 'Possible duplicate' });
+    fireEvent.click(screen.getByRole('button', { name: 'Mark Triaged' }));
+
+    await waitFor(() => {
+      const reviewCall = fetchMock.mock.calls.find(([path]) => path === '/api/admin/editorial/review');
+      expect(reviewCall).toBeDefined();
+      expect(JSON.parse(String(reviewCall?.[1]?.body))).toMatchObject({
+        submission_id: 10,
+        action: 'triage',
+        triage_flags: '[]',
       });
     });
   });
@@ -314,6 +398,173 @@ describe('editorial archive APIs', () => {
       ]),
     );
     expect(runs.some((run) => run.sql.includes("status = 'approved'"))).toBe(true);
+  });
+
+  it('triages pending submissions with objective flags without a factual decision', async () => {
+    const { db, runs } = makeEditorialDb({
+      submissions: [
+        {
+          submission_id: 7,
+          submitted_by: 'Member <member@example.com>',
+          title: 'Submitted story',
+          description: 'Story text for editorial review.',
+          proposed_tag: 'submitted-story',
+          status: 'pending',
+        },
+      ],
+    });
+
+    const response = await editorialReviewPost({
+      request: adminPostRequest('/api/admin/editorial/review', {
+        submission_id: 7,
+        action: 'triage',
+        triage_flags: ['missing_source'],
+        duplicate_candidate: 'submitted-story',
+        review_notes: 'Needs source follow-up.',
+      }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      action: 'triage',
+    });
+    const updateRun = runs.find((run) => run.sql.includes("status = 'triaged'"));
+    expect(updateRun?.args).toEqual(
+      expect.arrayContaining(['["missing_source"]', 'submitted-story', 'Needs source follow-up.']),
+    );
+    expect(runs.some((run) => run.sql.includes('decision_at'))).toBe(false);
+  });
+
+  it('merges reviewed submissions into an existing content_inventory record', async () => {
+    const { db, runs } = makeEditorialDb({
+      submissions: [
+        {
+          submission_id: 8,
+          submitted_by: 'Member <member@example.com>',
+          title: 'Submitted merge detail',
+          description: 'Additional detail for the existing story.',
+          proposed_tag: 'existing-story',
+          status: 'under_review',
+        },
+      ],
+      inventory: [{ id: 22, title: 'Existing story', review_notes: 'Existing note', search_text: 'existing story' }],
+    });
+
+    const response = await editorialReviewPost({
+      request: adminPostRequest('/api/admin/editorial/review', {
+        submission_id: 8,
+        action: 'merge',
+        target_inventory_id: 22,
+        duplicate_candidate: 'existing-story',
+        review_notes: 'Merged useful source detail.',
+      }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      action: 'merge',
+      inventory_id: 22,
+    });
+    expect(runs.some((run) => run.sql.includes('UPDATE content_inventory'))).toBe(true);
+    expect(runs.some((run) => run.sql.includes("status = 'merged'"))).toBe(true);
+  });
+
+  it('rejects submissions with purge eligibility metadata', async () => {
+    const { db, runs } = makeEditorialDb({
+      submissions: [
+        {
+          submission_id: 9,
+          submitted_by: 'Member <member@example.com>',
+          title: 'Rejected story',
+          description: 'Rejected text.',
+          proposed_tag: 'rejected-story',
+          status: 'triaged',
+        },
+      ],
+    });
+
+    const response = await editorialReviewPost({
+      request: adminPostRequest('/api/admin/editorial/review', {
+        submission_id: 9,
+        action: 'reject',
+        review_notes: 'Out of scope after human review.',
+      }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      action: 'reject',
+    });
+    const updateRun = runs.find((run) => run.sql.includes("status = 'rejected'"));
+    expect(updateRun?.args[2]).toBeNull();
+    expect(updateRun?.args[4]).toBe('2026-06-02T12:00:00Z');
+    expect(updateRun?.args[5]).toBe(1);
+  });
+
+  it('retains rejected submissions without marking them purge eligible', async () => {
+    const { db, runs } = makeEditorialDb({
+      submissions: [
+        {
+          submission_id: 10,
+          submitted_by: 'Member <member@example.com>',
+          title: 'Retained story',
+          description: 'Rejected but retained text.',
+          status: 'under_review',
+        },
+      ],
+    });
+
+    const response = await editorialReviewPost({
+      request: adminPostRequest('/api/admin/editorial/review', {
+        submission_id: 10,
+        action: 'reject',
+        retention_reason: 'Retained for source follow-up.',
+      }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    const updateRun = runs.find((run) => run.sql.includes("status = 'rejected'"));
+    expect(updateRun?.args[2]).toBe('Retained for source follow-up.');
+    expect(updateRun?.args[4]).toBeNull();
+    expect(updateRun?.args[5]).toBe(0);
+  });
+
+  it('marks eligible rejected submissions as purged without deleting the audit row', async () => {
+    const { db, runs } = makeEditorialDb({
+      submissions: [
+        {
+          submission_id: 11,
+          submitted_by: 'Member <member@example.com>',
+          title: 'Purge-ready story',
+          description: 'Purge-ready text.',
+          status: 'rejected',
+          retention_reason: '',
+        },
+      ],
+    });
+
+    const response = await editorialReviewPost({
+      request: adminPostRequest('/api/admin/editorial/review', {
+        submission_id: 11,
+        action: 'purge',
+        review_notes: 'Quarterly purge complete.',
+      }),
+      env: { ADMIN_TOKEN: 'secret', DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      action: 'purge',
+    });
+    expect(runs.some((run) => run.sql.includes("status = 'purged'"))).toBe(true);
   });
 
   it('does not coerce blank event_year values to zero', async () => {
@@ -402,7 +653,9 @@ describe('member submissions and library archive reads', () => {
       ok: true,
       message: 'Submission queued for editorial review',
     });
-    expect(runs.some((run) => run.sql.includes('INSERT INTO submission_queue'))).toBe(true);
+    const insertRun = runs.find((run) => run.sql.includes('INSERT INTO submission_queue'));
+    expect(insertRun).toBeDefined();
+    expect(insertRun?.args[1]).toContain('"title":"A long submitted story"');
   });
 
   it('returns only published content_inventory records for member library reads', async () => {
@@ -541,5 +794,39 @@ describe('member submissions and library archive reads', () => {
       total: 0,
       items: [],
     });
+  });
+
+  it('does not expose queue records through member search results', async () => {
+    const { db } = makeEditorialDb({
+      submissions: [
+        {
+          submission_id: 12,
+          submitted_by: 'Member <member@example.com>',
+          title: 'Hidden queue record',
+          description: 'This under-review queue text must not appear in search.',
+          status: 'under_review',
+        },
+        {
+          submission_id: 13,
+          submitted_by: 'Member <member@example.com>',
+          title: 'Rejected queue record',
+          description: 'This rejected queue text must not appear in search.',
+          status: 'rejected',
+        },
+      ],
+    });
+
+    const response = await searchGet({
+      request: memberRequest('/api/search?q=queue'),
+      env: { DB: db },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      total: 0,
+      results: [],
+    });
+    expect(db.prepare).not.toHaveBeenCalledWith(expect.stringContaining('submission_queue'));
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

- **Issue:** #1401

## CHANGE SUMMARY
- Added a forward-only `submission_queue` migration for approved review states, raw payload, triage, decision, rejection, purge, and retention metadata.
- Updated member submission intake and admin editorial list/review APIs for triage, under-review, approve, merge, reject, retain, and purge transitions.
- Added admin editorial queue controls for status filtering and manual workflow actions.
- Added targeted regression coverage for queue states and public search exclusion.

## REVIEWER RESPONSE ACCOUNTING
- [ ] Reviewed all reviewer comments.
- [ ] Reviewed all bot comments.
- [ ] Reviewed all GitHub review threads.
- [ ] Copilot disposition received or not applicable.
- [ ] Codex disposition received or not applicable.
- [ ] Gemini disposition received or not applicable.
- [ ] Every actionable reviewer comment has a PR-body disposition.
- [ ] Every non-actionable reviewer comment is explicitly marked non-actionable with reason.
- [ ] GitHub review threads resolved or intentionally left unresolved with reason.
- [x] No out-of-scope file changes.
- [ ] All actionable reviewer and bot feedback is resolved or explicitly dispositioned.
- [ ] PR is ready for human review.
- [ ] Post-merge source issue closure is complete; tracker/status-index follow-up is complete only when explicitly authorized by the source issue.

## CURRENT REVIEWER BLOCKERS

PR #1431 is not ready for merge review. Open reviewer threads still require source changes and/or explicit dispositions:

1. Prevent `submitted_by` email exposure in default public `credit_line` values.
2. Preserve existing `review_notes` in the admin UI by loading them into the textarea.
3. Prioritize custom retention reason input over the default retained reason.
4. Trim retention reason in UI logic so whitespace does not diverge from API behavior.
5. Validate optional purge date input instead of storing invalid date strings.
6. Prevent backwards `under_review` to `triaged` transitions.
7. Correct test stub/default assertions for `purge_eligible_at` using the +90-day default.
8. Correct migration `decision_at` fallback for legacy rejected rows with null `reviewed_at`.

## PROGRESS + READINESS
- Phase: Program 2 / Task 003
- Task: Submission workflow implementation delta
- Status: DRAFT — reviewer remediation required
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO based on current changed-file inspection
- Blocking Issues: unresolved reviewer threads remain open on current head

## PR GATE READINESS CHECKLIST
- [ ] PR is in GitHub Ready for Review state (`isDraft: false`).
- [x] Live PR check panel inspected.
- [x] Commit-level workflow runs inspected.
- [x] Latest-head gates are green based on inspected workflow runs.
- [ ] All reviewer feedback has both textual disposition and GitHub thread-state disposition.
- [x] No merge-readiness claim made before all gate surfaces inspected.
- [ ] Status is set to READY FOR REVIEW only after all required gates and reviewer-response obligations are complete on latest head.

<!-- CURSOR_AGENT_PR_BODY_END -->