### PR TITLE
ops: Record Bill sign-off for Program #1500 Task 001 (#1544)

### DIFF
--- a/docs/ops/trackers/PROGRAM-1500-CLOSEOUT-STABILIZATION-IMPLEMENTATION-QUEUE.md
+++ b/docs/ops/trackers/PROGRAM-1500-CLOSEOUT-STABILIZATION-IMPLEMENTATION-QUEUE.md
@@ -242,8 +242,8 @@ Program #1500 is complete when **all** of the following are true:
 
 | Seq | Child issue | Parent | Dependency | Agent | Status | Handoff target | P2 conflict | Codex risk | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 001 | `#1544` — Add pre-merge post-merge-readiness gate | `#1500` | none | Codex | Draft | `#1545` | Low | Medium | Ready after buildout merge + explicit assignment |
-| 002 | `#1545` — Consolidate duplicate post-merge closeout workflows | `#1500` | `#1544` | Codex | Blocked | `#1546` | Low | High | Confirm overlapping workflows before edit |
+| 001 | `#1544` — Add pre-merge post-merge-readiness gate | `#1500` | none | Codex | Merged | `#1545` | Low | Medium | Bill sign-off 2026-06-11; PR #1552 merged + closeout verified |
+| 002 | `#1545` — Consolidate duplicate post-merge closeout workflows | `#1500` | `#1544` | Codex | Ready | `#1546` | Low | High | PR #1567 open; assign on `#1545` before implementation |
 | 003 | `#1546` — Fix failure-path label hygiene | `#1500` | `#1545` | Codex | Blocked | `#1547` | Low | Medium | Label state machine tests required |
 | 004 | `#1547` — Automate remediation manifest cleanup | `#1500` | `#1546` | Codex | Blocked | `#1548` | Low | Medium | Safe prune semantics — no destructive manifest wipe |
 | 005 | `#1548` — Reconcile CI/orchestration docs and deprecated workflows | `#1500` | `#1544`–`#1547` | Either | Blocked | terminal | Low | Low | Docs after behavior stable |

--- a/docs/ops/trackers/THREAD-LOG_Master.md
+++ b/docs/ops/trackers/THREAD-LOG_Master.md
@@ -16,6 +16,71 @@ Last Reviewed: 2026-06-11
 
 ------------------------------------------------------------------------
 
+## THREAD CLOSEOUT RECORD --- 2026-06-11 --- Program #1500 / #1544 Task 001 sign-off
+
+### Starting State
+PR `#1552` (Task 001 — pre-merge post-merge-readiness gate) merged to `main` via merge
+commit `90754605b1da7135c8bfdad2b422484d0ce59990`. Source issue `#1544` closed with
+`status:complete` after Post-Merge Detection passed. Program queue still required
+Atlas/Bill human sign-off on the child issue before treating Task 001 as fully accepted.
+
+### Objective
+Record Bill (wdhunter645) sign-off acceptance for Program #1500 Task 001 on child issue
+`#1544` and document predecessor completion for Task 002 (`#1545`) without authorizing
+Task 002 implementation from this sign-off alone.
+
+### Task 001 sign-off accepted
+
+**Scope:**
+- Program #1500 — CI Post-Merge Closeout Reliability
+- Child issue #1544 — Add pre-merge post-merge-readiness gate
+- PR #1552
+
+**Evidence:**
+- PR #1552 merged to `main` (merge SHA `90754605b1da7135c8bfdad2b422484d0ce59990`).
+- Post-Merge Detection closeout passed; `#1544` closed with `status:complete`.
+- `gate-post-merge-readiness.yml` and `post_merge_readiness_gate.mjs` on `main`.
+- Operator follow-up remains: add `post-merge-readiness` to `main` branch-protection required checks.
+
+**Disposition:**
+- Task 001 is complete and sign-off accepted (Bill / wdhunter645).
+- `#1544` predecessor requirement for `#1545` is satisfied.
+- Task 002 (`#1545`) was not started from this sign-off; explicit assignment on `#1545` still required.
+
+### GitHub issue comment mirror (#1544)
+
+Post on https://github.com/wdhunter645/next-starter-template/issues/1544 when signed in as owner:
+
+```markdown
+## Atlas/Bill sign-off — Task 001 accepted
+
+Sign-off accepted for Program #1500 Task 001 (`#1544`).
+
+**Scope:** Pre-merge post-merge-readiness gate (PR #1552)
+
+**Evidence:**
+- PR #1552 merged to `main` (`90754605b1da7135c8bfdad2b422484d0ce59990`)
+- Post-merge closeout passed; this issue closed with `status:complete`
+- Acceptance criteria met for Task 001 allowlist and verification scope
+
+**Disposition:**
+- Task 001 complete — sign-off accepted
+- Task 002 (`#1545`) predecessor satisfied; assign Codex only on explicit authorization on `#1545`
+
+— Bill (wdhunter645)
+```
+
+### Work Performed
+- Appended this sign-off record to THREAD-LOG.
+
+### Result
+Task 001 human sign-off recorded in repository ops history.
+
+### Next Action
+Post the mirror comment on `#1544` from owner account if issue-thread visibility is required. Await explicit assignment on `#1545` before Task 002 implementation.
+
+------------------------------------------------------------------------
+
 ## THREAD CLOSEOUT RECORD --- 2026-06-11 --- Program #1255 / #1258 Task 005 sign-off
 
 ### Starting State


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Records Atlas/Bill sign-off acceptance for Program #1500 Task 001 on child issue #1544.

- Appends THREAD-LOG closeout record with mirror GitHub issue comment text
- Updates program queue Task 001 status to Merged (PR #1552 + closeout verified)

No runtime or CI changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eec45154-d9db-44e8-a71d-f7ffc77ef3e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eec45154-d9db-44e8-a71d-f7ffc77ef3e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record sign-off for the pre-merge post-merge-readiness gate in Program #1500 Task 001 (`#1544`), reflecting PR `#1552` merge and closeout. Adds a THREAD-LOG closeout entry with mirrored comment text and updates the queue: Task 001 marked Merged; Task 002 (`#1545`) set to Ready, with no runtime or CI changes.

<sup>Written for commit 996af694288fd3eded00d09a4a61d2a9529809eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

