### PR TITLE
test(#1259): Task 003 — auth-state validation (guest/member/admin)

### DIFF
--- a/docs/ops/implementation-plans/website-qa-production-validation.md
+++ b/docs/ops/implementation-plans/website-qa-production-validation.md
@@ -7,7 +7,7 @@ Does Not Own: Runtime implementation before child issues, unauthorized GitHub is
 Status: phase-4-active
 Task 001 complete: docs/ops/reports/website-qa-production-validation-as-built-gap-analysis.md (PR `#1657` merged `da02c01`; issue `#1659` closed)
 Task 002 complete: docs/ops/reports/website-qa-production-validation-route-nav-validation.md (PR `#1662` merged `2e811a6`; issue `#1661` closed)
-Task 003 next: auth-state validation — authorized; not yet on main
+Task 003 in progress: docs/ops/reports/website-qa-production-validation-auth-state-validation.md (PR pending)
 Project: website-qa-production-validation
 Owner: Atlas
 Execution Mode: orchestrated-after-approval
@@ -30,8 +30,8 @@ Program #1255 child project `#1259` (Website QA / Production Validation).
 Phase 3 planning for `#1259` is **complete** (planning PR `#1656` merged `b0cc0da`).
 Phase 4 Task 001 gap analysis is **complete** (PR `#1657` merged `da02c01`; issue `#1659`
 closed). Task 002 route/nav validation is **complete** (PR `#1662` merged `2e811a6`;
-issue `#1661` closed). Task 003 auth-state validation is **authorized** and next on
-the queue. Predecessor `#1258` is **closed complete** (terminal PR `#1652`). Tasks
+issue `#1661` closed). Task 003 auth-state validation is **in progress** in this
+branch. Predecessor `#1258` is **closed complete** (terminal PR `#1652`). Tasks
 004+ require explicit per-task Atlas/Bill authorization.
 
 Plan status: `phase-4-active` (not `production-ready`). Child issue creation
@@ -50,7 +50,7 @@ remains held unless explicitly authorized.
 | Legacy QA issue table | `docs/ops/reports/website-qa-production-validation-legacy-issue-reconciliation.md` |
 | Task 001 gap analysis | `docs/ops/reports/website-qa-production-validation-as-built-gap-analysis.md` |
 | Task 002 route/nav validation | `docs/ops/reports/website-qa-production-validation-route-nav-validation.md` (PR `#1662`) |
-| Task 003 auth-state validation | (pending — authorized; deliverable not yet on `main`) |
+| Task 003 auth-state validation | `docs/ops/reports/website-qa-production-validation-auth-state-validation.md` (PR pending) |
 | Ops admin handoff | `docs/how-to/website/admin-operations-overview.md` |
 | Content inventory authority | `#1256` / `docs/reference/website/content-inventory-model.md` |
 
@@ -311,6 +311,6 @@ Plan status is `phase-4-active` (not `production-ready`).
 
 Phase 3 planning exit is **complete** (planning PR `#1656` merged `b0cc0da`). Tasks 001
 and 002 are **complete** (PRs `#1657` / `#1662`; issues `#1659` / `#1661` closed).
-Task 003 auth-state validation is **authorized** and next. Tasks 004–009 require
+Task 003 auth-state validation is **in progress** in this branch. Tasks 004–009 require
 explicit per-task Atlas/Bill authorization. Child GitHub issues remain held unless
 explicitly authorized.

--- a/docs/ops/implementation-plans/website-qa-production-validation.md
+++ b/docs/ops/implementation-plans/website-qa-production-validation.md
@@ -7,7 +7,7 @@ Does Not Own: Runtime implementation before child issues, unauthorized GitHub is
 Status: phase-4-active
 Task 001 complete: docs/ops/reports/website-qa-production-validation-as-built-gap-analysis.md (PR `#1657` merged `da02c01`; issue `#1659` closed)
 Task 002 complete: docs/ops/reports/website-qa-production-validation-route-nav-validation.md (PR `#1662` merged `2e811a6`; issue `#1661` closed)
