### PR TITLE
fix(ci): post-merge closeout for PR #1528 / #1258

### DIFF
--- a/docs/ops/implementation-plans/website-operations-admin.md
+++ b/docs/ops/implementation-plans/website-operations-admin.md
@@ -245,7 +245,7 @@ Task 001 classifies the lane as already satisfied.
 | --- | --- |
 | **Title** | Task 004 — Admin shell and member operations delta (`#1119` / T41) |
 | **Objective** | Harden dashboard, join-requests, member-operations, worklist, stats surfaces. |
-| **Allowed files/areas** | `src/app/admin/page.tsx`, `src/app/admin/join-requests/**`, `src/app/admin/member-operations/**`, `src/app/admin/worklist/**`, `src/components/admin/**`, `functions/api/admin/stats.ts`, `functions/api/admin/worklist.ts`, `functions/api/admin/join-requests/**` |
+| **Allowed files/areas** | `src/app/admin/page.tsx`, `src/app/admin/join-requests/**`, `src/app/admin/member-operations/**`, `src/app/admin/worklist/**`, `src/components/admin/**`, `functions/api/admin/stats.ts`, `functions/api/admin/worklist.ts`, `functions/api/admin/join-requests/**`, `functions/api/admin/welcome-email.ts`, `functions/api/admin/membership-card.ts` |
 | **Non-goals** | New admin modules; public route changes |
 | **Acceptance criteria** | Admin nav complete; empty/error states safe; join/member ops actionable |
 | **Verification** | `npm run typecheck`; manual admin smoke |

