### PR TITLE
ops: close superseded PR #1492 via one-shot workflow

### DIFF
--- a/.github/workflows/ops-close-superseded-pr-1492.yml
+++ b/.github/workflows/ops-close-superseded-pr-1492.yml
@@ -1,0 +1,50 @@
+name: OPS — Close Superseded PR #1492
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/ops-close-superseded-pr-1492.yml
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  close-superseded-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close PR #1492 superseded by merged PR #1491
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = 1492;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+
+            if (pr.state === 'closed') {
+              core.info(`PR #${prNumber} is already closed.`);
+              return;
+            }
+
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: prNumber,
+              state: 'closed',
+            });
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body: [
+                'Superseded by PR #1491 (merged 2026-06-09), which consolidated post-merge closeout remediation for PRs #1472, #1486, and #1489.',
+                '',
+                'Closed automatically by `ops-close-superseded-pr-1492.yml`.',
+              ].join('\n'),
+            });
+
+            core.info(`Closed superseded PR #${prNumber}.`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #1500

## PRE-OPEN GATE PREFLIGHT (MANDATORY)
- [x] Confirm exactly one same-repository, open, non-PR source issue exists.
- [x] Confirm one accepted issue-accounting line is present before opening or updating the PR.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root

## QUEUE / DEPENDENCY MAP STATUS
- Dependency-map result: not-applicable
- Next queue item: not-applicable
- Continue/halt decision: not-applicable — one-shot ops housekeeping

## PROGRESS + READINESS (MANDATORY)
- Phase: Post-merge closeout housekeeping
- Task: Close duplicate PR #1492 superseded by merged #1491
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: none

## DOCUMENTATION SOURCE (MANDATORY)
- [ ] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [x] LEGACY_FALLBACK

## LABEL
- Intent label for this PR: change-ops

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical closeout protocol: `/docs/ops/pmo/github-issue-closeout-protocol.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `.github/workflows/ops-close-superseded-pr-1492.yml`

All other files are out of scope

## CHANGE SUMMARY
- Add one-shot workflow that closes PR #1492 (duplicate post-merge closeout branch superseded by merged PR #1491).
- Workflow is idempotent: no-op if #1492 is already closed.
- Runs automatically on merge to `main` (push path trigger) or via `workflow_dispatch`.

## BUILD / TEST / VERIFICATION
- Workflow YAML syntax validated locally.
- Idempotent close logic reviewed (checks `pr.state === 'closed'` before update).
- Cloud agent token cannot close PRs directly (`Resource not accessible by integration`); branch `cursor/post-merge-closeout-1472-1489-f838` already deleted.

## ACCEPTANCE CRITERIA
- [x] Workflow file scoped to single allowlisted path
- [x] On merge, workflow closes PR #1492 with superseded-by-#1491 comment
- [x] No runtime or closeout manifest changes

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches final diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed

## POST-MERGE ISSUE DISPOSITION
- No source issue mutation required for #1500; this is housekeeping under the closeout reliability program.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86303df9-b4e2-4d0d-8910-a5fc8900f838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86303df9-b4e2-4d0d-8910-a5fc8900f838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-shot GitHub Actions workflow to automatically close superseded PR #1492, which was replaced by merged #1491. This prevents duplicate post-merge closeout.

- **New Features**
  - Adds `.github/workflows/ops-close-superseded-pr-1492.yml` using `actions/github-script@v7`.
  - Triggers on push to `main` (path-scoped) and `workflow_dispatch`.
  - Idempotent: skips if #1492 is already closed and adds a “superseded by #1491” comment on close.

<sup>Written for commit 6ef364c5039cb23297e55a1ef2b9454bb9a1557c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