-Task 003 in progress: docs/ops/reports/website-qa-production-validation-auth-state-validation.md (PR pending)
+Task 003 complete: docs/ops/reports/website-qa-production-validation-auth-state-validation.md (PR `#1667`; issue `#1666`)
 Project: website-qa-production-validation
 Owner: Atlas
 Execution Mode: orchestrated-after-approval
@@ -30,8 +30,8 @@ Program #1255 child project `#1259` (Website QA / Production Validation).
 Phase 3 planning for `#1259` is **complete** (planning PR `#1656` merged `b0cc0da`).
 Phase 4 Task 001 gap analysis is **complete** (PR `#1657` merged `da02c01`; issue `#1659`
 closed). Task 002 route/nav validation is **complete** (PR `#1662` merged `2e811a6`;
-issue `#1661` closed). Task 003 auth-state validation is **in progress** in this
-branch. Predecessor `#1258` is **closed complete** (terminal PR `#1652`). Tasks
+issue `#1661` closed). Task 003 auth-state validation is **complete** in PR `#1667`
+(issue `#1666`). Predecessor `#1258` is **closed complete** (terminal PR `#1652`). Tasks
 004+ require explicit per-task Atlas/Bill authorization.
 
 Plan status: `phase-4-active` (not `production-ready`). Child issue creation
@@ -50,7 +50,7 @@ remains held unless explicitly authorized.
 | Legacy QA issue table | `docs/ops/reports/website-qa-production-validation-legacy-issue-reconciliation.md` |
 | Task 001 gap analysis | `docs/ops/reports/website-qa-production-validation-as-built-gap-analysis.md` |
 | Task 002 route/nav validation | `docs/ops/reports/website-qa-production-validation-route-nav-validation.md` (PR `#1662`) |
-| Task 003 auth-state validation | `docs/ops/reports/website-qa-production-validation-auth-state-validation.md` (PR pending) |
+| Task 003 auth-state validation | `docs/ops/reports/website-qa-production-validation-auth-state-validation.md` (PR `#1667`) |
 | Ops admin handoff | `docs/how-to/website/admin-operations-overview.md` |
 | Content inventory authority | `#1256` / `docs/reference/website/content-inventory-model.md` |
 
@@ -311,6 +311,6 @@ Plan status is `phase-4-active` (not `production-ready`).
 
 Phase 3 planning exit is **complete** (planning PR `#1656` merged `b0cc0da`). Tasks 001
 and 002 are **complete** (PRs `#1657` / `#1662`; issues `#1659` / `#1661` closed).
-Task 003 auth-state validation is **in progress** in this branch. Tasks 004–009 require
-explicit per-task Atlas/Bill authorization. Child GitHub issues remain held unless
-explicitly authorized.
+Task 003 auth-state validation is **complete** in PR `#1667` (issue `#1666`). Tasks
+004–009 require explicit per-task Atlas/Bill authorization. Child GitHub issues
+remain held unless explicitly authorized.

