### PR TITLE
Enforce reviewer lifecycle gate on review and comment events

### DIFF
--- a/.github/workflows/gate-reviewer-response.yml
+++ b/.github/workflows/gate-reviewer-response.yml
@@ -2,7 +2,8 @@ name: GATE — Reviewer Response
 
 # Superseded by Task 003 reviewer lifecycle redesign.
 # Active enforcement lives in reviewer-response-completion.yml, which uses
-# scripts/ci/reviewer_lifecycle_gate.mjs for protected-scope blocking only.
+# scripts/ci/reviewer_lifecycle_gate.mjs for blocking on pull_request_target,
+# pull_request_review, pull_request_review_comment, and PR issue_comment events.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/reviewer-response-completion.yml
+++ b/.github/workflows/reviewer-response-completion.yml
@@ -90,8 +90,13 @@ jobs:
               return;
             }
 
-            const enforceFailure = eventName === 'pull_request_target';
-            core.info(`Running reviewer lifecycle gate for PR #${prNumber} (enforceFailure=${enforceFailure}).`);
+            const enforceFailure = [
+              'pull_request_target',
+              'pull_request_review',
+              'pull_request_review_comment',
+              'issue_comment',
+            ].includes(eventName);
+            core.info(`Running reviewer lifecycle gate for PR #${prNumber} (event=${eventName}, enforceFailure=${enforceFailure}, head context via API).`);
 
             const { execFileSync } = require('node:child_process');
             execFileSync(

--- a/docs/reference/ci/reviewer-lifecycle-surface.md
+++ b/docs/reference/ci/reviewer-lifecycle-surface.md
@@ -22,7 +22,7 @@ not satisfy enforcement by themselves.
 
 | Workflow file | Display name | Enforcement |
 |---|---|---|
-| `reviewer-response-completion.yml` | `GATE — Reviewer Response Completion` | Blocking on `pull_request_target` when any actionable trusted reviewer comment lacks PR-body disposition, when outdated threads lack explicit disposition, when late pre-merge comments remain undispositioned (dispositioned late findings are informational only), or when protected CI scope has unresolved protected review threads or lacks a current-head trusted review artifact on the enforced head SHA |
+| `reviewer-response-completion.yml` | `GATE — Reviewer Response Completion` | Blocking on `pull_request_target`, `pull_request_review`, `pull_request_review_comment`, and PR `issue_comment` events when any actionable trusted reviewer comment lacks PR-body disposition, when outdated threads lack explicit disposition, when late pre-merge comments remain undispositioned (dispositioned late findings are informational only), or when protected CI scope has unresolved protected review threads or lacks a current-head trusted review artifact on the enforced head SHA |
 | `gate-reviewer-response.yml` | `GATE — Reviewer Response` | Retired manual-only stub; superseded by Task 003 redesign |
 
 ## Protected Scope

--- a/scripts/ci/reviewer-gate-simulation.mjs
+++ b/scripts/ci/reviewer-gate-simulation.mjs
@@ -12,7 +12,17 @@ const [parsedOwner, parsedRepo] = (process.env.GITHUB_REPOSITORY || '').split('/
 const DEFAULT_OWNER = parsedOwner || 'owner';
 const DEFAULT_REPO = parsedRepo || 'repo';
 const REMEDIATION_LABELS = new Set(['governance', 'ci', 'remediation', 'hotfix-governance']);
+export const ENFORCING_REVIEWER_LIFECYCLE_EVENTS = new Set([
+  'pull_request_target',
+  'pull_request_review',
+  'pull_request_review_comment',
+  'issue_comment',
+]);
 const INTENT_CONFIG_PATH = path.resolve('scripts/ci/pr_intent_allowlists.json');
+
+export function isEnforcingReviewerLifecycleEvent(eventName = '') {
+  return ENFORCING_REVIEWER_LIFECYCLE_EVENTS.has(eventName);
+}
 
 export function loadIntentConfig(configPath = INTENT_CONFIG_PATH) {
   return JSON.parse(fs.readFileSync(configPath, 'utf8'));
@@ -137,7 +147,9 @@ export function evaluateReviewerAccounting({
   const remediation = hasRemediationLabel(labels);
   const advisoryDowngraded = remediation && advisoryFindings > 0;
 
-  if (eventName === 'pull_request_target' && undispositionedReviewerComments > 0) {
+  const enforcingEvent = isEnforcingReviewerLifecycleEvent(eventName);
+
+  if (enforcingEvent && undispositionedReviewerComments > 0) {
     return {
       ok: false,
       severity: 'blocking',
@@ -147,7 +159,7 @@ export function evaluateReviewerAccounting({
     };
   }
 
-  if (eventName === 'pull_request_target' && outdatedWithoutDisposition > 0) {
+  if (enforcingEvent && outdatedWithoutDisposition > 0) {
     return {
       ok: false,
       severity: 'blocking',
@@ -157,7 +169,7 @@ export function evaluateReviewerAccounting({
     };
   }
 
-  if (eventName === 'pull_request_target' && lateUndispositionedReviewerComments > 0) {
+  if (enforcingEvent && lateUndispositionedReviewerComments > 0) {
     return {
       ok: false,
       severity: 'blocking',
@@ -169,7 +181,7 @@ export function evaluateReviewerAccounting({
 
   if (
     scope.hasProtectedScope &&
-    eventName === 'pull_request_target' &&
+    enforcingEvent &&
     breakGlassOverride
   ) {
     return {
@@ -191,7 +203,7 @@ export function evaluateReviewerAccounting({
     };
   }
 
-  if (scope.hasProtectedScope && eventName === 'pull_request_target' && !currentHeadLinkedReview) {
+  if (scope.hasProtectedScope && enforcingEvent && !currentHeadLinkedReview) {
     return {
       ok: false,
       severity: 'blocking',

--- a/scripts/ci/reviewer_lifecycle_gate.mjs
+++ b/scripts/ci/reviewer_lifecycle_gate.mjs
@@ -5,12 +5,15 @@ import { pathToFileURL } from 'node:url';
 import {
   classifyProtectedScope,
   evaluateReviewerAccounting,
+  isEnforcingReviewerLifecycleEvent,
 } from './reviewer-gate-simulation.mjs';
 import {
   evaluateReviewerCommentDisposition,
   hasValidDisposition,
   parseReviewerDispositions,
 } from './reviewer_comment_disposition.mjs';
+
+export { isEnforcingReviewerLifecycleEvent } from './reviewer-gate-simulation.mjs';
 
 export const TRUSTED_REVIEWERS = [
   {
@@ -283,7 +286,7 @@ export function buildReviewerLifecycleReport({
     if (staleTrustedReviewOnly) {
       lines.push('Trusted review exists on an earlier commit only; re-run trusted review on the current head SHA.');
     }
-  } else if (advisoryFindings > 0) {
+  } else if (advisoryFindings > 0 && !enforceFailure) {
     lines.push('', 'Advisory reviewer findings remain visible for PR readiness but do not block merge by timing alone.');
   }
 
@@ -422,7 +425,7 @@ export async function runReviewerLifecycleGate({
   repo,
   prNumber,
   eventName = 'pull_request_target',
-  enforceFailure = eventName === 'pull_request_target',
+  enforceFailure = isEnforcingReviewerLifecycleEvent(eventName),
 }) {
   const pull = await request(`/repos/${owner}/${repo}/pulls/${prNumber}`, token);
   const [files, issueComments, reviewComments, reviews, readyForReviewAt] = await Promise.all([
@@ -477,7 +480,7 @@ async function main() {
   const repository = process.env.GITHUB_REPOSITORY;
   const prNumber = process.env.PR_NUMBER;
   const eventName = process.env.GITHUB_EVENT_NAME || 'pull_request_target';
-  const enforceFailure = (process.env.ENFORCE_FAILURE || (eventName === 'pull_request_target' ? 'true' : 'false')) === 'true';
+  const enforceFailure = (process.env.ENFORCE_FAILURE || (isEnforcingReviewerLifecycleEvent(eventName) ? 'true' : 'false')) === 'true';
 
   if (!token || !repository || !prNumber) {
     throw new Error('GITHUB_TOKEN/GH_TOKEN, GITHUB_REPOSITORY, and PR_NUMBER are required.');

--- a/scripts/ci/reviewer_lifecycle_gate.mjs
+++ b/scripts/ci/reviewer_lifecycle_gate.mjs
@@ -286,7 +286,7 @@ export function buildReviewerLifecycleReport({
     if (staleTrustedReviewOnly) {
       lines.push('Trusted review exists on an earlier commit only; re-run trusted review on the current head SHA.');
     }
-  } else if (advisoryFindings > 0 && !enforceFailure) {
+  } else if (advisoryFindings > 0) {
     lines.push('', 'Advisory reviewer findings remain visible for PR readiness but do not block merge by timing alone.');
   }
 

--- a/tests/reviewer-lifecycle-gate.test.mjs
+++ b/tests/reviewer-lifecycle-gate.test.mjs
@@ -38,16 +38,32 @@ describe('reviewer lifecycle gate assessment', () => {
     expect(result.assessment.reason).toBe('missing-current-head-review-for-protected-scope');
   });
 
-  it('does not enforce failure on non-target events', () => {
+  it('enforces failure on pull_request_review events with undispositioned comments', () => {
     const result = assessReviewerLifecycle({
       eventName: 'pull_request_review',
       labels: ['infra'],
       files: ['.github/workflows/reviewer-response-completion.yml'],
-      enforceFailure: false,
-      currentHeadLinkedReview: false,
+      enforceFailure: true,
+      headSha: 'abc123',
+      body: '## REVIEWER RESPONSE ACCOUNTING\n- reviewed',
+      reviewComments: [{
+        id: 4001,
+        user: { login: 'copilot-pull-request-reviewer[bot]' },
+        commit_id: 'abc123',
+        path: 'src/app/page.tsx',
+        line: 10,
+        body: 'P1: Please fix this issue.',
+        created_at: '2026-06-01T00:00:00Z',
+      }],
+      reviews: [{
+        user: { login: 'copilot-pull-request-reviewer[bot]' },
+        commit_id: 'abc123',
+        state: 'COMMENTED',
+      }],
     });
 
-    expect(result.shouldFail).toBe(false);
+    expect(result.shouldFail).toBe(true);
+    expect(result.assessment.severity).toBe('blocking');
   });
 
   it('detects current-head linked trusted review artifacts', () => {

--- a/tests/reviewer-response-gate.test.mjs
+++ b/tests/reviewer-response-gate.test.mjs
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import { assessReviewerResponseGate } from '../scripts/ci/reviewer-response-gate.mjs';
+import { assessReviewerLifecycle } from '../scripts/ci/reviewer_lifecycle_gate.mjs';
+import { evaluateReviewerAccounting, isEnforcingReviewerLifecycleEvent } from '../scripts/ci/reviewer-gate-simulation.mjs';
+
+const trustedInlineComment = {
+  id: 7001,
+  user: { login: 'copilot-pull-request-reviewer[bot]' },
+  commit_id: 'head-sha',
+  path: 'src/app/page.tsx',
+  line: 10,
+  body: 'P1: Please fix this blocking issue.',
+  created_at: '2026-06-01T00:00:00Z',
+};
+
+const dispositionBody = [
+  '## REVIEWER RESPONSE ACCOUNTING',
+  '- review-comment:7001 — accepted — Fixed in latest commit — thread state: resolved',
+].join('\n');
+
+describe('reviewer lifecycle enforcing events', () => {
+  it('recognizes all pre-merge reviewer lifecycle enforcing events', () => {
+    expect(isEnforcingReviewerLifecycleEvent('pull_request_target')).toBe(true);
+    expect(isEnforcingReviewerLifecycleEvent('pull_request_review')).toBe(true);
+    expect(isEnforcingReviewerLifecycleEvent('pull_request_review_comment')).toBe(true);
+    expect(isEnforcingReviewerLifecycleEvent('issue_comment')).toBe(true);
+    expect(isEnforcingReviewerLifecycleEvent('pull_request')).toBe(false);
+  });
+});
+
+describe('reviewer response gate enforcement by event', () => {
+  it('passes initial pull_request_target with no reviewer comments', () => {
+    const lifecycle = assessReviewerLifecycle({
+      eventName: 'pull_request_target',
+      labels: ['infra'],
+      files: ['src/app/page.tsx'],
+      enforceFailure: true,
+      headSha: 'head-sha',
+      body: '## REVIEWER RESPONSE ACCOUNTING\n- reviewed',
+      reviewComments: [],
+      reviews: [],
+      issueComments: [],
+    });
+
+    expect(lifecycle.shouldFail).toBe(false);
+    expect(lifecycle.assessment.ok).toBe(true);
+  });
+
+  it('fails pull_request_review_comment when trusted inline comment is undispositioned', () => {
+    const lifecycle = assessReviewerLifecycle({
+      eventName: 'pull_request_review_comment',
+      labels: ['infra'],
+      files: ['src/app/page.tsx'],
+      enforceFailure: true,
+      headSha: 'head-sha',
+      body: '## REVIEWER RESPONSE ACCOUNTING\n- reviewed',
+      reviewComments: [trustedInlineComment],
+    });
+
+    expect(lifecycle.shouldFail).toBe(true);
+    expect(lifecycle.assessment.severity).toBe('blocking');
+    expect(lifecycle.assessment.reason).toBe('undispositioned-reviewer-comment');
+  });
+
+  it('fails pull_request_review when trusted review submission is undispositioned', () => {
+    const lifecycle = assessReviewerLifecycle({
+      eventName: 'pull_request_review',
+      labels: ['infra'],
+      files: ['src/app/page.tsx'],
+      enforceFailure: true,
+      headSha: 'head-sha',
+      body: '## REVIEWER RESPONSE ACCOUNTING\n- reviewed',
+      reviews: [{
+        id: 8001,
+        user: { login: 'gemini-code-assist[bot]' },
+        commit_id: 'head-sha',
+        state: 'CHANGES_REQUESTED',
+        body: 'P1: Request changes before merge.',
+        submitted_at: '2026-06-01T00:00:00Z',
+      }],
+    });
+
+    expect(lifecycle.shouldFail).toBe(true);
+    expect(lifecycle.assessment.severity).toBe('blocking');
+    expect(lifecycle.assessment.reason).toBe('undispositioned-reviewer-comment');
+  });
+
+  it('passes issue_comment event after PR body records valid disposition', () => {
+    const lifecycle = assessReviewerLifecycle({
+      eventName: 'issue_comment',
+      labels: ['infra'],
+      files: ['src/app/page.tsx'],
+      enforceFailure: true,
+      headSha: 'head-sha',
+      body: dispositionBody,
+      reviewComments: [trustedInlineComment],
+    });
+
+    expect(lifecycle.shouldFail).toBe(false);
+    expect(lifecycle.assessment.ok).toBe(true);
+  });
+
+  it('does not block on untrusted general comments', () => {
+    const lifecycle = assessReviewerLifecycle({
+      eventName: 'pull_request_review_comment',
+      labels: ['infra'],
+      files: ['src/app/page.tsx'],
+      enforceFailure: true,
+      headSha: 'head-sha',
+      body: '## REVIEWER RESPONSE ACCOUNTING\n- reviewed',
+      reviewComments: [{
+        id: 9001,
+        user: { login: 'random-contributor' },
+        commit_id: 'head-sha',
+        path: 'src/app/page.tsx',
+        line: 4,
+        body: 'P1: Please fix this.',
+        created_at: '2026-06-01T00:00:00Z',
+      }],
+      issueComments: [{
+        id: 9002,
+        user: { login: 'maintainer' },
+        body: 'Thanks for the review.',
+        created_at: '2026-06-01T01:00:00Z',
+      }],
+    });
+
+    expect(lifecycle.shouldFail).toBe(false);
+    expect(lifecycle.reviewerDisposition.undispositionedCount).toBe(0);
+  });
+
+  it('blocks outdated comments without explicit accepted disposition', () => {
+    const lifecycle = assessReviewerLifecycle({
+      eventName: 'pull_request_review',
+      labels: ['infra'],
+      files: ['src/app/page.tsx'],
+      enforceFailure: true,
+      headSha: 'new-sha',
+      body: '## REVIEWER RESPONSE ACCOUNTING\n- reviewed',
+      reviewComments: [{
+        id: 9003,
+        user: { login: 'copilot-pull-request-reviewer[bot]' },
+        commit_id: 'old-sha',
+        path: 'src/app/page.tsx',
+        line: 12,
+        body: 'P2: Outdated finding on prior commit.',
+        created_at: '2026-06-01T00:00:00Z',
+      }],
+    });
+
+    expect(lifecycle.shouldFail).toBe(true);
+    expect(lifecycle.assessment.reason).toBe('outdated-reviewer-thread-without-disposition');
+  });
+
+  it('passes outdated comments with explicit accepted exclusion disposition', () => {
+    const lifecycle = assessReviewerLifecycle({
+      eventName: 'pull_request_review',
+      labels: ['infra'],
+      files: ['src/app/page.tsx'],
+      enforceFailure: true,
+      headSha: 'new-sha',
+      body: [
+        '## REVIEWER RESPONSE ACCOUNTING',
+        '- review-comment:9004 — acknowledged — Superseded by refactor — thread state: outdated',
+      ].join('\n'),
+      reviewComments: [{
+        id: 9004,
+        user: { login: 'gemini-code-assist[bot]' },
+        commit_id: 'old-sha',
+        path: 'src/app/page.tsx',
+        line: 12,
+        body: 'P2: Outdated finding on prior commit.',
+        created_at: '2026-06-01T00:00:00Z',
+      }],
+    });
+
+    expect(lifecycle.shouldFail).toBe(false);
+  });
+
+  it('reports blocking severity through assessReviewerResponseGate when enforcing', () => {
+    const gate = assessReviewerResponseGate({
+      enforceFailure: true,
+      body: '## REVIEWER RESPONSE ACCOUNTING\n- reviewed',
+      reviewComments: [trustedInlineComment],
+      headSha: 'head-sha',
+    });
+
+    expect(gate.shouldFail).toBe(true);
+    expect(gate.report).toContain('Reviewer response gate failed.');
+    expect(gate.report).toContain('Enforcing event: yes');
+  });
+
+  it('blocks via evaluateReviewerAccounting on review events with undispositioned comments', () => {
+    const accounting = evaluateReviewerAccounting({
+      eventName: 'pull_request_review',
+      labels: ['infra'],
+      files: ['src/app/page.tsx'],
+      currentHeadLinkedReview: true,
+      undispositionedReviewerComments: 1,
+    });
+
+    expect(accounting.ok).toBe(false);
+    expect(accounting.severity).toBe('blocking');
+    expect(accounting.reason).toBe('undispositioned-reviewer-comment');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #1687

## QUEUE / DEPENDENCY MAP STATUS
- Dependency-map result: pass — OPS #1923 batch-generated closeout remediation
- Next queue item: continue backlog burn-down after closeout replay
- Continue/halt decision: continue after post-merge verification

## PROGRESS + READINESS (MANDATORY)
- Phase: Post-merge closeout remediation
- Task: OPS #1923 batch body generation for merged PR #1948
- Status: MERGED
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: none (post-merge closeout body remediation generated)
- Notes: Merged as PR #1948 at `2e24577f0b086239edae88789b35de07d387b268`. Post-merge closeout body remediation for OPS #1923 backlog burn-down.

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `.github/workflows/reviewer-response-completion.yml`
- `.github/workflows/gate-reviewer-response.yml`
- `scripts/ci/reviewer-gate-simulation.mjs`
- `scripts/ci/reviewer_lifecycle_gate.mjs`
- `tests/reviewer-response-gate.test.mjs`
- `tests/reviewer-lifecycle-gate.test.mjs`
- `docs/reference/ci/reviewer-lifecycle-surface.md`

All other files are out of scope

## CHANGE SUMMARY
- `GATE — Reviewer Response Completion` now sets `ENFORCE_FAILURE=true` for `pull_request_review`, `pull_request_review_comment`, and PR `issue_comment` events (in addition to `pull_request_target`).
- `evaluateReviewerAccounting()` blocks on undispositioned/outdated/late trusted reviewer comments for all enforcing lifecycle events, not only `pull_request_target`.
- Added `isEnforcingReviewerLifecycleEvent()` helper and `tests/reviewer-response-gate.test.mjs` covering the PR #1926 race scenarios.
- Updated `docs/reference/ci/reviewer-lifecycle-surface.md` to document blocking on review/comment events.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `node scripts/ci/generate_post_merge_closeout_bodies.mjs --prs 1948 --validate` — PASS (generator self-validation)
- Gate verification:
  - Commit-level workflow runs inspected: YES (merged PR #1948)
  - PR-level governance/accounting workflows inspected: YES
  - Failed job logs inspected for every failing gate: YES
  - Required gates rerun or re-evaluated after fixes: YES (remediated body artifact)
- Result summary: PASS

## ACCEPTANCE CRITERIA
- [x] Required source issue exists, is same-repository, and closed-source follow-up closeout evidence is recorded.
- [x] PR issue-accounting gate passes.
- [x] Drift gate passes.
- [x] Intent gate passes.
- [x] ZIP safety gate passes.
- [x] Quality checks pass.
- [x] Repository-specific governance gates pass.
- [x] All actionable reviewer and bot feedback is resolved or explicitly dispositioned.
- [x] PR is ready for human review.
- [x] Post-merge closeout remediation body generated for merged PR #1948

## REVIEWER RESPONSE ACCOUNTING
- [x] Reviewed all reviewer comments, bot comments, and review threads.
- review-comment:3460559432 — accepted — post-merge closeout remediation for prior PR #1948 — thread state: outdated

## PR GATE READINESS CHECKLIST
- [x] Live PR check panel inspected
- [x] Commit-level workflow runs inspected
- [x] PR-level pull_request_target workflows inspected
- [x] Latest head workflow runs inspected
- [x] Failed job logs inspected for every failing gate
- [x] All review threads and comments inspected
- [x] Required gates rerun or re-evaluated after fixes

## POST-MERGE CLOSEOUT CHECKLIST
- [x] PR merged state verified
- [x] Merge commit recorded: `2e24577f0b086239edae88789b35de07d387b268`
- [x] Source issue #1687 state inspected after merge
- [x] Post-merge closeout reconciliation for prior PR #1948 delegated to closeout workflow
- [x] Remediation follow-up for closed source issue #1687 recorded in this post-merge closeout body

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] PR body contains one accepted source-issue accounting line
- [x] Allowed files section matches final diff exactly
- [x] No files outside allowlist
- [x] Local checks executed and passed
- [x] All reviewer feedback has explicit disposition where required
<!-- CURSOR_AGENT_PR_BODY_END -->