--- a/scripts/ci/post-merge-closeout/pr-1528-body.md
+++ b/scripts/ci/post-merge-closeout/pr-1528-body.md
@@ -1,0 +1,138 @@
+- **Issue:** #1258
+
+## PRE-OPEN GATE PREFLIGHT (MANDATORY)
+- [x] Confirm exactly one same-repository, open, non-PR source issue exists.
+- [x] Confirm one accepted issue-accounting line is present before opening or updating the PR. Preferred format: `- **Issue:** #1258`.
+
+## MANDATORY FIRST STEP (ZIP SAFETY)
+- [x] No ZIP file exists in the repo root
+- [x] Final diff confirms no ZIP file is committed
+
+## QUEUE / DEPENDENCY MAP STATUS
+- Dependency-map result: pass
+- Next queue item: halt — Phase 3 planning complete; Phase 4 implementation awaits Atlas/Bill approval
+- Continue/halt decision: halt — planning PR merged; no Phase 4 build work authorized
+
+## PROGRESS + READINESS (MANDATORY)
+- Phase: Program #1255 Phase 3 — Website Operations Admin planning
+- Task: #1258 planning package
+- Status: MERGED
+- Scope Confirmed: YES
+- Out-of-Scope Changes Present: NO
+- Blocking Issues: none (post-merge closeout body remediation applied)
+- Notes: Merged as PR #1528 (merge SHA `9d50bcd8f3f386ee18cee2e15fe396d5febe537c`). Post-merge closeout remediation applied for reviewer disposition and active child-project label reconciliation.
+
+## DOCUMENTATION SOURCE (MANDATORY)
+- [ ] DIATAXIS_FULL
+- [x] DIATAXIS_ROUTED
+- [ ] LEGACY_FALLBACK
+
+Source Files Used:
+- `docs/ops/implementation-plans/website-operations-admin.md`
+- `docs/ops/reports/website-operations-admin-legacy-issue-reconciliation.md`
+- `docs/how-to/website/website-implementation-and-content-operations-plan.md`
+- `docs/reference/pmo/lgfc-program-queue-and-dependency-map.md`
+
+## LABEL
+- Intent label for this PR: docs-only
+
+## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
+Docs/ops-only planning PR. No public UI, visual design, route, layout, or content model implementation.
+
+## FILE-TOUCH ALLOWLIST (MANDATORY)
+Allowed files:
+- docs/ops/implementation-plans/website-operations-admin.md
+- docs/ops/reports/website-operations-admin-legacy-issue-reconciliation.md
+- active_tasklist.md
+- docs/ops/pmo/program-registry.md
+- docs/reference/pmo/lgfc-program-queue-and-dependency-map.md
+
+All other files are out of scope
+
+## VISUAL / UX INVARIANTS (MANDATORY)
+- [x] Documentation-only PR.
+- [x] No runtime UI changes.
+- [x] No route/layout/header/footer changes.
+
+## CHANGE SUMMARY
+- Created Website Operations Admin implementation plan for #1258.
+- Reconciled legacy admin/ops issues #1053 and #1118–#1127 against as-built `main`.
+- Proposed serial child task sequence (Tasks 001–013, titles only — no issues created).
+- Refreshed PMO registry, queue map, and active tasklist snapshot for #1256 complete / #1258 active planning.
+- No implementation work performed.
+
+## BUILD / TEST / VERIFICATION
+```bash
+git status --short
+git diff --check
+./scripts/ci/docs_check_headers.sh \
+  docs/ops/implementation-plans/website-operations-admin.md \
+  docs/ops/reports/website-operations-admin-legacy-issue-reconciliation.md \
+  docs/ops/pmo/program-registry.md \
+  docs/reference/pmo/lgfc-program-queue-and-dependency-map.md \
+  active_tasklist.md
+```
+Results: all passed at merge. No dedicated markdown lint beyond docs header check.
+
+## REVIEWER RESPONSE ACCOUNTING
+- [x] Reviewed all reviewer comments.
+- [x] Reviewed all bot comments.
+- [x] Reviewed all GitHub review threads.
+- [x] Copilot disposition received or not applicable.
+- [x] Codex disposition received or not applicable.
+- [x] Gemini disposition received or not applicable.
+- [x] Cubic disposition received or not applicable.
+- [x] Every actionable reviewer comment has a PR-body disposition with `review-comment:<id>`.
+- [x] Every outdated review thread has explicit PR-body disposition with comment ID and thread state.
+
+Reviewer items:
+- review-comment:3388176474 — accepted — table header changed to `issue` in implementation plan — thread state: outdated
+- review-comment:3388176499 — accepted — changed to `issue titles only` in implementation plan — thread state: outdated
+- review-comment:3388176515 — accepted — reconciliation table header changed to `issue` — thread state: outdated
+- review-comment:3388185498 — accepted — boundary bullet rewritten as complete sentence clarifying label authority — thread state: outdated
+- review-comment:3388186741 — accepted — proposed task allowlists now use repo-root paths throughout — thread state: outdated
+- review-comment:3388427176 — acknowledged — full PMO dependency-map fields deferred to Atlas/Bill approval before `production-ready`; Phase 3 plan remains `ready-for-review` — thread state: outdated
+- review-comment:3388427182 — acknowledged — Task 004 allowlist expanded to include `functions/api/admin/welcome-email.ts` and `functions/api/admin/membership-card.ts` in follow-up doc revision — thread state: outdated
+
+## PR GATE READINESS CHECKLIST
+- [x] Live PR check panel inspected
+- [x] Commit-level workflow runs inspected
+- [x] PR-level pull_request_target workflows inspected
+- [x] All review threads and comments inspected
+- [x] Actionable review feedback has PR-body disposition and GitHub thread-state disposition
+- [x] Final PR panel confirms merge-readiness at merge time
+
+## POST-MERGE CLOSEOUT CHECKLIST
+- [x] PR merged state verified
+- [x] Merge commit recorded (`9d50bcd8f3f386ee18cee2e15fe396d5febe537c`)
+- [x] Source issue state inspected after merge
+- [x] Post-merge closeout body remediation applied for reviewer disposition and active child-project label reconciliation
+
+## ACCEPTANCE CRITERIA
+- [x] One docs-only PR opened against main
+- [x] Source issue is exactly #1258
+- [x] #1258 planning artifacts exist and are reviewable
+- [x] Legacy issues #1053 and #1118–#1127 reconciled
+- [x] Proposed child task map exists; no child issues created
+- [x] #1259 remains queued (not touched)
+- [x] #1500 remains queued (not touched)
+- [x] No application code changes
+- [x] No workflow YAML changes
+- [x] No D1 migrations
+- [x] Post-merge closeout criteria satisfied after merge and closeout body remediation
+
+## REQUIRED PRE-REVIEW SELF-CHECK
+- [x] PR body contains all required sections with exact headings
+- [x] PR body contains one accepted source-issue accounting line governed by `/docs/governance/PR_GOVERNANCE.md`.
+- [x] Allowed files section matches final diff exactly
+- [x] No files outside allowlist
+- [x] ZIP safety confirmed
+- [x] All reviewer feedback has both textual disposition and GitHub thread-state disposition
+- [x] Post-merge closeout body remediation applied for merged PR governance
+
+## POST-MERGE ISSUE DISPOSITION
+- Source issue **#1258** remains **open** with `status:active`; remove only `status:post-merge-verify` and other stale workflow labels; **do not close** #1258 (Phase 3 planning complete; Phase 4 not authorized)
+- Close remediation issue **#1529** when validator passes after body apply
+- Do not launch #1259, #1500, or Phase 4 implementation child issues
+
+<!-- closeout-trigger: 2026-06-10 -->