--- a/docs/ops/reports/website-qa-production-validation-auth-state-validation.md
+++ b/docs/ops/reports/website-qa-production-validation-auth-state-validation.md
@@ -1,0 +1,100 @@
+---
+Doc Type: Operations
+Audience: Human + AI
+Authority Level: Controlled
+Owns: Program #1259 Task 003 auth-state validation evidence for Website QA / Production Validation
+Does Not Own: Application code changes unless gap-only fix authorized, issue closure, or workflow YAML
+Canonical Reference: /docs/ops/implementation-plans/website-qa-production-validation.md
+Related issues: #1255, #1259, #1013, #1110
+Last Reviewed: 2026-06-15
+---
+
+# Website QA / Production Validation — Auth-State Validation
+
+## Purpose
+
+Task 003 deliverable for Program #1255 child project `#1259`. Verify guest,
+member, and admin auth behavior across layout gates, session hook redirects,
+public header variants, and logout flow. Gaps are classified with severity for
+downstream tasks.
+
+## Boundary
+
+- Auth-state scoped tests and documentation only
+- No auth provider redesign
+- Responsive viewport checklist deferred to Task 004
+
+Assessment date: **2026-06-15** (`main` after Task 002 PR `#1662` merge `2e811a6`).
+
+## Executive summary
+
+Auth-state validation **passes** with two documented pass-with-note items.
+Layout gates fail closed for guests and non-admin members. Public header and
+hamburger variants align with session state. No code fixes required in this task.
+
+| Result | Count |
+| --- | --- |
+| Pass | 16 |
+| Pass with note | 2 |
+| Fail | 0 |
+
+Automated evidence: `tests/public-auth-state-validation.test.tsx` (12 cases),
+`tests/use-member-session.test.tsx` (5 cases), plus existing
+`tests/join-login-auth.test.tsx` and `tests/admin-operations.test.tsx`.
+
+## Auth-state matrix
+
+| State | Session API (`/api/session/me`) | Public routes | `/fanclub/**` | `/admin/**` | Public header |
+| --- | --- | --- | --- | --- | --- |
+| **Guest** | non-ok / no email | Allowed | Redirect → `/` | Redirect → `/` | Join + Login |
+| **Member** | ok + email, role `member` | Allowed | Allowed | Redirect → `/` | Club Home + Logout |
+| **Admin** | ok + email, role `admin` | Allowed | Allowed | Allowed | Club Home + Logout on public pages |
+
+**Architectural note:** Route protection is client-side via `useMemberSession` in
+layout files. Brief `null` render may occur before redirect on gated routes.
+
+## Checklist
+
+| # | Check | Result | Evidence |
+| --- | --- | --- | --- |
+| 1 | Fanclub layout blocks loading state | **Pass** | `public-auth-state-validation.test.tsx` |
+| 2 | Fanclub layout blocks guests | **Pass** | same |
+| 3 | Fanclub layout allows authenticated members | **Pass** | same |
+| 4 | Admin layout blocks guests | **Pass** | same |
+| 5 | Admin layout blocks non-admin members | **Pass** | same |
+| 6 | Admin layout allows admins | **Pass** | same + `admin-operations.test.tsx` |
+| 7 | Fanclub layout uses `redirectTo: '/'` without `requireAdmin` | **Pass** | source contract test |
+| 8 | Admin layout uses `requireAdmin: true` + role check | **Pass** | source contract test |
+| 9 | `useMemberSession` redirects guests | **Pass** | `use-member-session.test.tsx` |
+| 10 | `useMemberSession` allows members on fanclub gate | **Pass** | same |
+| 11 | `useMemberSession` redirects members from admin gate | **Pass** | same |
+| 12 | `useMemberSession` allows admins on admin gate | **Pass** | same |
+| 13 | `useMemberSession` redirects on fetch failure | **Pass** | same |
+| 14 | Public header guest controls (Join/Login) | **Pass** | `public-auth-state-validation.test.tsx` |
+| 15 | Public header member controls (Club Home/Logout) | **Pass** | same |
+| 16 | Logout posts to `/api/logout` and returns home | **Pass** | logout source contract |
+| 17 | Fanclub e2e uses mocked session | **Pass with note** | `launch-readiness-fanclub-routes.spec.ts` — not true unauth redirect |
+| 18 | Client-side gate flash before redirect | **Pass with note** | Documented; no `middleware.ts` |
+
+## Gap disposition
+
+| Gap | Severity | Task 003 disposition |
+| --- | --- | --- |
+| Fanclub layout redirect untested (Task 001) | Medium | **Closed** — layout gate tests added |
+| Fanclub e2e mocked session only | Low | Documented; production smoke deferred |
+| Client-only gates (brief flash) | Low | Documented in matrix |
+| Membercard API gated paths | Low | Deferred to Task 006 surface validation |
+
+No Task 003 code fixes required.
+
+## Validation commands
+
+```bash
+npm test -- tests/public-auth-state-validation.test.tsx tests/use-member-session.test.tsx tests/join-login-auth.test.tsx tests/admin-operations.test.tsx
+
+printf '%s\n' \
+  docs/ops/reports/website-qa-production-validation-auth-state-validation.md \
+  docs/ops/implementation-plans/website-qa-production-validation.md \
+  > /tmp/task003-docs-header-list.txt
+DOCS_HEADER_FILE_LIST=/tmp/task003-docs-header-list.txt ./scripts/ci/docs_check_headers.sh .
+```

