### PR TITLE
fix: harden events calendar admin operations (#1258 Task 009)

### DIFF
--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PageShell from '@/components/PageShell';
 import AdminNav from '@/components/admin/AdminNav';
+import AdminStatusText from '@/components/admin/AdminStatusText';
 import AdminTokenPanel from '@/components/admin/AdminTokenPanel';
-import { adminJson } from '@/lib/adminClient';
+import { adminJson, getStoredAdminToken } from '@/lib/adminClient';
 
 type EventRecord = {
   id: number;
@@ -105,7 +106,7 @@ function draftFromRecord(record: EventRecord): EventDraft {
 
 export default function AdminEventsPage() {
   const [month, setMonth] = useState(monthKeyFromDate());
-  const [status, setStatus] = useState('Idle.');
+  const [status, setStatus] = useState('Save an admin API token above to load events.');
   const [seedStatus, setSeedStatus] = useState('');
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -113,6 +114,8 @@ export default function AdminEventsPage() {
   const [items, setItems] = useState<EventRecord[]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [draft, setDraft] = useState<EventDraft>(EMPTY_DRAFT);
+  const [tokenReady, setTokenReady] = useState(false);
+  const loadRequestRef = useRef(0);
 
   const selected = useMemo(
     () => (selectedId === null ? null : items.find((item) => item.id === selectedId) ?? null),
@@ -120,12 +123,29 @@ export default function AdminEventsPage() {
   );
 
   const load = useCallback(async () => {
+    if (!getStoredAdminToken()) {
+      setItems([]);
+      setStatus('Save an admin API token above to load events.');
+      setLoading(false);
+      return;
+    }
+
+    const requestId = ++loadRequestRef.current;
     setLoading(true);
     setStatus(`Loading events for ${month}…`);
 
     const result = await adminJson<EventListResponse>(
       `/api/admin/events/list?month=${encodeURIComponent(month)}&limit=100`,
     );
+
+    if (requestId !== loadRequestRef.current) {
+      return;
+    }
+
+    if (!getStoredAdminToken()) {
+      setLoading(false);
+      return;
+    }
 
     if (!result.ok) {
       setItems([]);
@@ -151,6 +171,11 @@ export default function AdminEventsPage() {
   }, []);
 
   const createEvent = useCallback(async () => {
+    if (!getStoredAdminToken()) {
+      setStatus('Error: Save an admin API token above before creating events.');
+      return;
+    }
+
     setSaving(true);
     setStatus('Creating event…');
 
@@ -174,6 +199,11 @@ export default function AdminEventsPage() {
   const updateEvent = useCallback(async () => {
     if (selectedId === null) return;
 
+    if (!getStoredAdminToken()) {
+      setStatus('Error: Save an admin API token above before updating events.');
+      return;
+    }
+
     setSaving(true);
     setStatus(`Updating event ${selectedId}…`);
 
@@ -194,6 +224,11 @@ export default function AdminEventsPage() {
   }, [draft, load, selectedId]);
 
   const seedNextTen = useCallback(async () => {
+    if (!getStoredAdminToken()) {
+      setSeedStatus('Error: Save an admin API token above before seeding events.');
+      return;
+    }
+
     setSeeding(true);
     setSeedStatus('Seeding placeholder events…');
 
@@ -216,7 +251,10 @@ export default function AdminEventsPage() {
   }, [load]);
 
   useEffect(() => {
-    void load();
+    if (getStoredAdminToken()) {
+      setTokenReady(true);
+      void load();
+    }
   }, [load]);
 
   return (
@@ -225,36 +263,71 @@ export default function AdminEventsPage() {
       subtitle="Create, update, and seed events that feed the public /events page and homepage calendar."
     >
       <AdminNav />
-      <AdminTokenPanel onSaved={() => void load()} />
+      <AdminTokenPanel
+        onSaved={() => {
+          if (!getStoredAdminToken()) {
+            loadRequestRef.current += 1;
+            setTokenReady(false);
+            setLoading(false);
+            setSaving(false);
+            setSeeding(false);
+            setItems([]);
+            setSelectedId(null);
+            setDraft(EMPTY_DRAFT);
+            setSeedStatus('');
+            setStatus('Save an admin API token above to load events.');
+            return;
+          }
+          setTokenReady(true);
+          void load();
+        }}
+      />
+
+      {!tokenReady ? (
+        <p style={{ marginTop: 16, opacity: 0.85 }}>Save an admin API token above to load events.</p>
+      ) : null}
 
       <div style={{ display: 'grid', gap: 18, marginTop: 16 }}>
-        <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
-          <label style={{ display: 'grid', gap: 6 }}>
-            Month
-            <input
-              type="month"
-              value={month}
-              onChange={(event) => setMonth(event.target.value)}
-              style={fieldStyle()}
-            />
-          </label>
+        <div style={{ display: 'grid', gap: 10 }}>
+          <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+            <label style={{ display: 'grid', gap: 6 }}>
+              Month
+              <input
+                type="month"
+                value={month}
+                onChange={(event) => setMonth(event.target.value)}
+                disabled={!tokenReady}
+                style={fieldStyle()}
+              />
+            </label>
 
-          <button type="button" onClick={() => void load()} disabled={loading} style={buttonStyle(loading)}>
-            {loading ? 'Loading…' : 'Refresh'}
-          </button>
+            <button
+              type="button"
+              onClick={() => void load()}
+              disabled={loading || !tokenReady}
+              style={buttonStyle(loading || !tokenReady)}
+            >
+              {loading ? 'Loading…' : 'Refresh'}
+            </button>
 
-          <button type="button" onClick={() => void seedNextTen()} disabled={seeding} style={buttonStyle(seeding)}>
-            {seeding ? 'Seeding…' : 'Seed next 10 placeholders'}
-          </button>
+            <button
+              type="button"
+              onClick={() => void seedNextTen()}
+              disabled={seeding || !tokenReady}
+              style={buttonStyle(seeding || !tokenReady)}
+            >
+              {seeding ? 'Seeding…' : 'Seed next 10 placeholders'}
+            </button>
 
-          <button type="button" onClick={resetCreateForm} style={buttonStyle()}>
-            New event
-          </button>
+            <button type="button" onClick={resetCreateForm} disabled={!tokenReady} style={buttonStyle(!tokenReady)}>
+              New event
+            </button>
+          </div>
 
-          <span style={{ opacity: 0.85 }}>{status}</span>
+          <AdminStatusText message={status} />
         </div>
 
-        {seedStatus ? <p style={{ margin: 0, opacity: 0.85 }}>{seedStatus}</p> : null}
+        {seedStatus ? <AdminStatusText message={seedStatus} /> : null}
 
         <section style={{ border: '1px solid rgba(0,0,0,0.12)', borderRadius: 14, padding: 14 }}>
           <h2 style={{ marginTop: 0 }}>{selected ? `Edit event #${selected.id}` : 'Create event'}</h2>
@@ -370,11 +443,11 @@ export default function AdminEventsPage() {
             </label>
 
             <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-              <button type="submit" disabled={saving} style={buttonStyle(saving)}>
+              <button type="submit" disabled={saving || !tokenReady} style={buttonStyle(saving || !tokenReady)}>
                 {saving ? 'Saving…' : selected ? 'Save changes' : 'Create event'}
               </button>
               {selected ? (
-                <button type="button" onClick={resetCreateForm} style={buttonStyle()}>
+                <button type="button" onClick={resetCreateForm} disabled={!tokenReady} style={buttonStyle(!tokenReady)}>
                   Cancel edit
                 </button>
               ) : null}
@@ -404,7 +477,12 @@ export default function AdminEventsPage() {
                         status: {record.status}
                       </div>
                     </div>
-                    <button type="button" onClick={() => startEdit(record)} style={buttonStyle()}>
+                    <button
+                      type="button"
+                      onClick={() => startEdit(record)}
+                      disabled={!tokenReady}
+                      style={buttonStyle(!tokenReady)}
+                    >
                       Edit
                     </button>
                   </div>

--- a/tests/admin-events.test.tsx
+++ b/tests/admin-events.test.tsx
@@ -157,6 +157,71 @@ describe('admin events page', () => {
     });
   });
 
+  it('does not load events until an admin token is saved', async () => {
+    window.localStorage.removeItem('lgfc_admin_token');
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+
+    render(<AdminEventsPage />);
+
+    expect(screen.getAllByText(/Save an admin API token above to load events/i).length).toBeGreaterThan(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('clears event state when the admin token is removed', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const path = String(input);
+      if (path.startsWith('/api/admin/events/list')) {
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            items: [
+              {
+                id: 1,
+                title: 'Fan Club Meetup',
+                start_date: '2026-06-15',
+                end_date: '2026-06-15',
+                status: 'posted',
+              },
+            ],
+          }),
+        );
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${path}`));
+    });
+
+    render(<AdminEventsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fan Club Meetup')).toBeInTheDocument();
+    });
+
+    window.localStorage.removeItem('lgfc_admin_token');
+    fireEvent.change(screen.getByLabelText('Admin token'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save token' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Fan Club Meetup')).not.toBeInTheDocument();
+      expect(screen.getAllByText(/Save an admin API token above to load events/i).length).toBeGreaterThan(0);
+    });
+
+    expect(fetchMock.mock.calls.filter(([path]) => String(path).startsWith('/api/admin/events/list'))).toHaveLength(1);
+  });
+
+  it('announces list errors via AdminStatusText alert', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (String(input).startsWith('/api/admin/events/list')) {
+        return Promise.resolve(jsonResponse({ ok: false, error: 'Database unavailable' }, 503));
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${String(input)}`));
+    });
+
+    render(<AdminEventsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Error: Database unavailable');
+    });
+  });
+
   it('loads events with the stored admin token', async () => {
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
       const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #1561

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## QUEUE / DEPENDENCY MAP STATUS
- Dependency-map result: **pass** — Task 008 (#1560) merged on `main`.
- Next queue item: **Task 010** — Fundraiser and campaign admin delta (#1562); blocked until #1561 merges.
- Continue/halt decision: **continue** — Only Task 009 in scope.

## PROGRESS + READINESS (MANDATORY)
- Phase: Phase 4 — Website Operations Admin (`#1258`)
- Task: Task 009 — Events calendar administration delta (`#1561`)
- Status: MERGED
- Scope Confirmed: YES
- Notes: Merged as PR #1596 (merge SHA `2562444483bd91288916049644eb9c7c7212be8f`). Post-merge closeout body remediation applied.

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Canonical design reference: `/docs/reference/design/LGFC-Production-Design-and-Standards.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `src/app/admin/events/page.tsx`
- `tests/admin-events.test.tsx`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## CHANGE SUMMARY
- Gate `/admin/events` behind stored admin token with hydration-safe `tokenReady` state
- Add stale-load request guards and reset event state when token is cleared
- Surface list/seed/mutation status via `AdminStatusText` with alert semantics for errors
- Disable refresh, seed, create/update, and edit actions until token is saved
- Expanded tests (+3): no fetch without token, token-clear reset, error alert announcement

## BUILD / TEST / VERIFICATION
```bash
npm run typecheck
npx vitest run tests/admin-events.test.tsx
npm test
npm run build
```
- PASS — 19/19 events tests; 589/589 full suite at merge time
- Result summary: PASS

## REVIEWER RESPONSE ACCOUNTING
- [x] Reviewed all reviewer comments.
- [x] Gemini and Copilot dispositions received.

Reviewer items:
- review-comment:3404222935 — acknowledged — Duplicate token prompt `<p>` retained for explicit pre-token UX; `AdminStatusText` handles API errors — thread state: outdated
- review-comment:3404222944 — acknowledged — `getAllByText` retained to assert duplicate prompt surfaces during token-clear reset — thread state: outdated
- review-comment:3404222960 — acknowledged — `getAllByText` retained to assert duplicate prompt surfaces during token-clear reset — thread state: outdated
- review-comment:3404238429 — acknowledged — Create/update errors use `Create error:` / `Update error:` prefixes; list/auth errors use `Error:` prefix with `role="alert"` — thread state: outdated
- review-comment:3404238455 — acknowledged — Seed auth guard uses `Error:` prefix; operational seed failures use `Seed error:` without alert semantics by design — thread state: outdated

## ACCEPTANCE CRITERIA
- [x] Admin event CRUD safe under empty/error/auth conditions
- [x] Public calendar read paths unchanged (API tests pass)
- [x] One PR with `- **Issue:** #1561`
- [x] Task 010+ not started
- [x] Post-merge closeout criteria satisfied after merge and closeout body remediation

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches final diff exactly
- [x] ZIP safety confirmed
- [x] Local checks executed and passed
- [x] All reviewer feedback has both textual disposition and GitHub thread-state disposition
- [x] Post-merge closeout body remediation applied for merged PR governance

## POST-MERGE ISSUE DISPOSITION
- Close source **#1561** when validator passes after body apply

**Program reference:** #1255

<!-- closeout-trigger: 2026-06-12 -->
<!-- CURSOR_AGENT_PR_BODY_END -->
