### PR TITLE
docs(#1719): sync Priority #3 launch-control issues

### DIFF
--- a/docs/ops/pmo/pmo-backlog.md
+++ b/docs/ops/pmo/pmo-backlog.md
@@ -5,7 +5,7 @@ Authority Level: Operational Authority
 Owns: PMO Backlog inventory for ideas, project drafts, implementation-ready projects, backlog review history, and promotion candidates
 Does Not Own: Program launch approval, final prioritization, implementation scope, issue creation, merge authority, or Cursor execution authorization
 Canonical Reference: /docs/ops/pmo/PMO-V3-OPERATING-MODEL.md
-Related Issues: #1379, #1411, #1255, #1500, #1501, #1678, #1685, #1696
+Related Issues: #1379, #1411, #1255, #1500, #1501, #1678, #1685, #1696, #1700, #1701, #1702, #1703, #1704, #1705, #1706, #1707, #1708
 Last Reviewed: 2026-06-17
 ---
 
@@ -28,7 +28,7 @@ This document owns PMO Backlog inventory, promotion history, weekly project revi
 - **Program `#1255`** remains the active website implementation program owned by Cursor for completion.
 - **Program `#1500` is closed complete.** It may supersede or partially satisfy post-merge closeout stabilization backlog items, but it does not launch additional governance work by itself.
 - **Priority #1 Website Completion / Fan Club Product Buildout** has a parked program issue and task chain (#1685 through #1694). It remains blocked from implementation until Bill/Atlas explicitly launch or reprioritize it.
-- **Priority #2 Fundraiser / Charity Campaign Operations Buildout** now has a planning-ready documentation package: `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md` and `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md`. It remains blocked from implementation until Bill/Atlas explicitly launch it.
+- **Priority #2 Fundraiser / Charity Campaign Operations Buildout** has program issue #1700 and child issue chain #1701 through #1708. Task 001 assignment guidance is posted on #1701. It remains queued behind Program #1255/#1259 and parked Priority #1 unless Bill/Atlas explicitly reprioritize.
 - **The backlog does not authorize implementation by itself.** Production-ready documentation remains the execution gate: projects with production-ready docs can move first once explicitly authorized.
 - Filenames that still contain `program-5` (for example `docs/ops/pmo/program-5-admin-page-and-tools-design-readiness.md`) are **legacy source material** from the retired PMO v2 five-lane model. They are not active PMO v3 program authority and require PMO v3 conversion before promotion.
 
@@ -38,7 +38,7 @@ This document owns PMO Backlog inventory, promotion history, weekly project revi
 - No backlog link can be mistaken for an active PMO v3 program lane or automatic execution queue.
 - Weekly PMO project review keeps the backlog current rather than static.
 - Priority #1 remains parked until Bill/Atlas explicitly launch or reprioritize it.
-- Priority #2 is documented for later launch review once the active queue permits it.
+- Priority #2 is launch-control ready as #1700 with child tasks #1701 through #1708, pending queue authorization.
 
 ## Prioritized working backlog inventory
 
@@ -52,13 +52,13 @@ Items are sorted **top-down by current priority need** as of the Bill/Atlas PMO 
 | 1c | Content management strategy | child project | Define how website content is posted, updated, reviewed, and managed without developer intervention. | Execute via Priority #1 Tasks 004, 005, 008, and 009. | `#1256`; `docs/ops/implementation-plans/website-content-strategy-editorial-inventory.md`; `docs/ops/implementation-plans/website-completion-fan-club-product-buildout.md` | Includes upstream content collection handoff. | implementation-ready after launch authorization |
 | 1d | Content collection strategy | child project merged into 1c | Define how Lou Gehrig content is discovered, retained, credited, reviewed, and converted into site-ready content. | Implement as upstream intake/source-credit layer within content management tasks, not as a standalone program peer. | `docs/ops/pmo/website-completion-fan-club-product-buildout-readiness.md`; `docs/ops/implementation-plans/website-completion-fan-club-product-buildout.md` | Duplicate/version candidate with rank 12 resolved for Priority #1: subordinate to content management. | implementation-ready after launch authorization |
 | 1e | Website design review / as-built versus LGFC vision | child project | Compare current implementation against approved LGFC design vision and identify gaps. | Execute as Priority #1 Task 001 and validate again in Task 009. | `docs/reference/design/LGFC-Production-Design-and-Standards.md`; `docs/reference/design/fanclub-subpages.md`; `docs/ops/implementation-plans/website-completion-fan-club-product-buildout.md` | None identified. | implementation-ready after launch authorization |
-| 2 | **Fundraiser / Charity Campaign Operations Buildout** | future-program candidate | Repeatable fundraiser operations, Givebutter integration boundary, leaderboard/winner rules, homepage promotion, donor recognition without PII exposure, and launch testing. | Keep as planning-ready package until Bill/Atlas explicitly launch after active queue resolution. | `#1696`; `#1379` (historical ideas source); `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | Bill/Atlas identified this as the Priority #2 group. Prior backlog row "Fundraiser / charity campaign operations" merged here. | planning-ready; blocked until launch authorization |
-| 2a | Fundraiser operations playbook | child project | Repeatable annual setup, preview, launch, closeout, winner publication, and post-campaign archive. | Execute via Priority #2 Tasks 001, 007, and 008 after launch authorization. | `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | None identified. | planning-ready |
-| 2b | Givebutter integration model | child project | Campaign, auction, live feed, external-link, and data-boundary rules. | Execute via Priority #2 Tasks 002, 004, 006, and 007 after launch authorization. | `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | External campaign/payment/auction ownership remains outside LGFC runtime implementation. | planning-ready |
-| 2c | Leaderboard / winner system | child project | Scoring, snapshots, deterministic winner calculation, tiebreakers, and no-PII publication policy. | Execute via Priority #2 Tasks 003, 006, and 007 after launch authorization. | `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | Must not depend on raw public donor PII. | planning-ready |
-| 2d | Homepage spotlight / campaign surface | child project | Controlled fundraiser promotion, campaign status, approved links/embed behavior, and preview/review flows. | Execute via Priority #2 Tasks 004, 006, and 007 after launch authorization. | `#1255`; `docs/reference/design/LGFC-Production-Design-and-Standards.md`; `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md` | Campaign surfaces must fail closed when disabled, missing, invalid, stale, or unpublished. | planning-ready |
-| 2e | Sponsor / donor recognition | child project | Recognition rules that avoid exposing donor PII. | Execute via Priority #2 Tasks 005, 006, and 007 after launch authorization. | `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | Overlaps rank 15 Sponsor/donor recognition operations — merged for fundraiser context; non-fundraiser recognition may remain future scope. | planning-ready |
-| 2f | Testing package | child project | End-to-end fundraiser readiness checklist before public launch. | Execute via Priority #2 Tasks 007 and 008 after launch authorization. | `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | None identified. | planning-ready |
+| 2 | **Fundraiser / Charity Campaign Operations Buildout** | launch-control ready future program | Repeatable fundraiser operations, Givebutter integration boundary, leaderboard/winner rules, homepage promotion, donor recognition without PII exposure, and launch testing. | Keep queued behind Program #1255/#1259 and parked Priority #1 unless Bill/Atlas explicitly launch or reprioritize. | `#1696`; `#1700`; `#1701`–`#1708`; `#1379` (historical ideas source); `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | Bill/Atlas identified this as the Priority #2 group. Prior backlog row "Fundraiser / charity campaign operations" merged here. | launch-control ready; blocked until queue authorization |
+| 2a | Fundraiser operations playbook | child project | Repeatable annual setup, preview, launch, closeout, winner publication, and post-campaign archive. | Execute via #1701 after queue authorization. | `#1701`; `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | None identified. | launch-control ready |
+| 2b | Givebutter integration model | child project | Campaign, auction, live feed, external-link, and data-boundary rules. | Execute via #1702 after #1701. | `#1702`; `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | External campaign/donation/campaign ownership remains outside LGFC runtime implementation. | launch-control ready |
+| 2c | Leaderboard / winner system | child project | Scoring, snapshots, deterministic winner calculation, tiebreakers, and no-PII publication policy. | Execute via #1703 after #1701 and #1702. | `#1703`; `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | Must not depend on raw public donor PII. | launch-control ready |
+| 2d | Homepage spotlight / campaign surface | child project | Controlled fundraiser promotion, campaign status, approved links/embed behavior, and preview/review flows. | Execute via #1704 after #1701 and #1702. | `#1704`; `#1255`; `docs/reference/design/LGFC-Production-Design-and-Standards.md`; `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md` | Campaign surfaces must fail closed when disabled, missing, invalid, stale, or unpublished. | launch-control ready |
+| 2e | Sponsor / donor recognition | child project | Recognition rules that avoid exposing donor PII. | Execute via #1705 after #1701 through #1704. | `#1705`; `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | Overlaps rank 15 Sponsor/donor recognition operations — merged for fundraiser context; non-fundraiser recognition may remain future scope. | launch-control ready |
+| 2f | Testing package | child project | End-to-end fundraiser readiness checklist before public launch. | Execute via #1707 after #1706; close out through #1708. | `#1707`; `#1708`; `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`; `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` | None identified. | launch-control ready |
 | 3 | PMO v3 authority (former `#1411` area) | governance/ops backlog | Durable PMO v3 language: program issue numbers identify programs; PMO Backlog holds ideas/project drafts. | Retain as reference; implement only if a current open source issue authorizes and scope does not conflict with active website work. | `#1411`, `docs/ops/pmo/PMO-V3-OPERATING-MODEL.md`, `docs/ops/implementation-plans/program-1-pmo-automation-agent-workflow-control.md` | Former Program `#1411` project area — not automatically executable. | partial |
 | 4 | Workflow Automation Design Migration (former `#1411` area) | governance/ops backlog | Migrate Workflow Automation design from backlog/Drive/chat into GitHub documentation authority. | Review `docs/ops/pmo/workflow-automation.md` for gaps; authorize implementation only through a current open source issue. | `#1411`, `docs/ops/pmo/workflow-automation.md` | Promoted from backlog into `#1411` planning; now inventory again. | partial |
 | 5 | Cursor Continuation and Queue Contract (former `#1411` area) | governance/ops backlog | Rules for when Cursor continues, stops, reports validation, and waits at review handoff. | Align with `docs/reference/pmo/lgfc-cursor-execution-contract.md` during authorized governance work only. | `#1411`, `#1417`–`#1424` (stale task issues) | Task issues `#1417`–`#1424` contain stale PMO v2 terminology — flag for review, do not delete. | partial |
@@ -94,7 +94,7 @@ Items are sorted **top-down by current priority need** as of the Bill/Atlas PMO 
 
 Priority #1 is classified as **implementation-ready after launch authorization** because its readiness package, implementation plan, and parked issue chain exist in repository documentation.
 
-Priority #2 is classified as **planning-ready** because its readiness package and implementation plan exist in repository documentation, but it remains blocked from implementation until Atlas/Bill explicitly launch it and create child implementation issues.
+Priority #2 is classified as **launch-control ready** because its readiness package, implementation plan, master program issue, child task issues, predecessor/successor chain, and Task 001 assignment guidance exist in repository documentation/GitHub issue authority.
 
 No backlog item may execute from this classification alone. Cursor execution still requires a current program/task/source issue and explicit Bill/Atlas launch or assignment authorization.
 
@@ -113,7 +113,7 @@ A **weekly PMO project review** is the mechanism to review backlog items, define
 
 - **Priority order guides discussion**, but **production-ready documentation remains the execution gate.**
 - Items with `implementation-ready` readiness may move first **only after** explicit Atlas/Bill authorization through a current open program or source issue.
-- Items with `planning-ready` readiness may be reviewed for launch sequencing but may not execute until a current launch source issue authorizes them.
+- Items with `launch-control ready` readiness may be reviewed for launch sequencing but may not execute until a current launch source issue authorizes them.
 - This backlog is reviewed and updated regularly — it is **not** a static archive.
 
 ### Meeting outputs
@@ -121,7 +121,7 @@ A **weekly PMO project review** is the mechanism to review backlog items, define
 Each weekly review should record:
 
 - backlog items discussed and rank adjustments;
-- classification changes (idea → project draft → governance/ops backlog → planning-ready → implementation-ready);
+- classification changes (idea → project draft → governance/ops backlog → planning-ready → launch-control ready → implementation-ready);
 - promotion decisions and deferrals;
 - required documentation PRs;
 - duplicate/version artifacts identified for merge, archive, or retention;
@@ -141,7 +141,7 @@ Future PMO review should identify:
 | Historical evidence to keep | `#1379`, `#1411` planning artifacts, `program-3-*` / `program-5-*` legacy filenames, task issues `#1417`–`#1424` |
 | Obsolete references to archive | Stale PMO v2 Program 1–5 lane labels in child task issues (review only — do not mutate issues from backlog doc updates) |
 | Items superseded by `#1500` | Post-merge closeout evidence stabilization (rank 9); queue/wave model (rank 8) only to the extent documented by Program #1500 closeout evidence |
-| Items promoted into future programs | Website Completion (rank 1) is parked and implementation-ready-after-launch; Fundraiser Buildout (rank 2) is planning-ready and blocked from execution |
+| Items promoted into future programs | Website Completion (rank 1) is parked and implementation-ready-after-launch; Fundraiser Buildout (rank 2) is launch-control ready and queued behind active/higher-priority programs |
 
 ## PMO v3 execution rule (non-negotiable)
 
@@ -157,6 +157,7 @@ Future PMO review should identify:
 | 2026-06-11 | Bill/Atlas PMO v3 priority review: `#1411` closed — former project areas moved to governance/ops backlog inventory. Backlog converted to prioritized working list. Website Completion / Fan Club Product Buildout and Fundraiser / Charity Campaign Operations Buildout documented as high-priority future program draft candidates. Weekly PMO project review added. Program `#1500` noted as current stabilization preparation track. |
 | 2026-06-16 | Priority #1 readiness package created under #1678. Website Completion / Fan Club Product Buildout is documented as the next-program candidate for Cursor assignment after explicit Bill/Atlas launch authorization. Content collection rank 1d is subordinated to content management strategy for normal editorial intake/source-credit workflow. |
 | 2026-06-17 | Priority #2 readiness package created under #1696. Fundraiser / Charity Campaign Operations Buildout is documented as planning-ready for later launch review, with Givebutter boundary rules, donor privacy controls, campaign-surface fail-closed expectations, and pre-launch testing requirements. |
+| 2026-06-17 | Priority #2 launch-control layer created as #1700 with child task issues #1701 through #1708 and Task 001 assignment guidance on #1701. |
 
 ## Recently promoted (historical)
 
@@ -164,7 +165,7 @@ Future PMO review should identify:
 | --- | --- | --- |
 | Workflow Automation | Program `#1411` — PMO Automation and Agent Workflow Control | Promoted through `#1411` planning cycle. `#1411` is now closed; workflow automation areas return to backlog inventory (rank 4) unless relaunched through a current open source issue. |
 | Website Completion / Fan Club Product Buildout | Priority #1 next-program candidate | Promoted from project draft to implementation-ready-after-launch documentation package by #1678; parked as #1685/#1686–#1694 pending launch authorization. |
-| Fundraiser / Charity Campaign Operations Buildout | Priority #2 future-program candidate | Promoted from project draft to planning-ready documentation package by #1696; remains blocked from implementation until Bill/Atlas launch authorization. |
+| Fundraiser / Charity Campaign Operations Buildout | Priority #2 future-program candidate | Promoted from project draft to planning-ready documentation package by #1696; launch-control layer created as #1700/#1701–#1708; remains queued until Bill/Atlas launch authorization. |
 
 ## Promotion checklist
 

--- a/docs/ops/pmo/program-registry.md
+++ b/docs/ops/pmo/program-registry.md
@@ -5,7 +5,7 @@ Authority Level: Operational Authority
 Owns: PMO program issue registry, current program issue assignments, launch-state control, child-project mapping, and authoritative execution chain for LGFC orchestrated work
 Does Not Own: PMO v3 top-level policy, implementation plan task definitions, workflow code, runtime behavior, product design, or unauthorized GitHub issue mutation
 Canonical Reference: /docs/ops/pmo/PMO-V3-OPERATING-MODEL.md
-Related Issues: #1411, #1417, #1418, #1419, #1420, #1421, #1422, #1423, #1424, #1379, #1255, #1256, #1258, #1259, #1501, #1500, #1678, #1685, #1696
+Related Issues: #1411, #1417, #1418, #1419, #1420, #1421, #1422, #1423, #1424, #1379, #1255, #1256, #1258, #1259, #1501, #1500, #1678, #1685, #1696, #1700, #1701, #1702, #1703, #1704, #1705, #1706, #1707, #1708
 Last Reviewed: 2026-06-17
 ---
 
@@ -30,7 +30,8 @@ unauthorized GitHub issue mutation.
 - Child project #1259 is open and active for Phase 4 execution; Tasks 001–004 are complete; Task 005+ is held pending per-task authorization.
 - issue #1500 (CI Post-Merge Closeout Reliability) is **closed complete**.
 - Priority #1 Website Completion / Fan Club Product Buildout is parked as program issue #1685 with child issues #1686 through #1694; it remains blocked until Atlas/Bill explicitly launch or reprioritize it.
-- Priority #2 Fundraiser / Charity Campaign Operations Buildout now has a planning-ready documentation package: `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`. Implementation plan: `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md`. It remains blocked from execution.
+- Priority #2 Fundraiser / Charity Campaign Operations Buildout has program issue #1700 with child task issues #1701 through #1708. Task 001 assignment guidance is posted on #1701. The program remains queued behind Program #1255/#1259 and parked Priority #1 unless Bill/Atlas explicitly reprioritize.
+- issue #1696 completed the Priority #2 documentation package and is historical source evidence after merge of #1697.
 - issue #1411 is completed — a planning/control artifact, not an open blocked program.
 - GitHub issue titles use `Program: <name>`. Documentation references use `Program #<issue-number> — <name>`.
 
@@ -41,7 +42,7 @@ unauthorized GitHub issue mutation.
 - Child projects under each program are clearly subordinate to their umbrella
   program issue.
 - Priority #1 can be launched as a PMO v3 program when Bill/Atlas explicitly authorize it and update the parked program issue state.
-- Priority #2 can become a PMO v3 program after Bill/Atlas explicitly authorize launch and create or update the relevant program issue.
+- Priority #2 is ready for launch review because the master program issue, child task issues, predecessor/successor chain, and Task 001 assignment guidance exist.
 
 Program issue numbers identify programs going forward. Future programs should use
 `Program #<issue-number> — <name>` in documentation. GitHub issue titles use
@@ -95,7 +96,7 @@ Future programs are created as GitHub program issues when Atlas/Bill approve a n
 | Candidate | Backlog rank | Status | Launch rule | Planning package | Implementation plan |
 | --- | ---: | --- | --- | --- | --- |
 | Website Completion / Fan Club Product Buildout | 1 | Parked; implementation-ready after launch authorization | Blocked until Atlas/Bill explicitly launch or reprioritize the parked program issue #1685 | `docs/ops/pmo/website-completion-fan-club-product-buildout-readiness.md` | `docs/ops/implementation-plans/website-completion-fan-club-product-buildout.md` |
-| Fundraiser / Charity Campaign Operations Buildout | 2 | Planning-ready; blocked from execution | Blocked until production-ready launch authorization exists and child implementation issues are explicitly created | `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md` | `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` |
+| Fundraiser / Charity Campaign Operations Buildout | 2 | Launch-control ready; queued behind active/parked higher-priority programs | Blocked until Atlas/Bill explicitly authorize Cursor to begin #1701 | `docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md` | `docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md` |
 
 ### Priority #1 candidate child projects
 
@@ -109,14 +110,16 @@ Future programs are created as GitHub program issues when Atlas/Bill approve a n
 
 ### Priority #2 candidate child projects
 
-| Child project | PMO decision | Implementation-plan coverage |
-| --- | --- | --- |
-| Fundraiser operations playbook | Included in Priority #2 | Tasks 001, 007, 008 |
-| Givebutter integration model | Included in Priority #2; external/vendor configuration remains out of scope | Tasks 002, 004, 006, 007 |
-| Leaderboard / winner system | Included in Priority #2; deterministic and privacy-safe | Tasks 003, 006, 007 |
-| Homepage spotlight / campaign surface | Included in Priority #2; must fail closed | Tasks 004, 006, 007 |
-| Sponsor / donor recognition | Included in Priority #2; merges rank 15 duplicate/version scope for fundraiser context | Tasks 005, 006, 007 |
-| Testing package | Required before launch | Tasks 007 and 008 |
+| Child project | PMO decision | Implementation-plan coverage | Issue |
+| --- | --- | --- | --- |
+| Fundraiser operations playbook | Included in Priority #2 | Tasks 001, 007, 008 | #1701 |
+| Givebutter integration model | Included in Priority #2; external/vendor configuration remains out of scope | Tasks 002, 004, 006, 007 | #1702 |
+| Leaderboard / winner system | Included in Priority #2; deterministic and privacy-safe | Tasks 003, 006, 007 | #1703 |
+| Homepage spotlight / campaign surface | Included in Priority #2; must fail closed | Tasks 004, 006, 007 | #1704 |
+| Sponsor / donor recognition | Included in Priority #2; merges rank 15 duplicate/version scope for fundraiser context | Tasks 005, 006, 007 | #1705 |
+| Website-side campaign configuration and display implementation | Included in Priority #2 after Tasks 002–005 | Task 006 | #1706 |
+| Testing package | Required before launch | Tasks 007 and 008 | #1707 |
+| Program closeout and operator handoff | Terminal closeout | Task 008 | #1708 |
 
 ## Staged / blocked program issues
 
@@ -124,7 +127,8 @@ Future programs are created as GitHub program issues when Atlas/Bill approve a n
 | --- | --- | --- | --- | --- |
 | #1411 | PMO Automation and Agent Workflow Control | Program 1 | Completed planning artifact (issue closed, status:complete) | issue #1411 is not an open blocked program. New execution requires a current open source issue. PMO automation execution remains blocked until Atlas/Bill explicitly launch a new cycle. |
 | #1685 | Website Completion / Fan Club Product Buildout | none | Parked future program issue | Remains blocked until Atlas/Bill explicitly authorize launch or reprioritization. |
-| #1696 | Fundraiser / Charity Campaign Operations Buildout documentation package | none | Planning package source issue | Planning/documentation only; does not launch implementation or child issues. |
+| #1696 | Fundraiser / Charity Campaign Operations Buildout documentation package | none | Completed planning source issue | Planning documentation completed by #1697; does not itself launch implementation. |
+| #1700 | Fundraiser / Charity Campaign Operations Buildout | none | Launch-control ready | Child issues #1701–#1708 exist; Task 001 assignment guidance is posted on #1701; execution waits for explicit queue authorization. |
 
 ## Historical program evidence
 
@@ -145,7 +149,7 @@ Completed program cycles remain audit evidence and may be cited for historical c
 | Is a program issue | No |
 | Executable by itself | No |
 | Review cadence | Reviewed as a primary agenda item during PMO meetings |
-| Current top candidate | Website Completion / Fan Club Product Buildout remains parked; Fundraiser / Charity Campaign Operations Buildout is documented as the next prepared package after active queue resolution |
+| Current top candidate | Website Completion / Fan Club Product Buildout remains parked; Fundraiser / Charity Campaign Operations Buildout is launch-control ready as #1700–#1708 after active queue resolution or explicit reprioritization |
 
 ## Program #1411 — PMO Automation and Agent Workflow Control
 
@@ -208,6 +212,8 @@ Program #1255 remains controlled by its own active source issues and Cursor exec
 - Priority #1 implementation plan: `/docs/ops/implementation-plans/website-completion-fan-club-product-buildout.md`
 - Priority #2 readiness: `/docs/ops/pmo/fundraiser-charity-campaign-operations-buildout-readiness.md`
 - Priority #2 implementation plan: `/docs/ops/implementation-plans/fundraiser-charity-campaign-operations-buildout.md`
+- Priority #2 program: `#1700`
+- Priority #2 task issues: `#1701` through `#1708`
 - Cursor execution contract: `/docs/reference/pmo/lgfc-cursor-execution-contract.md`
 - PMO critical path: `/docs/ops/pmo/critical-path.md`
 - Workflow Automation authority: `/docs/ops/pmo/workflow-automation.md`


### PR DESCRIPTION
Closed by Atlas: opened from the wrong stale branch (`docs/priority-2-program-issue-sync`). Do not merge. A corrected Priority #3 sync PR will be opened from a fresh branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs PMO docs to reflect Priority #2 Fundraiser program as launch-control ready, with program issue #1700 and child issues #1701–#1708. Addresses #1719 by updating status, issue links, and execution guidance to clarify the launch path and queue state.

- **Refactors**
  - `docs/ops/pmo/pmo-backlog.md`
    - Added #1700–#1708 to Related Issues and inventory.
    - Reclassified Priority #2 from planning-ready to launch-control ready; updated rows 2, 2a–2f with issue sequencing and gating.
    - Updated readiness ladder, meeting outputs, and history to include the launch-control layer and Task 001 guidance on #1701.
  - `docs/ops/pmo/program-registry.md`
    - Added #1700–#1708 to Related Issues; documented #1700 as the master with queued status.
    - Updated candidate table: Priority #2 now launch-control ready; launch rule points to starting #1701.
    - Mapped Priority #2 child projects to specific issues (#1701–#1708); marked #1696 as completed planning; added cross-references at the end.

<sup>Written for commit 24ad74fc9271a339c63e6358c3cc91dfa4c3337e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