--- a/docs/ops/reports/website-qa-production-validation-auth-state-validation.md
+++ b/docs/ops/reports/website-qa-production-validation-auth-state-validation.md
@@ -38,7 +38,7 @@ hamburger variants align with session state. No code fixes required in this task
 | Pass with note | 2 |
 | Fail | 0 |
 
-Automated evidence: `tests/public-auth-state-validation.test.tsx` (12 cases),
+Automated evidence: `tests/public-auth-state-validation.test.tsx` (9 cases),
 `tests/use-member-session.test.tsx` (5 cases), plus existing
 `tests/join-login-auth.test.tsx` and `tests/admin-operations.test.tsx`.
 
@@ -63,8 +63,8 @@ layout files. Brief `null` render may occur before redirect on gated routes.
 | 4 | Admin layout blocks guests | **Pass** | same |
 | 5 | Admin layout blocks non-admin members | **Pass** | same |
 | 6 | Admin layout allows admins | **Pass** | same + `admin-operations.test.tsx` |
-| 7 | Fanclub layout uses `redirectTo: '/'` without `requireAdmin` | **Pass** | source contract test |
-| 8 | Admin layout uses `requireAdmin: true` + role check | **Pass** | source contract test |
+| 7 | Fanclub layout uses member session gate (behavioral) | **Pass** | layout gate tests |
+| 8 | Admin layout uses admin-only gate (behavioral) | **Pass** | layout gate tests |
 | 9 | `useMemberSession` redirects guests | **Pass** | `use-member-session.test.tsx` |
 | 10 | `useMemberSession` allows members on fanclub gate | **Pass** | same |
 | 11 | `useMemberSession` redirects members from admin gate | **Pass** | same |
@@ -72,7 +72,7 @@ layout files. Brief `null` render may occur before redirect on gated routes.
 | 13 | `useMemberSession` redirects on fetch failure | **Pass** | same |
 | 14 | Public header guest controls (Join/Login) | **Pass** | `public-auth-state-validation.test.tsx` |
 | 15 | Public header member controls (Club Home/Logout) | **Pass** | same |
-| 16 | Logout posts to `/api/logout` and returns home | **Pass** | logout source contract |
+| 16 | Logout posts to `/api/logout` and returns home | **Pass** | logout behavior test |
 | 17 | Fanclub e2e uses mocked session | **Pass with note** | `launch-readiness-fanclub-routes.spec.ts` — not true unauth redirect |
 | 18 | Client-side gate flash before redirect | **Pass with note** | Documented; no `middleware.ts` |
 