--- a/scripts/ci/post_merge_source_issue_closeout.mjs
+++ b/scripts/ci/post_merge_source_issue_closeout.mjs
@@ -13,6 +13,7 @@ export const REMEDIATION_ISSUE_LABEL = 'post-merge-failure';
 export const REMEDIATION_TITLE_PREFIX = 'Post-merge closeout exception for ';
 export const LEGACY_REMEDIATION_TITLE_PREFIX = 'Post-merge remediation required for ';
 export const TERMINAL_SOURCE_ISSUE_LABEL = 'status:complete';
+export const ACTIVE_SOURCE_ISSUE_LABEL = 'status:active';
 
 const FOLLOWUP_CLOSEOUT_PATTERN =
 	/\b(remediation|follow[- ]up|clarification|post[- ]merge evidence|closeout reconciliation|post[- ]merge closeout)\b/i;
@@ -23,6 +24,34 @@ export function isPermittedClosedSourceIssueFollowup({ body = '', sourceIssue = 
 	if (String(sourceIssue?.state || '').toLowerCase() !== 'closed') return false;
 	if (String(sourceIssue?.state_reason || '').toLowerCase() !== 'completed') return false;
 	return FOLLOWUP_CLOSEOUT_PATTERN.test(body) && PRIOR_CLOSEOUT_REF_PATTERN.test(body);
+}
+
+export function shouldKeepActiveSourceIssueOpen(body = '') {
+	const match = String(body || '').match(/## POST-MERGE ISSUE DISPOSITION[\s\S]*?(?=\n## [A-Z]|\n<!--|$)/i);
+	const section = match ? match[0] : '';
+	return (
+		/\bremains?\b/i.test(section) &&
+		/\bopen\b/i.test(section) &&
+		/\bdo not close\b/i.test(section) &&
+		/\bstatus:active\b/i.test(section)
+	);
+}
+
+export function planActiveSourceIssueRelabel({ issueLabels = [] } = {}) {
+	const labels = new Set(
+		Array.from(issueLabels || [])
+			.map((label) => (typeof label === 'string' ? label : label?.name))
+			.filter(Boolean),
+	);
+	const removeLabels = STALE_SOURCE_ISSUE_LABELS.filter((label) => labels.has(label));
+
+	return {
+		ok: true,
+		reason: 'active_source_issue_relabel_ready',
+		removeLabels,
+		addLabel: '',
+		summary: `remove ${removeLabels.length ? removeLabels.join(', ') : 'none'}; preserve ${ACTIVE_SOURCE_ISSUE_LABEL}; source issue remains open`,
+	};
 }
 
 export function isRemediationIssue({ title = '', labels = [] } = {}) {
@@ -157,6 +186,9 @@ export function shouldCloseSourceIssue({
 	}
 	if (issueMeta && isRemediationIssue(issueMeta) && !closedFollowupAllowed) {
 		return { close: false, reason: 'remediation_issue' };
+	}
+	if (shouldKeepActiveSourceIssueOpen(prBody)) {
+		return { close: false, reason: 'active_source_issue_remains_open' };
 	}
 	if (terminalLabelResult && !terminalLabelResult.ok) {
 		return { close: false, reason: terminalLabelResult.reason || 'terminal_label_reconciliation_failed' };

--- a/scripts/ci/post_merge_validator.mjs
+++ b/scripts/ci/post_merge_validator.mjs
@@ -9,7 +9,9 @@ import { implementationEvidenceFailures } from './post_merge_implementation_evid
 import { linkedIssueNumber, sourceIssueAccounting } from './issue_accounting.mjs';
 import {
 	isPermittedClosedSourceIssueFollowup,
+	planActiveSourceIssueRelabel,
 	planTerminalLabelReconciliation,
+	shouldKeepActiveSourceIssueOpen,
 } from './post_merge_source_issue_closeout.mjs';
 
 export { isPermittedClosedSourceIssueFollowup };
@@ -93,6 +95,19 @@ export function sourceIssueStateFailures({ body = '', sourceIssue = null, source
 			code: 'source_issue_not_open',
 			message: `Source issue is ${sourceIssue.state || 'unknown'} at closeout start; CI refused to relabel or close it.`,
 		});
+	}
+
+	if (shouldKeepActiveSourceIssueOpen(body)) {
+		const relabel = planActiveSourceIssueRelabel({
+			issueLabels: sourceIssue.labels || [],
+		});
+		if (!relabel.ok) {
+			failures.push({
+				code: relabel.reason || 'active_source_issue_relabel_failed',
+				message: relabel.summary || 'Active source issue relabel is not deterministic.',
+			});
+		}
+		return failures;
 	}
 
 	const terminalLabelResult = planTerminalLabelReconciliation({
@@ -655,10 +670,12 @@ export async function runValidator({
 			]);
 			sourceIssue = issue;
 			repoLabels = labels;
-			terminalLabelResult = planTerminalLabelReconciliation({
-				issueLabels: sourceIssue.labels || [],
-				repoLabels,
-			});
+			terminalLabelResult = shouldKeepActiveSourceIssueOpen(normalizedPr.body || '')
+				? planActiveSourceIssueRelabel({ issueLabels: sourceIssue.labels || [] })
+				: planTerminalLabelReconciliation({
+					issueLabels: sourceIssue.labels || [],
+					repoLabels,
+				});
 			sourceIssueCloseoutMode = isPermittedClosedSourceIssueFollowup({
 				body: normalizedPr.body,
 				sourceIssue,

--- a/scripts/orchestrator/sync-pr-state.mjs
+++ b/scripts/orchestrator/sync-pr-state.mjs
@@ -7,9 +7,11 @@ import { pathToFileURL } from 'node:url';
 import { linkedIssueNumber, sourceIssueAccounting } from '../ci/issue_accounting.mjs';
 import {
   buildSourceIssueCloseoutComment,
+  planActiveSourceIssueRelabel,
   planTerminalLabelReconciliation,
   postMergeVerificationResult,
   shouldCloseSourceIssue,
+  shouldKeepActiveSourceIssueOpen,
 } from '../ci/post_merge_source_issue_closeout.mjs';
 
 const repo = process.env.GITHUB_REPOSITORY;
@@ -149,6 +151,29 @@ export function syncPrState({
     });
 
     if (!closeDecision.close) {
+      if (
+        closeDecision.reason === 'active_source_issue_remains_open' &&
+        shouldKeepActiveSourceIssueOpen(pr.body || '')
+      ) {
+        const relabelPlan = planActiveSourceIssueRelabel({ issueLabels: meta.labels || [] });
+        reconcileTerminalLabelsFn(issueNumber, relabelPlan);
+        const mergeSha = postMergeResult?.merge_sha || pr.mergeCommit?.oid || '';
+        const closeoutComment = buildSourceIssueCloseoutComment({
+          prNumber,
+          mergeSha,
+          sourceIssueNumber: issueNumber,
+          validatorStatus: postMergeResult?.status || 'pass',
+          verificationResult: postMergeVerificationResult(postMergeResult),
+          closeoutReason: closeDecision.reason,
+          validationSummary: validationSummary(postMergeResult),
+          terminalLabelResult: relabelPlan.summary,
+          sourceIssueCloseoutMode: postMergeResult?.source_issue_closeout_mode,
+          queueAdvancementStatus:
+            'no queue action; Phase 3 planning complete; source issue remains active pending Phase 4 approval',
+        });
+        run(['issue', 'comment', issueNumber, '--repo', repo, '--body', closeoutComment]);
+        return 'active_relabeled';
+      }
       log(`Skipping source issue closeout for PR #${prNumber}: ${closeDecision.reason}.`);
       return closeDecision.reason;
     }

--- a/tests/post-merge-source-issue-closeout.test.mjs
+++ b/tests/post-merge-source-issue-closeout.test.mjs
@@ -4,9 +4,11 @@ import { linkedIssueNumber, sourceIssueAccounting } from '../scripts/ci/issue_ac
 import {
 	buildSourceIssueCloseoutComment,
 	isRemediationIssue,
+	planActiveSourceIssueRelabel,
 	planTerminalLabelReconciliation,
 	postMergeVerificationResult,
 	shouldCloseSourceIssue,
+	shouldKeepActiveSourceIssueOpen,
 	STALE_SOURCE_ISSUE_LABELS,
 } from '../scripts/ci/post_merge_source_issue_closeout.mjs';
 import { buildResult } from '../scripts/ci/post_merge_validator.mjs';
@@ -156,6 +158,39 @@ describe('source issue closeout decision', () => {
 				postMergeResult: { status: 'pass', remediation_required: false },
 			}),
 		).toMatchObject({ close: false, reason: 'missing_source_issue' });
+	});
+
+	it('keeps active child project issues open when disposition requires status:active', () => {
+		const body = [
+			baseBody,
+			'',
+			'## POST-MERGE ISSUE DISPOSITION',
+			'- Source issue **#1258** remains **open** with `status:active`; remove only `status:post-merge-verify`; **do not close** #1258',
+		].join('\n');
+
+		expect(shouldKeepActiveSourceIssueOpen(body)).toBe(true);
+		expect(
+			shouldCloseSourceIssue({
+				action: 'post_merge_success',
+				issueNumber: '1258',
+				isMerged: true,
+				postMergeResult: { status: 'pass', remediation_required: false },
+				issueMeta: {
+					title: 'PROJECT: Website Operations Admin',
+					labels: ['type:website', 'status:active', 'status:post-merge-verify', 'website'],
+				},
+				prBody: body,
+			}),
+		).toEqual({ close: false, reason: 'active_source_issue_remains_open' });
+		expect(
+			planActiveSourceIssueRelabel({
+				issueLabels: ['type:website', 'status:active', 'status:post-merge-verify', 'website'],
+			}),
+		).toMatchObject({
+			ok: true,
+			removeLabels: ['status:post-merge-verify'],
+			summary: expect.stringContaining('preserve status:active'),
+		});
 	});
 
 	it('does not close remediation issues mis-linked as source issues', () => {


### PR DESCRIPTION
- **Issue:** #1529

## PRE-OPEN GATE PREFLIGHT (MANDATORY)
- [x] Confirm exactly one same-repository, open, non-PR source issue exists.
- [x] Confirm one accepted issue-accounting line is present before opening or updating the PR.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root

## QUEUE / DEPENDENCY MAP STATUS
- Dependency-map result: not-applicable
- Next queue item: not-applicable — post-merge closeout remediation for PR #1528
- Continue/halt decision: not-applicable — bounded closeout remediation only

## PROGRESS + READINESS (MANDATORY)
- Phase: Post-merge closeout remediation
- Task: PR #1528 / source #1258 active child-project closeout
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: none

## DOCUMENTATION SOURCE (MANDATORY)
- [ ] DIATAXIS_FULL
- [ ] DIATAXIS_ROUTED
- [x] LEGACY_FALLBACK

## LABEL
- Intent label for this PR: change-ops

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical closeout protocol: `/docs/ops/pmo/github-issue-closeout-protocol.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- scripts/ci/post-merge-closeout/pr-1528-body.md
- scripts/ci/post_merge_source_issue_closeout.mjs
- scripts/ci/post_merge_validator.mjs
- scripts/orchestrator/sync-pr-state.mjs
- tests/post-merge-source-issue-closeout.test.mjs
- docs/ops/implementation-plans/website-operations-admin.md

All other files are out of scope

## CHANGE SUMMARY
- Add post-merge closeout body for merged PR #1528 with reviewer dispositions and active-issue disposition for #1258.
- Support relabel-only closeout when POST-MERGE ISSUE DISPOSITION keeps source issue open with `status:active`.
- Expand Task 004 allowlist in planning doc per Codex review (welcome-email, membership-card APIs).

## BUILD / TEST / VERIFICATION
```bash
npx vitest run --config tests/vitest.node.config.ts tests/post-merge-source-issue-closeout.test.mjs
```
Result: PASS (18/18)

## ACCEPTANCE CRITERIA
- [x] pr-1528-body.md includes reviewer dispositions for all outdated threads
- [x] Active child project #1258 can relabel without erroneous close
- [x] Remediation issue #1529 closeout path enabled after workflow re-run
- [x] Allowlist matches diff exactly

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches final diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed

## POST-MERGE ISSUE DISPOSITION
- Close remediation issue **#1529** when post-merge closeout for PR #1528 passes after body apply


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI post-merge closeout to support a relabel-only flow when the source issue must stay open with `status:active`. Adds the closeout body for PR #1528 / issue #1258 and enables closing remediation issue #1529 after the workflow re-runs.

- **Bug Fixes**
  - Add `shouldKeepActiveSourceIssueOpen` and `planActiveSourceIssueRelabel` to detect an active disposition in the PR body, preserve `status:active`, and remove stale labels.
  - Update `post_merge_validator.mjs` and `sync-pr-state.mjs` to skip closing, apply relabels, and post a closeout comment for this mode.
  - Add `scripts/ci/post-merge-closeout/pr-1528-body.md` with reviewer dispositions and the active-issue disposition for #1258.
  - Expand Task 004 allowlist in `docs/ops/implementation-plans/website-operations-admin.md` to include `functions/api/admin/welcome-email.ts` and `functions/api/admin/membership-card.ts`.

<sup>Written for commit 4be4aaefe54f05bfff73d5b252d895c2972ebdf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->