### PR TITLE
fix: reconcile #1404 labels when only optional post-merge workflows fail

### DIFF
--- a/scripts/ci/post-merge-closeout/targets-ci-pending-rerun.json
+++ b/scripts/ci/post-merge-closeout/targets-ci-pending-rerun.json
@@ -1,5 +1,5 @@
 {
-  "triggered_at": "2026-06-09T18:15:00Z",
+  "triggered_at": "2026-06-09T18:25:00Z",
   "targets": [
     {
       "pr": 1472,

--- a/scripts/ci/post_merge_validator.mjs
+++ b/scripts/ci/post_merge_validator.mjs
@@ -355,9 +355,7 @@ export function buildResult({
 		reviewerDispositionFailures.length +
 		requiredWorkflowFailures.length;
 	const status = blockingFailureCount === 0 ? 'pass' : 'fail';
-	const remediationWorkflowFailures = failures.filter(
-		(failure) => failure.required || failure.classification !== 'optional-remediation-failure',
-	);
+	const remediationWorkflowFailures = failures.filter((failure) => failure.required);
 	const remediationRequired =
 		blockingMetadata.length > 0 ||
 		implementation.length > 0 ||

--- a/tests/post-merge-source-issue-closeout.test.mjs
+++ b/tests/post-merge-source-issue-closeout.test.mjs
@@ -128,23 +128,23 @@ describe('source issue closeout decision', () => {
 			resolution: { pr: '1239' },
 			failures: [
 				{
-					workflow: 'Auto-Sync Documentation',
-					classification: 'secret-access/configuration',
-					required: false,
+					workflow: 'GATE — Reviewer Response Completion',
+					classification: 'optional-remediation-failure',
+					required: true,
 					conclusion: 'failure',
 				},
 			],
 		});
 
-		expect(result).toMatchObject({ status: 'pass', sync_action: 'post_merge_remediation', remediation_required: true });
+		expect(result).toMatchObject({ status: 'fail', sync_action: 'post_merge_failure', remediation_required: true });
 		expect(
 			shouldCloseSourceIssue({
-				action: 'post_merge_remediation',
+				action: 'post_merge_failure',
 				issueNumber: '1196',
 				isMerged: true,
 				postMergeResult: result,
 			}),
-		).toMatchObject({ close: false, reason: 'action_post_merge_remediation' });
+		).toMatchObject({ close: false, reason: 'action_post_merge_failure' });
 	});
 
 	it('does not close when the linked issue cannot be identified', () => {

--- a/tests/post-merge-validator.test.mjs
+++ b/tests/post-merge-validator.test.mjs
@@ -260,7 +260,7 @@ describe('post-merge workflow failure classification', () => {
 		const result = buildResult({ pr: mergedPr(), resolution: { pr: '1188' }, failures });
 
 		expect(failures[0]).toMatchObject({ required: false, classification: 'secret-access/configuration' });
-		expect(result).toMatchObject({ status: 'pass', remediation_required: true, sync_action: 'post_merge_remediation' });
+		expect(result).toMatchObject({ status: 'pass', remediation_required: false, sync_action: 'post_merge_success' });
 	});
 });
 
@@ -271,9 +271,9 @@ describe('post-merge structured output and remediation body', () => {
 			resolution: { pr: '1188' },
 			failures: [
 				{
-					workflow: 'Auto-Sync Documentation',
-					classification: 'secret-access/configuration',
-					required: false,
+					workflow: 'GATE — Quality Checks',
+					classification: 'required-workflow-failure',
+					required: true,
 					url: 'https://github.test/actions/2',
 					conclusion: 'failure',
 				},
@@ -282,7 +282,7 @@ describe('post-merge structured output and remediation body', () => {
 		});
 
 		expect(result).toMatchObject({
-			status: 'pass',
+			status: 'fail',
 			pr: 1188,
 			merge_sha: 'abc123',
 			source_issue: '1122',
@@ -291,13 +291,13 @@ describe('post-merge structured output and remediation body', () => {
 			evidence_summary: expect.objectContaining({
 				workflow_failures: 1,
 			}),
-			sync_action: 'post_merge_remediation',
+			sync_action: 'post_merge_failure',
 		});
 		expect(commentBody(result)).toContain('## Workflow failures');
 		expect(renderPostMergeReport(result)).toContain('Implementation evidence failures: 0');
 		expect(remediationTitle(result)).toBe('Post-merge closeout exception for PR #1188 / source #1122 / workflow_failure');
 		expect(remediationBody(result)).toContain('Required Atlas/Bill decision');
-		expect(remediationBody(result)).toContain('Auto-Sync Documentation');
+		expect(remediationBody(result)).toContain('GATE — Quality Checks');
 	});
 
 	it('fails when merged implementation evidence is incomplete', () => {
@@ -333,7 +333,7 @@ describe('post-merge structured output and remediation body', () => {
 		});
 
 		expect(result.status).toBe('pass');
-		expect(result.remediation_required).toBe(true);
+		expect(result.remediation_required).toBe(false);
 	});
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Stop counting non-required workflow failures toward `remediation_required` in `buildResult`, so optional failures like Auto-Sync Documentation secret-access issues no longer block closed-source label reconciliation.
- Re-trigger post-merge closeout rerun manifest for PR #1473 / source issue #1404.

## Verification

- `npm test -- tests/post-merge-validator.test.mjs tests/post-merge-source-issue-closeout.test.mjs tests/post-merge-closeout-all-manifests.test.mjs` — PASS (40 tests)

## Expected post-merge effect

Post-Merge PR Body Closeout should run `post_merge_success` for PR #1473 and reconcile **#1404** terminal labels (`status:complete` only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59357a4d-b095-4abd-a5f9-0a6b5accaac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59357a4d-b095-4abd-a5f9-0a6b5accaac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow closed‑source label reconciliation when only optional post‑merge workflows fail. Optional failures no longer set remediation_required; only required workflow failures block closeout.

- **Bug Fixes**
  - Updated buildResult to ignore optional remediation failures when computing remediation_required; only failures with required: true count.
  - Updated tests to reflect: required failures now yield status: 'fail' and sync_action: 'post_merge_failure'; optional failures keep status: 'pass' and sync_action: 'post_merge_success'.
  - Bumped the rerun manifest timestamp to re-trigger PR #1473 closeout and reconcile #1404 labels.

<sup>Written for commit 3dcc589912a7d72c2b16c681b892ceb0a619a435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