--- a/tests/public-auth-state-validation.test.tsx
+++ b/tests/public-auth-state-validation.test.tsx
@@ -1,0 +1,217 @@
+import { readFileSync } from 'node:fs';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AdminLayout from '@/app/admin/layout';
+import MemberLayout from '@/app/fanclub/layout';
+import Header from '@/components/Header';
+
+const mockUseMemberSession = vi.hoisted(() => vi.fn());
+const mockRouterReplace = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useMemberSession', () => ({
+  useMemberSession: mockUseMemberSession,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockRouterReplace }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function mockSessionFetch(payload: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      json: async () => payload,
+    }),
+  );
+}
+
+describe('fanclub layout auth gate (#1259 Task 003)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks children while session is loading', () => {
+    mockUseMemberSession.mockReturnValue({
+      isLoading: true,
+      isAuthenticated: false,
+      role: 'guest',
+      email: '',
+    });
+
+    render(
+      <MemberLayout>
+        <div>FanClub protected content</div>
+      </MemberLayout>,
+    );
+
+    expect(screen.queryByText('FanClub protected content')).not.toBeInTheDocument();
+  });
+
+  it('blocks unauthenticated guests from fanclub routes', () => {
+    mockUseMemberSession.mockReturnValue({
+      isLoading: false,
+      isAuthenticated: false,
+      role: 'guest',
+      email: '',
+    });
+
+    render(
+      <MemberLayout>
+        <div>FanClub protected content</div>
+      </MemberLayout>,
+    );
+
+    expect(screen.queryByText('FanClub protected content')).not.toBeInTheDocument();
+  });
+
+  it('renders children for authenticated members', () => {
+    mockUseMemberSession.mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+      role: 'member',
+      email: 'fan@example.com',
+    });
+
+    render(
+      <MemberLayout>
+        <div>FanClub protected content</div>
+      </MemberLayout>,
+    );
+
+    expect(screen.getByText('FanClub protected content')).toBeInTheDocument();
+  });
+});
+
+describe('admin layout auth gate (#1259 Task 003)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks unauthenticated users', () => {
+    mockUseMemberSession.mockReturnValue({
+      isLoading: false,
+      isAuthenticated: false,
+      role: 'guest',
+      email: '',
+    });
+
+    render(
+      <AdminLayout>
+        <div>Admin protected content</div>
+      </AdminLayout>,
+    );
+
+    expect(screen.queryByText('Admin protected content')).not.toBeInTheDocument();
+  });
+
+  it('blocks authenticated non-admin members', () => {
+    mockUseMemberSession.mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+      role: 'member',
+      email: 'fan@example.com',
+    });
+
+    render(
+      <AdminLayout>
+        <div>Admin protected content</div>
+      </AdminLayout>,
+    );
+
+    expect(screen.queryByText('Admin protected content')).not.toBeInTheDocument();
+  });
+
+  it('renders children for authenticated admins', () => {
+    mockUseMemberSession.mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+      role: 'admin',
+      email: 'admin@example.com',
+    });
+
+    render(
+      <AdminLayout>
+        <div>Admin protected content</div>
+      </AdminLayout>,
+    );
+
+    expect(screen.getByText('Admin protected content')).toBeInTheDocument();
+  });
+});
+
+describe('layout auth source contracts (#1259 Task 003)', () => {
+  it('wires fanclub layout to member session redirect', () => {
+    const source = readFileSync('src/app/fanclub/layout.tsx', 'utf8');
+    expect(source).toContain('useMemberSession');
+    expect(source).toContain("redirectTo: '/'");
+    expect(source).not.toContain('requireAdmin');
+  });
+
+  it('wires admin layout to admin-only session redirect', () => {
+    const source = readFileSync('src/app/admin/layout.tsx', 'utf8');
+    expect(source).toContain('useMemberSession');
+    expect(source).toContain("redirectTo: '/'");
+    expect(source).toContain('requireAdmin: true');
+    expect(source).toContain("role !== 'admin'");
+  });
+
+  it('documents client-side gate flash behavior in layout files', () => {
+    const fanclub = readFileSync('src/app/fanclub/layout.tsx', 'utf8');
+    const admin = readFileSync('src/app/admin/layout.tsx', 'utf8');
+    expect(fanclub).toContain('return null');
+    expect(admin).toContain('return null');
+  });
+});
+
+describe('public header auth variants (#1259 Task 003)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows guest controls when session is unauthenticated', async () => {
+    mockSessionFetch({ ok: false });
+
+    render(<Header showLogo={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Join' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('link', { name: 'Login' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Club Home' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Logout' })).not.toBeInTheDocument();
+  });
+
+  it('shows member controls when session is authenticated', async () => {
+    mockSessionFetch({ ok: true, email: 'fan@example.com', role: 'member' });
+
+    render(<Header showLogo={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Club Home' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('link', { name: 'Logout' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Join' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Login' })).not.toBeInTheDocument();
+  });
+});
+
+describe('logout flow contract (#1259 Task 003)', () => {
+  it('posts to /api/logout and returns home', () => {
+    const source = readFileSync('src/app/logout/page.tsx', 'utf8');
+    expect(source).toContain("fetch('/api/logout'");
+    expect(source).toContain("method: 'POST'");
+    expect(source).toContain("window.location.href = '/'");
+  });
+});

--- a/tests/public-auth-state-validation.test.tsx
+++ b/tests/public-auth-state-validation.test.tsx
@@ -1,9 +1,9 @@
-import { readFileSync } from 'node:fs';
 import { render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AdminLayout from '@/app/admin/layout';
+import LogoutPage from '@/app/logout/page';
 import MemberLayout from '@/app/fanclub/layout';
 import Header from '@/components/Header';
 
@@ -149,30 +149,6 @@ describe('admin layout auth gate (#1259 Task 003)', () => {
   });
 });
 
-describe('layout auth source contracts (#1259 Task 003)', () => {
-  it('wires fanclub layout to member session redirect', () => {
-    const source = readFileSync('src/app/fanclub/layout.tsx', 'utf8');
-    expect(source).toContain('useMemberSession');
-    expect(source).toContain("redirectTo: '/'");
-    expect(source).not.toContain('requireAdmin');
-  });
-
-  it('wires admin layout to admin-only session redirect', () => {
-    const source = readFileSync('src/app/admin/layout.tsx', 'utf8');
-    expect(source).toContain('useMemberSession');
-    expect(source).toContain("redirectTo: '/'");
-    expect(source).toContain('requireAdmin: true');
-    expect(source).toContain("role !== 'admin'");
-  });
-
-  it('documents client-side gate flash behavior in layout files', () => {
-    const fanclub = readFileSync('src/app/fanclub/layout.tsx', 'utf8');
-    const admin = readFileSync('src/app/admin/layout.tsx', 'utf8');
-    expect(fanclub).toContain('return null');
-    expect(admin).toContain('return null');
-  });
-});
-
 describe('public header auth variants (#1259 Task 003)', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -207,11 +183,29 @@ describe('public header auth variants (#1259 Task 003)', () => {
   });
 });
 
