### PR TITLE
fix: harden admin shell and member ops (#1258 Task 004)

### DIFF
--- a/active_tasklist.md
+++ b/active_tasklist.md
@@ -15,7 +15,7 @@ Use this file only as an optional, human-readable snapshot.
 | Item | State | Notes |
 | --- | --- | --- |
 | `#1255` | `status:active` | Umbrella program — Website Implementation and Content Operations |
-| `#1258` | `status:active` | **Phase 4 Task 004** — admin shell / member ops (next); Tasks 001–003 complete (PRs `#1531`, `#1533`, `#1536`; post-merge status via `#1534`) |
+| `#1258` | `status:active` | **Phase 4 Task 004** — admin shell / member ops (PR in review); Tasks 001–003 complete (PRs `#1531`, `#1533`, `#1536`; post-merge via `#1534`, `#1540`) |
 
 ## Queued — not started
 

--- a/docs/ops/implementation-plans/website-operations-admin.md
+++ b/docs/ops/implementation-plans/website-operations-admin.md
@@ -8,7 +8,8 @@ Status: phase-4-active
 Task 001 complete: docs/ops/reports/website-operations-admin-as-built-gap-analysis.md (PR `#1531`)
 Task 002 complete: docs/reference/architecture/access-model.md (PR `#1533`)
 Task 003 complete: Fan Club operational workflows verification (`#1118` / T40; PR `#1536`)
-Next task: Task 004 — Admin shell and member operations delta (`#1119` / T41)
+Task 004 in progress: Admin shell and member operations delta (`#1119` / T41)
+Next task: Task 005 — Moderation and review workflow delta (`#1120` / T42)
 Project: website-operations-admin
 Owner: Atlas
 Execution Mode: orchestrated-after-approval
@@ -24,8 +25,8 @@ Last Reviewed: 2026-06-10
 ## Status
 
 Phase 4 implementation for `#1258` is **active** on `main`. Tasks 001–003 are
-complete (PRs `#1531`, `#1533`, `#1536`; post-merge status via `#1534`). **Task
-004** is next and awaits explicit authorization. Plan status remains
+complete (PRs `#1531`, `#1533`, `#1536`; post-merge via `#1534`, `#1540`). **Task
+004** is in review. Plan status remains
 `phase-4-active` (not `production-ready`). Child issue creation remains held
 unless explicitly authorized by existing automation.
 
@@ -102,8 +103,8 @@ Navigation source: `src/components/admin/AdminNav.tsx` (15 operational links).
 
 **Access model documentation:** `docs/reference/architecture/access-model.md` was
 reconciled in Task 002 (PR `#1533`) to dual gating (session UI + `ADMIN_TOKEN` API).
-Remaining nuance: `/admin/d1-test` still uses page-local `sessionStorage` token UX
-(documented as follow-up for Task 004).
+Task 004 unifies `/admin/d1-test` with `AdminTokenPanel` / `localStorage`
+(`adminClient.ts`). `footer-quotes` admin UI remains deferred.
 
 ### Admin API surface (`functions/api/admin/**`)
 
@@ -262,7 +263,8 @@ Task 001 classifies the lane as already satisfied.
 | **Acceptance criteria** | Admin nav complete; empty/error states safe; join/member ops actionable |
 | **Verification** | `npm run typecheck`; manual admin smoke |
 | **Dependencies** | Tasks 002–003 complete |
-| **Status** | Next (Phase 4; awaits authorization) |
+| **Status** | In review (Phase 4) |
+| **Task 004 notes** | Accessible error alerts on shell pages; D1 test token UX unified; `footer-quotes` UI still deferred |
 
 ### Task 005 — Moderation and Review Workflow Delta
 

--- a/docs/ops/implementation-plans/website-operations-admin.md
+++ b/docs/ops/implementation-plans/website-operations-admin.md
@@ -8,7 +8,7 @@ Status: phase-4-active
 Task 001 complete: docs/ops/reports/website-operations-admin-as-built-gap-analysis.md (PR `#1531`)
 Task 002 complete: docs/reference/architecture/access-model.md (PR `#1533`)
 Task 003 complete: Fan Club operational workflows verification (`#1118` / T40; PR `#1536`)
-Task 004 in progress: Admin shell and member operations delta (`#1119` / T41)
+Task 004 in review: Admin shell and member operations delta (`#1119` / T41)
 Next task: Task 005 — Moderation and review workflow delta (`#1120` / T42)
 Project: website-operations-admin
 Owner: Atlas

--- a/src/app/admin/d1-test/page.tsx
+++ b/src/app/admin/d1-test/page.tsx
@@ -117,6 +117,14 @@ export default function AdminD1TestPage() {
         <div className={styles.wrap}>
           <AdminTokenPanel
             onSaved={() => {
+              if (!getStoredAdminToken()) {
+                setTokenReady(false);
+                setTables([]);
+                setDetail(null);
+                setError('');
+                setStatus('');
+                return;
+              }
               if (tokenReady) {
                 void load();
               } else {

--- a/src/app/admin/d1-test/page.tsx
+++ b/src/app/admin/d1-test/page.tsx
@@ -1,178 +1,184 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import PageShell from '@/components/PageShell';
 import AdminNav from '@/components/admin/AdminNav';
+import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
+import AdminStatusText from '@/components/admin/AdminStatusText';
+import { adminJson, getStoredAdminToken } from '@/lib/adminClient';
+import styles from '@/components/admin/AdminDashboard.module.css';
 
 type TableInfo = { name: string; count: number };
 
-const styles: Record<string, React.CSSProperties> = {
+type D1SummaryResponse = { ok: true; tables?: TableInfo[] };
+type D1DetailResponse = {
+  ok: true;
+  table?: string;
+  schema?: unknown;
+  rows?: unknown;
+};
+
+const localStyles: Record<string, React.CSSProperties> = {
   main: { padding: '32px 16px', maxWidth: 1100, margin: '0 auto' },
   h1: { fontSize: 34, margin: '0 0 8px 0' },
   lead: { fontSize: 16, lineHeight: 1.7, margin: '0 0 18px 0' },
-  row: { display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' },
-  input: { padding: '10px 12px', borderRadius: 10, border: '1px solid rgba(0,0,0,0.25)', minWidth: 260 },
-  btn: { padding: '10px 14px', borderRadius: 12, border: '1px solid rgba(0,0,0,0.25)', background: 'white', cursor: 'pointer' },
-  card: { border: '1px solid rgba(0,0,0,0.15)', borderRadius: 16, padding: 16, marginTop: 16, background: 'rgba(255,255,255,0.9)' },
   table: { width: '100%', borderCollapse: 'collapse', marginTop: 10 },
   th: { textAlign: 'left', padding: '8px 6px', borderBottom: '1px solid rgba(0,0,0,0.15)' },
   td: { padding: '8px 6px', borderBottom: '1px solid rgba(0,0,0,0.08)', verticalAlign: 'top', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace', fontSize: 13 },
   small: { fontSize: 13, opacity: 0.85 },
-  err: { color: '#b00020', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace', fontSize: 13, whiteSpace: 'pre-wrap' },
   pre: { fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace', fontSize: 13, whiteSpace: 'pre-wrap' },
 };
 
-function useAdminToken() {
-  const [token, setToken] = useState('');
-  useEffect(() => {
-    try {
-      const t = sessionStorage.getItem('lgfc_admin_token') || '';
-      setToken(t);
-    } catch {}
-  }, []);
-
-  const save = (next: string) => {
-    setToken(next);
-    try {
-      sessionStorage.setItem('lgfc_admin_token', next);
-    } catch {}
-  };
-
-  return { token, setToken: save };
-}
-
-async function adminFetch(token: string, url: string) {
-  const headers: Record<string, string> = {};
-  if (token) headers['x-admin-token'] = token;
-  const res = await fetch(url, { headers });
-  const text = await res.text();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let data: any = null;
-  try { data = JSON.parse(text); } catch { data = { raw: text }; }
-  return { res, data };
-}
-
 export default function AdminD1TestPage() {
-  const { token, setToken } = useAdminToken();
   const [tables, setTables] = useState<TableInfo[]>([]);
   const [selected, setSelected] = useState<string>('');
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [detail, setDetail] = useState<any>(null);
+  const [detail, setDetail] = useState<D1DetailResponse | null>(null);
   const [error, setError] = useState<string>('');
+  const [status, setStatus] = useState<string>('');
   const [loading, setLoading] = useState(false);
+  const [tokenReady, setTokenReady] = useState(false);
 
   const sorted = useMemo(() => [...tables].sort((a, b) => a.name.localeCompare(b.name)), [tables]);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setLoading(true);
     setError('');
+    setStatus('Loading D1 tables…');
     setDetail(null);
     try {
-      const { res, data } = await adminFetch(token, '/api/admin/d1-inspect');
-      if (!res.ok) throw new Error(JSON.stringify(data, null, 2));
-      setTables(data.tables || []);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      setError(e?.message || String(e));
+      const result = await adminJson<D1SummaryResponse>('/api/admin/d1-inspect');
+      if (!result.ok || !result.data) {
+        setTables([]);
+        setError(`Error: ${result.error}`);
+        setStatus('');
+        return;
+      }
+      setTables(result.data.tables || []);
+      setStatus((result.data.tables || []).length ? '' : 'No D1 tables returned.');
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(`Error: ${msg}`);
+      setStatus('');
+      setTables([]);
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const loadTable = async (name: string) => {
+  const loadTable = useCallback(async (name: string) => {
     setSelected(name);
     setLoading(true);
     setError('');
+    setStatus(`Loading ${name}…`);
     setDetail(null);
     try {
-      const { res, data } = await adminFetch(token, `/api/admin/d1-inspect?table=${encodeURIComponent(name)}&limit=5`);
-      if (!res.ok) throw new Error(JSON.stringify(data, null, 2));
-      setDetail(data);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      setError(e?.message || String(e));
+      const result = await adminJson<D1DetailResponse>(
+        `/api/admin/d1-inspect?table=${encodeURIComponent(name)}&limit=5`,
+      );
+      if (!result.ok || !result.data) {
+        setError(`Error: ${result.error}`);
+        setStatus('');
+        return;
+      }
+      setDetail(result.data);
+      setStatus('');
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(`Error: ${msg}`);
+      setStatus('');
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
-    // auto-load if token exists
-    if (token) void load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token]);
+    if (getStoredAdminToken()) {
+      setTokenReady(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (tokenReady) {
+      void load();
+    }
+  }, [tokenReady, load]);
 
   return (
     <PageShell title="Admin – D1 Inspect" subtitle="Inspect tables and run safe, read-only queries">
       <AdminNav />
 
-    <div style={styles.main}>
-      <h1 style={styles.h1}>Admin • D1 Test</h1>
-      <p style={styles.lead}>
-        This page is a diagnostic view of all D1 tables: row counts, schema, and sample rows.
-        It requires your admin token (stored in sessionStorage as <code>lgfc_admin_token</code>).
-      </p>
+      <div style={localStyles.main}>
+        <h1 style={localStyles.h1}>Admin • D1 Test</h1>
+        <p style={localStyles.lead}>
+          Diagnostic view of D1 tables: row counts, schema, and sample rows. Uses the same admin API
+          token as other admin surfaces (`localStorage` via the token panel).
+        </p>
 
-      <div style={styles.card}>
-        <div style={styles.row}>
-          <input
-            style={styles.input}
-            placeholder="Paste ADMIN_TOKEN here"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            autoComplete="off"
-            spellCheck={false}
+        <div className={styles.wrap}>
+          <AdminTokenPanel
+            onSaved={() => {
+              setTokenReady(true);
+              void load();
+            }}
           />
-          <button style={styles.btn} onClick={load} disabled={loading || !token}>
-            {loading ? 'Loading…' : 'Load table list'}
-          </button>
-          <a href="/admin" style={{ ...styles.small, textDecoration: 'underline' }}>Back to Admin</a>
+
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <div className={styles.panelTitle}>D1 table list</div>
+              <button className={styles.btn} type="button" onClick={() => void load()} disabled={loading || !tokenReady}>
+                {loading ? 'Loading…' : 'Refresh'}
+              </button>
+            </div>
+            {!tokenReady ? (
+              <p className={styles.status}>Save an admin API token above to load D1 tables.</p>
+            ) : null}
+            {status ? <p className={styles.status}>{status}</p> : null}
+            {error ? <AdminStatusText message={error} className={styles.status} /> : null}
+          </div>
+
+          {!!sorted.length && (
+            <div className={styles.panel}>
+              <div style={localStyles.small}>Tables ({sorted.length}) — click a row to inspect</div>
+              <table style={localStyles.table}>
+                <thead>
+                  <tr>
+                    <th style={localStyles.th}>Table</th>
+                    <th style={localStyles.th}>Rows</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.map((t) => (
+                    <tr
+                      key={t.name}
+                      onClick={() => void loadTable(t.name)}
+                      style={{ cursor: 'pointer', background: t.name === selected ? 'rgba(0,0,0,0.04)' : 'transparent' }}
+                    >
+                      <td style={localStyles.td}>{t.name}</td>
+                      <td style={localStyles.td}>{t.count}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {detail ? (
+            <div className={styles.panel}>
+              <div style={localStyles.small}>
+                Detail: <strong>{detail.table}</strong>
+              </div>
+              <div style={{ marginTop: 12 }}>
+                <div style={localStyles.small}><strong>Schema</strong></div>
+                <pre style={localStyles.pre}>{JSON.stringify(detail.schema, null, 2)}</pre>
+              </div>
+              <div style={{ marginTop: 12 }}>
+                <div style={localStyles.small}><strong>Sample rows</strong></div>
+                <pre style={localStyles.pre}>{JSON.stringify(detail.rows, null, 2)}</pre>
+              </div>
+            </div>
+          ) : null}
         </div>
-        {!token && <div style={{ ...styles.small, marginTop: 10 }}>ADMIN_TOKEN is not set here yet. Paste it, then click “Load table list”.</div>}
       </div>
-
-      {error && (
-        <div style={styles.card}>
-          <div style={styles.err}>{error}</div>
-        </div>
-      )}
-
-      {!!sorted.length && (
-        <div style={styles.card}>
-          <div style={styles.small}>Tables ({sorted.length}) — click a row to inspect</div>
-          <table style={styles.table}>
-            <thead>
-              <tr>
-                <th style={styles.th}>Table</th>
-                <th style={styles.th}>Rows</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sorted.map((t) => (
-                <tr key={t.name} onClick={() => loadTable(t.name)} style={{ cursor: 'pointer', background: t.name === selected ? 'rgba(0,0,0,0.04)' : 'transparent' }}>
-                  <td style={styles.td}>{t.name}</td>
-                  <td style={styles.td}>{t.count}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {detail && (
-        <div style={styles.card}>
-          <div style={styles.small}>Detail: <strong>{detail.table}</strong></div>
-          <div style={{ marginTop: 12 }}>
-            <div style={styles.small}><strong>Schema</strong></div>
-            <pre style={styles.pre}>{JSON.stringify(detail.schema, null, 2)}</pre>
-          </div>
-          <div style={{ marginTop: 12 }}>
-            <div style={styles.small}><strong>Sample rows</strong></div>
-            <pre style={styles.pre}>{JSON.stringify(detail.rows, null, 2)}</pre>
-          </div>
-        </div>
-      )}
-    </div>
     </PageShell>
   );
 }

--- a/src/app/admin/d1-test/page.tsx
+++ b/src/app/admin/d1-test/page.tsx
@@ -117,8 +117,11 @@ export default function AdminD1TestPage() {
         <div className={styles.wrap}>
           <AdminTokenPanel
             onSaved={() => {
-              setTokenReady(true);
-              void load();
+              if (tokenReady) {
+                void load();
+              } else {
+                setTokenReady(true);
+              }
             }}
           />
 

--- a/src/app/admin/join-requests/page.tsx
+++ b/src/app/admin/join-requests/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import PageShell from '@/components/PageShell';
 import AdminNav from '@/components/admin/AdminNav';
 import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
+import AdminStatusText from '@/components/admin/AdminStatusText';
 import { adminJson, isRecord } from '@/lib/adminClient';
 import styles from '@/components/admin/AdminDashboard.module.css';
 
@@ -100,7 +101,13 @@ export default function AdminJoinRequestsPage() {
           Refresh
         </button>
 
-        {status ? <p className={styles.status}>{status}</p> : null}
+        {status ? (
+          status.startsWith('Error:') ? (
+            <AdminStatusText message={status} className={styles.status} />
+          ) : (
+            <p className={styles.status}>{status}</p>
+          )
+        ) : null}
 
         <div className={styles.list}>
           {items.map((j) => (

--- a/src/app/admin/member-operations/page.tsx
+++ b/src/app/admin/member-operations/page.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import PageShell from '@/components/PageShell';
 import AdminNav from '@/components/admin/AdminNav';
 import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
+import AdminStatusText from '@/components/admin/AdminStatusText';
 import { adminJson, isRecord } from '@/lib/adminClient';
 import styles from '@/components/admin/AdminDashboard.module.css';
 
@@ -140,7 +141,13 @@ export default function AdminMemberOperationsPage() {
                   Publish
                 </button>
               </div>
-              {messages[endpoint.key] ? <p className={styles.status}>{messages[endpoint.key]}</p> : null}
+              {messages[endpoint.key] ? (
+                messages[endpoint.key].startsWith('Error:') ? (
+                  <AdminStatusText message={messages[endpoint.key]} className={styles.status} />
+                ) : (
+                  <p className={styles.status}>{messages[endpoint.key]}</p>
+                )
+              ) : null}
               <div className={styles.formGrid}>
                 <label className={styles.field}>
                   <span>Title</span>

--- a/src/app/admin/worklist/page.tsx
+++ b/src/app/admin/worklist/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import PageShell from '@/components/PageShell';
 import AdminNav from '@/components/admin/AdminNav';
 import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
+import AdminStatusText from '@/components/admin/AdminStatusText';
 import { adminJson, isRecord } from '@/lib/adminClient';
 import styles from '@/components/admin/AdminDashboard.module.css';
 
@@ -148,7 +149,13 @@ export default function AdminWorklistPage() {
               Refresh
             </button>
           </div>
-          {status ? <p className={styles.status}>{status}</p> : null}
+          {status ? (
+            status.startsWith('Error:') ? (
+              <AdminStatusText message={status} className={styles.status} />
+            ) : (
+              <p className={styles.status}>{status}</p>
+            )
+          ) : null}
           <div className={styles.list}>
             {items.map((item) => (
               <article key={item.id} className={styles.listItem}>

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import styles from './AdminDashboard.module.css';
 import AdminTokenPanel from './AdminTokenPanel';
+import AdminStatusText from './AdminStatusText';
 import { adminJson, isRecord } from '@/lib/adminClient';
 
 type CountRow = { table: string; count: number };
@@ -133,7 +134,13 @@ export default function AdminDashboard() {
           </button>
         </div>
 
-        {status ? <p className={styles.status}>{status}</p> : null}
+        {status ? (
+          status.startsWith('Error:') ? (
+            <AdminStatusText message={status} className={styles.status} />
+          ) : (
+            <p className={styles.status}>{status}</p>
+          )
+        ) : null}
         {unavailable.length ? (
           <p className={styles.status}>Unavailable tables: {unavailable.join(', ')}</p>
         ) : null}

--- a/src/components/admin/AdminStatusText.tsx
+++ b/src/components/admin/AdminStatusText.tsx
@@ -1,0 +1,17 @@
+type AdminStatusTextProps = {
+  message: string;
+  className?: string;
+};
+
+export default function AdminStatusText({ message, className }: AdminStatusTextProps) {
+  const isError = message.startsWith('Error:');
+  return (
+    <p
+      className={className}
+      role={isError ? 'alert' : undefined}
+      aria-live={isError ? 'assertive' : undefined}
+    >
+      {message}
+    </p>
+  );
+}

--- a/tests/admin-operations.test.tsx
+++ b/tests/admin-operations.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AdminLayout from '@/app/admin/layout';
+import AdminD1TestPage from '@/app/admin/d1-test/page';
 import AdminJoinRequestsPage from '@/app/admin/join-requests/page';
 import AdminMemberOperationsPage from '@/app/admin/member-operations/page';
 import AdminWorklistPage from '@/app/admin/worklist/page';
@@ -153,6 +155,63 @@ describe('admin operational pages', () => {
 
     const alert = await screen.findByRole('alert');
     expect(alert).toHaveTextContent(/error: unauthorized/i);
+  });
+});
+
+describe('admin d1 inspect page', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    mockUsePathname.mockReturnValue('/admin/d1-test');
+  });
+
+  it('does not fetch D1 tables until a token is stored', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+
+    render(<AdminD1TestPage />);
+
+    expect(screen.getByText('Save an admin API token above to load D1 tables.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('loads D1 tables when a token is stored and announces API failures', async () => {
+    window.localStorage.setItem('lgfc_admin_token', 'secret');
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse({ ok: false, error: 'Unauthorized.' }, 401) as never);
+
+    render(<AdminD1TestPage />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/admin/d1-inspect',
+        expect.objectContaining({ cache: 'no-store' }),
+      );
+    });
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/error: unauthorized/i);
+  });
+
+  it('restores token gating when the admin token is cleared', async () => {
+    window.localStorage.setItem('lgfc_admin_token', 'secret');
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse({ ok: true, tables: [] }) as never);
+
+    render(<AdminD1TestPage />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    const tokenInput = screen.getByLabelText('Admin token');
+    await userEvent.clear(tokenInput);
+    await userEvent.click(screen.getByRole('button', { name: 'Save token' }));
+
+    expect(screen.getByText('Save an admin API token above to load D1 tables.')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/admin-operations.test.tsx
+++ b/tests/admin-operations.test.tsx
@@ -6,6 +6,7 @@ import AdminLayout from '@/app/admin/layout';
 import AdminJoinRequestsPage from '@/app/admin/join-requests/page';
 import AdminMemberOperationsPage from '@/app/admin/member-operations/page';
 import AdminWorklistPage from '@/app/admin/worklist/page';
+import AdminDashboard from '@/components/admin/AdminDashboard';
 import AdminNav from '@/components/admin/AdminNav';
 import { onRequestGet as statsGet } from '../functions/api/admin/stats';
 import { onRequestGet as worklistGet } from '../functions/api/admin/worklist';
@@ -125,6 +126,33 @@ describe('admin operational pages', () => {
 
     expect(await screen.findAllByText('No welcome email content is published yet.')).not.toHaveLength(0);
     expect(await screen.findAllByText('No membership card instructions are published yet.')).not.toHaveLength(0);
+  });
+
+  it('announces join-request API failures to assistive technology', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ ok: false, error: 'Unauthorized.' }, 401) as never);
+
+    render(<AdminJoinRequestsPage />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/error: unauthorized/i);
+  });
+
+  it('announces worklist API failures to assistive technology', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ ok: false, error: 'Unauthorized.' }, 401) as never);
+
+    render(<AdminWorklistPage />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/error: unauthorized/i);
+  });
+
+  it('announces dashboard stats failures to assistive technology', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ ok: false, error: 'Unauthorized.' }, 401) as never);
+
+    render(<AdminDashboard />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/error: unauthorized/i);
   });
 });
 


### PR DESCRIPTION
- **Issue:** #1258

## PRE-OPEN GATE PREFLIGHT (MANDATORY)
- [x] Confirm exactly one same-repository, open, non-PR source issue exists.
- [x] Confirm one accepted issue-accounting line is present before opening or updating the PR.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root

## QUEUE / DEPENDENCY MAP STATUS
- Dependency-map result: pass
- Next queue item: #1258 Task 005 — Moderation and review workflow delta (after merge)
- Continue/halt decision: halt — Task 004 implementation PR; stop at READY FOR REVIEW

## PROGRESS + READINESS (MANDATORY)
- Phase: Program #1255 Phase 4 — #1258 Task 004
- Task: Admin shell and member operations delta (`#1119` / T41)
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: none

## DOCUMENTATION SOURCE (MANDATORY)
- [ ] DIATAXIS_FULL
- [x] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

## LABEL
- Intent label for this PR: feature

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
Admin shell surfaces only: dashboard, join-requests, member-operations, worklist, D1 inspect token UX. No public route or net-new module scope beyond shell hardening.

## VISUAL / UX INVARIANTS (MANDATORY)
- Admin session + token gating unchanged.
- Error states use `role="alert"` / `aria-live="assertive"` for operator-visible API failures.
- D1 inspect uses shared `AdminTokenPanel` / `localStorage` (not page-local `sessionStorage`).
- `footer-quotes` admin UI remains deferred.

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- src/components/admin/AdminStatusText.tsx
- src/components/admin/AdminDashboard.tsx
- src/app/admin/join-requests/page.tsx
- src/app/admin/member-operations/page.tsx
- src/app/admin/worklist/page.tsx
- src/app/admin/d1-test/page.tsx
- tests/admin-operations.test.tsx
- docs/ops/implementation-plans/website-operations-admin.md
- active_tasklist.md

All other files are out of scope.

## CHANGE SUMMARY
- Add `AdminStatusText` for accessible admin API error announcements on shell pages.
- Unify `/admin/d1-test` with `AdminTokenPanel` + `adminJson` (`localStorage` token path).
- Expand `tests/admin-operations.test.tsx` for join-request, worklist, and dashboard error alerts.
- Update implementation plan Task 004 status and active tasklist snapshot.

## BUILD / TEST / VERIFICATION
```bash
git status --short
git diff --check
npm run typecheck
npx vitest run tests/admin-operations.test.tsx
```
Results: `typecheck` passed on follow-up commit; test suite expanded (CI authoritative).

## ACCEPTANCE CRITERIA
- [x] Admin shell pages surface empty/error states safely with accessible errors
- [x] D1 test token UX aligned with adminClient localStorage model
- [x] `footer-quotes` UI deferred (not in scope)
- [x] No D1 migrations, workflow YAML, child issues
- [x] `#1259` / `#1500` untouched; `#1258` not closed

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches final diff exactly
- [x] No files outside allowlist
- [x] ZIP safety confirmed

## REVIEWER RESPONSE ACCOUNTING
- [x] Reviewed all reviewer comments.
- [x] Reviewed all bot comments.
- [x] Reviewed all GitHub review threads.
- [x] Copilot disposition received or not applicable.
- [x] Codex disposition received or not applicable.
- [x] Gemini disposition received or not applicable.
- [x] Cubic disposition received or not applicable.
- [x] Every actionable reviewer comment has a PR-body disposition with `review-comment:<id>`.
- [x] Every outdated review thread has explicit PR-body disposition with comment ID and thread state.

Reviewer items:
- review-comment:3389237069 — accepted — D1 test `onSaved` avoids duplicate `load()` when `tokenReady` effect will fetch — thread state: outdated
- review-comment:3389253698 — accepted — `onSaved` resets `tokenReady` and clears D1 state when token is cleared — thread state: outdated
- review-comment:3389253765 — accepted — plan header Task 004 status aligned to `in review` — thread state: outdated
- review-comment:3389253794 — accepted — added D1 inspect gating/failure tests in `admin-operations.test.tsx`

## POST-MERGE ISSUE DISPOSITION
- Source issue **#1258** remains **open** with `status:active`; **do not close** `#1258`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened admin shell pages by surfacing accessible API error alerts and unified the `/admin/d1-test` token flow with the shared admin client. This improves operator feedback and aligns Task 004 with #1258.

- **New Features**
  - Added `AdminStatusText` to announce API errors with `role="alert"` and `aria-live="assertive"` on dashboard, join-requests, worklist, and member-operations.
  - Updated `/admin/d1-test` to use `AdminTokenPanel`, `localStorage` token model, and `adminJson`; added status messages and a refresh action.

- **Refactors**
  - Removed page-local `sessionStorage` token usage in D1 inspect; aligned with `adminClient` storage.
  - Expanded `tests/admin-operations.test.tsx` to assert alert semantics; updated docs to mark Task 004 in review.

<sup>Written for commit d199bbd7726c87e25a18f28d5952dce76dc2db37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->