-describe('logout flow contract (#1259 Task 003)', () => {
-  it('posts to /api/logout and returns home', () => {
-    const source = readFileSync('src/app/logout/page.tsx', 'utf8');
-    expect(source).toContain("fetch('/api/logout'");
-    expect(source).toContain("method: 'POST'");
-    expect(source).toContain("window.location.href = '/'");
+describe('logout flow behavior (#1259 Task 003)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('posts to /api/logout, clears local storage, and returns home', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const mockLocation = { href: '' };
+    vi.stubGlobal('location', mockLocation);
+    const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem');
+
+    render(<LogoutPage />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/logout', {
+        method: 'POST',
+        credentials: 'include',
+      });
+      expect(removeItemSpy).toHaveBeenCalledWith('lgfc_member_email');
+      expect(mockLocation.href).toBe('/');
+    });
   });
 });

--- a/tests/use-member-session.test.tsx
+++ b/tests/use-member-session.test.tsx
@@ -3,10 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useMemberSession } from '@/hooks/useMemberSession';
 
-const mockRouterReplace = vi.hoisted(() => vi.fn());
+const mockRouter = vi.hoisted(() => ({ replace: vi.fn() }));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ replace: mockRouterReplace }),
+  useRouter: () => mockRouter,
 }));
 
 function mockSessionFetch(payload: unknown) {
@@ -20,7 +20,7 @@ function mockSessionFetch(payload: unknown) {
 
 describe('useMemberSession fail-closed redirects (#1259 Task 003)', () => {
   beforeEach(() => {
-    mockRouterReplace.mockReset();
+    mockRouter.replace.mockReset();
   });
 
   afterEach(() => {
@@ -33,7 +33,7 @@ describe('useMemberSession fail-closed redirects (#1259 Task 003)', () => {
     renderHook(() => useMemberSession({ redirectTo: '/' }));
 
     await waitFor(() => {
-      expect(mockRouterReplace).toHaveBeenCalledWith('/');
+      expect(mockRouter.replace).toHaveBeenCalledWith('/');
     });
   });
 
@@ -48,7 +48,7 @@ describe('useMemberSession fail-closed redirects (#1259 Task 003)', () => {
 
     expect(result.current.isAuthenticated).toBe(true);
     expect(result.current.role).toBe('member');
-    expect(mockRouterReplace).not.toHaveBeenCalled();
+    expect(mockRouter.replace).not.toHaveBeenCalled();
   });
 
   it('redirects authenticated members when admin is required', async () => {
@@ -57,7 +57,7 @@ describe('useMemberSession fail-closed redirects (#1259 Task 003)', () => {
     renderHook(() => useMemberSession({ redirectTo: '/', requireAdmin: true }));
 
     await waitFor(() => {
-      expect(mockRouterReplace).toHaveBeenCalledWith('/');
+      expect(mockRouter.replace).toHaveBeenCalledWith('/');
     });
   });
 
@@ -71,7 +71,7 @@ describe('useMemberSession fail-closed redirects (#1259 Task 003)', () => {
     });
 
     expect(result.current.role).toBe('admin');
-    expect(mockRouterReplace).not.toHaveBeenCalled();
+    expect(mockRouter.replace).not.toHaveBeenCalled();
   });
 
   it('redirects on session fetch failure', async () => {
@@ -80,7 +80,7 @@ describe('useMemberSession fail-closed redirects (#1259 Task 003)', () => {
     renderHook(() => useMemberSession({ redirectTo: '/' }));
 
     await waitFor(() => {
-      expect(mockRouterReplace).toHaveBeenCalledWith('/');
+      expect(mockRouter.replace).toHaveBeenCalledWith('/');
     });
   });
 });

--- a/tests/use-member-session.test.tsx
+++ b/tests/use-member-session.test.tsx
@@ -1,0 +1,86 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useMemberSession } from '@/hooks/useMemberSession';
+
+const mockRouterReplace = vi.hoisted(() => vi.fn());
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockRouterReplace }),
+}));
+
+function mockSessionFetch(payload: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      json: async () => payload,
+    }),
+  );
+}
+
+describe('useMemberSession fail-closed redirects (#1259 Task 003)', () => {
+  beforeEach(() => {
+    mockRouterReplace.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('redirects guests when redirectTo is configured', async () => {
+    mockSessionFetch({ ok: false });
+
+    renderHook(() => useMemberSession({ redirectTo: '/' }));
+
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('allows authenticated members without admin requirement', async () => {
+    mockSessionFetch({ ok: true, email: 'fan@example.com', role: 'member' });
+
+    const { result } = renderHook(() => useMemberSession({ redirectTo: '/' }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.role).toBe('member');
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+  });
+
+  it('redirects authenticated members when admin is required', async () => {
+    mockSessionFetch({ ok: true, email: 'fan@example.com', role: 'member' });
+
+    renderHook(() => useMemberSession({ redirectTo: '/', requireAdmin: true }));
+
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('allows authenticated admins when admin is required', async () => {
+    mockSessionFetch({ ok: true, email: 'admin@example.com', role: 'admin' });
+
+    const { result } = renderHook(() => useMemberSession({ redirectTo: '/', requireAdmin: true }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.role).toBe('admin');
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+  });
+
+  it('redirects on session fetch failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+
+    renderHook(() => useMemberSession({ redirectTo: '/' }));
+
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith('/');
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #1666

## QUEUE / DEPENDENCY MAP STATUS
- Dependency-map result: pass
- Next queue item: halt — Task 004 requires explicit Atlas/Bill authorization after Task 003 merge
- Continue/halt decision: halt — per implementation plan authorization model

## PROGRESS + READINESS
- Phase: Phase 4
- Task: Task 003 — Auth-state validation (guest/member/admin)
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: none

## DOCUMENTATION SOURCE
- [x] DIATAXIS_ROUTED

Source Files Used:
- docs/ops/implementation-plans/website-qa-production-validation.md
- docs/ops/reports/website-qa-production-validation-as-built-gap-analysis.md
- src/app/fanclub/layout.tsx
- src/app/admin/layout.tsx
- src/hooks/useMemberSession.ts

## LABEL
- Intent label for this PR: infra

## DESIGN SOURCE OF TRUTH
- Canonical design reference: /docs/reference/design/LGFC-Production-Design-and-Standards.md
- Additional design/reference docs used for this PR:
  - docs/ops/implementation-plans/website-qa-production-validation.md
  - docs/ops/reports/website-qa-production-validation-as-built-gap-analysis.md

## FILE-TOUCH ALLOWLIST
Allowed files:
- tests/public-auth-state-validation.test.tsx
- tests/use-member-session.test.tsx
- docs/ops/reports/website-qa-production-validation-auth-state-validation.md
- docs/ops/implementation-plans/website-qa-production-validation.md

All other files are out of scope

## VISUAL / UX INVARIANTS
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT
- [x] Exactly ONE intent label applied (`infra`)
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## CHANGE SUMMARY
- Add `tests/public-auth-state-validation.test.tsx` — fanclub/admin layout gates, public header guest/member variants, logout behavior test.
- Add `tests/use-member-session.test.tsx` — fail-closed redirect behavior for guest/member/admin session states.
- Publish Task 003 validation report with guest/member/admin matrix (16 pass, 2 pass-with-note, 0 fail).
- Sync implementation plan tracker: Task 003 complete in PR `#1667` / issue `#1666`.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `npm test -- tests/public-auth-state-validation.test.tsx tests/use-member-session.test.tsx tests/join-login-auth.test.tsx tests/admin-operations.test.tsx` — PASS
  - `printf '%s\n' <changed-docs> > /tmp/task003-docs-header-list.txt && DOCS_HEADER_FILE_LIST=/tmp/task003-docs-header-list.txt ./scripts/ci/docs_check_headers.sh .` — PASS
- Gate verification:
  - Commit-level workflow runs inspected: YES
  - PR-level governance/accounting workflows inspected: YES
  - Failed job logs inspected for every failing gate: YES
  - Required gates rerun or re-evaluated after fixes: YES
- Result summary: PASS

## DOCUMENTATION UPDATES
- [x] Documentation updated in this PR
- Files:
  - docs/ops/reports/website-qa-production-validation-auth-state-validation.md
  - docs/ops/implementation-plans/website-qa-production-validation.md

## REVIEWER RESPONSE ACCOUNTING
- review-comment:3421060376 — accepted — removed unused `node:fs` import after dropping source-contract tests — thread state: resolved
- review-comment:3421060395 — accepted — replaced layout source string tests with behavioral layout gate tests only — thread state: resolved
- review-comment:3421060400 — accepted — added LogoutPage behavioral test for API call, storage cleanup, and redirect — thread state: resolved
- review-comment:3421080021 — accepted — hoisted stable `mockRouter` object for `useRouter` mock — thread state: resolved
- review-comment:3421080026 — accepted — implementation plan updated to Task 003 complete in PR `#1667` — thread state: resolved
- review-comment:3421084421 — accepted — same stable router mock fix as Codex P2 — thread state: resolved

## ACCEPTANCE CRITERIA
- [x] Guest/member/admin matrix documented with fail-closed paths verified
- [x] Fanclub layout gate tested (closes Task 001 gap)
- [x] Admin layout blocks non-admin members
- [x] `npm test` for touched tests passes
- [x] No application code changes (tests + docs only)
- Post-merge source issue #1666 closure: not applicable pre-merge — delegated to post-merge automation

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections
- [x] Allowed files section matches final diff exactly
- [x] Intent label `infra` singular
- [x] Local checks executed and passed
- [x] Docs headers verified on changed markdown files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ac79408-f27d-4718-9bd9-565cdfa8725a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ac79408-f27d-4718-9bd9-565cdfa8725a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tests and docs to validate guest/member/admin auth across fanclub/admin gates, public header variants, and logout. Stabilizes the `useRouter` test mock and marks Task 003 complete per issue #1666; no application code changes.

- **New Tests and Docs**
  - Added `tests/public-auth-state-validation.test.tsx` for fanclub/admin layout gates, public header variants, and logout behavior.
  - Added `tests/use-member-session.test.tsx` for fail-closed redirects (guest/member/admin and fetch failure).
  - Replaced layout/logout string-matching tests with behavioral assertions; removed legacy `readFileSync` tests.
  - Hoisted a stable `mockRouter` for `useRouter` to prevent flaky redirect assertions.
  - Updated implementation plan to mark Task 003 complete.

- **Verification**
  - Tests pass: `npm test -- tests/public-auth-state-validation.test.tsx tests/use-member-session.test.tsx tests/join-login-auth.test.tsx tests/admin-operations.test.tsx`.
  - Docs header check passes; no app code changes.

<sup>Written for commit c1de9279dfb9a1d7791158f801c467ce1585c63d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->