### PR TITLE
ops(#1965): GitHub API retry and rate-limit rerun queue

### DIFF
--- a/docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md
+++ b/docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md
@@ -69,3 +69,10 @@ Task 001 (path-scoped manifest replay on push)
 | 006 | #1969 | Closeout workflow partial_failure and job sharding |
 | 007 | #1970 | Backlog metrics and batch report taxonomy |
 | 008 | #1971 | Program rollout checkpoint and runbook updates |
+
+## Task status
+
+| Task | Issue | Status | Merge evidence |
+| --- | --- | --- | --- |
+| 001 | #1964 | complete | PR #1972 @ `82517eb0280dbdaa337a2080dadf51e64d46d651` |
+| 002 | #1965 | in progress | — |

--- a/scripts/ci/append_closeout_rerun_targets.mjs
+++ b/scripts/ci/append_closeout_rerun_targets.mjs
@@ -24,7 +24,13 @@ export function normalizeCloseoutTarget(target = {}) {
 		body_file: bodyFile,
 	};
 	if (target.merge_sha) normalized.merge_sha = String(target.merge_sha);
-	if (target.source_issue) normalized.source_issue = Number(target.source_issue);
+	if (target.source_issue !== undefined && target.source_issue !== null) {
+		const sourceIssue = Number(String(target.source_issue).replace(/^#/, ''));
+		if (!Number.isFinite(sourceIssue) || sourceIssue <= 0) {
+			throw new Error(`Closeout rerun target requires a numeric source_issue: ${JSON.stringify(target)}`);
+		}
+		normalized.source_issue = sourceIssue;
+	}
 	if (target.skip_body_apply === true) normalized.skip_body_apply = true;
 	return normalized;
 }
@@ -53,7 +59,12 @@ export function readRerunManifest(manifestPath = RERUN_MANIFEST, workspace = pro
 		return { manifestPath: resolved, payload: { targets: [] }, targets: [] };
 	}
 
-	const payload = JSON.parse(fs.readFileSync(resolved, 'utf8'));
+	const raw = fs.readFileSync(resolved, 'utf8').trim();
+	if (!raw) {
+		return { manifestPath: resolved, payload: { targets: [] }, targets: [] };
+	}
+
+	const payload = JSON.parse(raw);
 	const targets = Array.isArray(payload) ? payload : payload?.targets;
 	if (!Array.isArray(targets)) {
 		throw new Error(`Closeout rerun manifest must include a targets array: ${resolved}`);
@@ -131,7 +142,7 @@ export function toRerunTargetFromBatchTarget(target = {}, repositoryRoot = proce
 async function main() {
 	const args = process.argv.slice(2);
 	const manifestIndex = args.indexOf('--manifest');
-	const manifestPath = manifestIndex >= 0 ? args[manifestIndex + 1] : RERUN_MANIFEST;
+	const manifestPath = manifestIndex >= 0 && args[manifestIndex + 1] ? args[manifestIndex + 1] : RERUN_MANIFEST;
 	const stdinMode = args.includes('--stdin-targets');
 	const dryRun = args.includes('--dry-run');
 

--- a/scripts/ci/append_closeout_rerun_targets.mjs
+++ b/scripts/ci/append_closeout_rerun_targets.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { loadCloseoutTargets } from './run_batch_post_merge_closeout.mjs';
+import { RERUN_MANIFEST } from './resolve_closeout_manifests_from_push.mjs';
+
+export { RERUN_MANIFEST };
+
+export function normalizeCloseoutTarget(target = {}) {
+	const pr = Number(target.pr);
+	if (!Number.isFinite(pr) || pr <= 0) {
+		throw new Error(`Closeout rerun target requires a numeric pr: ${JSON.stringify(target)}`);
+	}
+	if (!target.body_file) {
+		throw new Error(`Closeout rerun target requires body_file: ${JSON.stringify(target)}`);
+	}
+
+	const bodyFile = String(target.body_file).replace(/\\/g, '/').replace(/^\.\//, '');
+	const normalized = {
+		pr,
+		body_file: bodyFile,
+	};
+	if (target.merge_sha) normalized.merge_sha = String(target.merge_sha);
+	if (target.source_issue) normalized.source_issue = Number(target.source_issue);
+	if (target.skip_body_apply === true) normalized.skip_body_apply = true;
+	return normalized;
+}
+
+export function targetIdentity(target = {}) {
+	return String(normalizeCloseoutTarget(target).pr);
+}
+
+export function mergeRerunTargets(existingTargets = [], incomingTargets = []) {
+	const merged = new Map();
+	for (const target of existingTargets) {
+		const normalized = normalizeCloseoutTarget(target);
+		merged.set(targetIdentity(normalized), normalized);
+	}
+	for (const target of incomingTargets) {
+		const normalized = normalizeCloseoutTarget(target);
+		const key = targetIdentity(normalized);
+		merged.set(key, { ...merged.get(key), ...normalized });
+	}
+	return [...merged.values()].sort((left, right) => left.pr - right.pr);
+}
+
+export function readRerunManifest(manifestPath = RERUN_MANIFEST, workspace = process.cwd()) {
+	const resolved = path.resolve(workspace, manifestPath);
+	if (!fs.existsSync(resolved)) {
+		return { manifestPath: resolved, payload: { targets: [] }, targets: [] };
+	}
+
+	const payload = JSON.parse(fs.readFileSync(resolved, 'utf8'));
+	const targets = Array.isArray(payload) ? payload : payload?.targets;
+	if (!Array.isArray(targets)) {
+		throw new Error(`Closeout rerun manifest must include a targets array: ${resolved}`);
+	}
+	return { manifestPath: resolved, payload: Array.isArray(payload) ? { targets } : payload, targets };
+}
+
+export function buildRerunManifestPayload({
+	existingPayload = {},
+	targets = [],
+	description = '',
+	triggeredAt = new Date().toISOString(),
+} = {}) {
+	return {
+		...existingPayload,
+		triggered_at: triggeredAt,
+		...(description ? { description } : {}),
+		targets,
+	};
+}
+
+export function appendCloseoutRerunTargets({
+	manifestPath = RERUN_MANIFEST,
+	targets = [],
+	workspace = process.cwd(),
+	description = 'Rate-limited closeout targets queued for rerun.',
+	triggeredAt = new Date().toISOString(),
+	dryRun = false,
+} = {}) {
+	if (!targets.length) {
+		return { manifestPath: path.resolve(workspace, manifestPath), added: [], targets: [], changed: false };
+	}
+
+	const { manifestPath: resolved, payload, targets: existingTargets } = readRerunManifest(manifestPath, workspace);
+	const mergedTargets = mergeRerunTargets(existingTargets, targets);
+	const added = targets
+		.map((target) => targetIdentity(target))
+		.filter((identity, index, identities) => identities.indexOf(identity) === index)
+		.filter((identity) => !existingTargets.some((entry) => targetIdentity(entry) === identity));
+
+	const nextPayload = buildRerunManifestPayload({
+		existingPayload: payload,
+		targets: mergedTargets,
+		description,
+		triggeredAt,
+	});
+
+	if (!dryRun) {
+		fs.mkdirSync(path.dirname(resolved), { recursive: true });
+		fs.writeFileSync(resolved, `${JSON.stringify(nextPayload, null, 2)}\n`);
+	}
+
+	return {
+		manifestPath: resolved,
+		added,
+		targets: mergedTargets,
+		changed: mergedTargets.length !== existingTargets.length || added.length > 0,
+	};
+}
+
+export function toRerunTargetFromBatchTarget(target = {}, repositoryRoot = process.cwd()) {
+	const bodyFile = path.isAbsolute(target.body_file)
+		? path.relative(repositoryRoot, target.body_file).replace(/\\/g, '/')
+		: String(target.body_file).replace(/\\/g, '/').replace(/^\.\//, '');
+
+	return normalizeCloseoutTarget({
+		pr: target.pr,
+		body_file: bodyFile,
+		merge_sha: target.merge_sha,
+		source_issue: target.source_issue,
+		skip_body_apply: target.skip_body_apply,
+	});
+}
+
+async function main() {
+	const args = process.argv.slice(2);
+	const manifestIndex = args.indexOf('--manifest');
+	const manifestPath = manifestIndex >= 0 ? args[manifestIndex + 1] : RERUN_MANIFEST;
+	const stdinMode = args.includes('--stdin-targets');
+	const dryRun = args.includes('--dry-run');
+
+	let targets = [];
+	if (stdinMode) {
+		const input = fs.readFileSync(0, 'utf8').trim();
+		targets = input ? JSON.parse(input) : [];
+	} else {
+		const pathsIndex = args.indexOf('--targets');
+		if (pathsIndex < 0) {
+			throw new Error('Provide --stdin-targets or --targets <json>');
+		}
+		targets = JSON.parse(args[pathsIndex + 1] || '[]');
+	}
+
+	const result = appendCloseoutRerunTargets({
+		manifestPath,
+		targets,
+		dryRun,
+	});
+	console.log(JSON.stringify(result, null, 2));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	main().catch((error) => {
+		console.error(error.message);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/ci/github_issue_api.mjs
+++ b/scripts/ci/github_issue_api.mjs
@@ -20,8 +20,8 @@ export function isGitHubRateLimitError(error) {
 	return error instanceof GitHubRateLimitError;
 }
 
-export function computeBackoffDelayMs(attempt, initialBackoffMs = 1000) {
-	return initialBackoffMs * 2 ** Math.max(attempt - 1, 0);
+export function computeBackoffDelayMs(attempt, initialBackoffMs = 1000, maxBackoffMs = 30000) {
+	return Math.min(initialBackoffMs * 2 ** Math.max(attempt - 1, 0), maxBackoffMs);
 }
 
 export async function sleep(ms) {

--- a/scripts/ci/github_issue_api.mjs
+++ b/scripts/ci/github_issue_api.mjs
@@ -1,3 +1,33 @@
+export class GitHubRateLimitError extends Error {
+	constructor(method, path, status, body = '') {
+		super(`${method} ${path} failed: ${status} ${body}`.trim());
+		this.name = 'GitHubRateLimitError';
+		this.method = method;
+		this.path = path;
+		this.status = status;
+		this.body = body;
+	}
+}
+
+export function isGitHubRateLimitResponse(status, body = '') {
+	const text = String(body || '');
+	if (status === 429) return true;
+	if (status === 403 && /rate limit|secondary rate limit/i.test(text)) return true;
+	return false;
+}
+
+export function isGitHubRateLimitError(error) {
+	return error instanceof GitHubRateLimitError;
+}
+
+export function computeBackoffDelayMs(attempt, initialBackoffMs = 1000) {
+	return initialBackoffMs * 2 ** Math.max(attempt - 1, 0);
+}
+
+export async function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function githubRepoRequest({
 	token,
 	repository,
@@ -5,22 +35,41 @@ export async function githubRepoRequest({
 	method = 'GET',
 	body,
 	userAgent = 'lgfc-ci-github-issue-api',
-}) {
-	const response = await fetch(`https://api.github.com/repos/${repository}${path}`, {
-		method,
-		headers: {
-			Authorization: `Bearer ${token}`,
-			Accept: 'application/vnd.github+json',
-			'X-GitHub-Api-Version': '2022-11-28',
-			'User-Agent': userAgent,
-			...(body ? { 'Content-Type': 'application/json' } : {}),
-		},
-		...(body ? { body: JSON.stringify(body) } : {}),
-	});
+	maxRetries = 3,
+	initialBackoffMs = 1000,
+	sleepFn = sleep,
+	fetchFn = fetch,
+} = {}) {
+	let attempt = 0;
 
-	if (!response.ok) {
-		throw new Error(`${method} ${path} failed: ${response.status} ${await response.text()}`);
+	while (true) {
+		const response = await fetchFn(`https://api.github.com/repos/${repository}${path}`, {
+			method,
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: 'application/vnd.github+json',
+				'X-GitHub-Api-Version': '2022-11-28',
+				'User-Agent': userAgent,
+				...(body ? { 'Content-Type': 'application/json' } : {}),
+			},
+			...(body ? { body: JSON.stringify(body) } : {}),
+		});
+
+		if (response.ok) {
+			return response.status === 204 ? null : response.json();
+		}
+
+		const responseText = await response.text();
+		if (isGitHubRateLimitResponse(response.status, responseText) && attempt < maxRetries) {
+			attempt += 1;
+			await sleepFn(computeBackoffDelayMs(attempt, initialBackoffMs));
+			continue;
+		}
+
+		if (isGitHubRateLimitResponse(response.status, responseText)) {
+			throw new GitHubRateLimitError(method, path, response.status, responseText);
+		}
+
+		throw new Error(`${method} ${path} failed: ${response.status} ${responseText}`);
 	}
-
-	return response.status === 204 ? null : response.json();
 }

--- a/scripts/ci/run_batch_post_merge_closeout.mjs
+++ b/scripts/ci/run_batch_post_merge_closeout.mjs
@@ -8,6 +8,11 @@ import { closeDuplicateRemediationIssues } from './close_duplicate_remediation_i
 import { runPostMergeCloseout } from './run_post_merge_closeout.mjs';
 import { WORKFLOW_RUN_SCOPE_MERGE_ONLY } from './post_merge_validator.mjs';
 import { pruneCloseoutManifestFromReport } from './prune_closeout_manifest.mjs';
+import { isGitHubRateLimitError } from './github_issue_api.mjs';
+import {
+	appendCloseoutRerunTargets,
+	toRerunTargetFromBatchTarget,
+} from './append_closeout_rerun_targets.mjs';
 
 export const BATCH_CLOSEOUT_REPORT_PATH = 'post-merge-batch-closeout.json';
 const DEFAULT_MANIFEST = 'scripts/ci/post-merge-closeout/targets.json';
@@ -90,6 +95,7 @@ export function buildBatchCloseoutReport({
 	results = [],
 	duplicateClose = {},
 	manifestPrune = null,
+	rerunAppend = null,
 	dryRun = false,
 	error = null,
 	failedPhase = null,
@@ -115,6 +121,7 @@ export function buildBatchCloseoutReport({
 		results,
 		duplicateClose,
 		manifestPrune,
+		rerunAppend,
 	};
 }
 
@@ -141,10 +148,13 @@ export async function runBatchPostMergeCloseout({
 	runPostMergeCloseoutFn = runPostMergeCloseout,
 	closeDuplicateRemediationIssuesFn = closeDuplicateRemediationIssues,
 	pruneCloseoutManifestFromReportFn = pruneCloseoutManifestFromReport,
+	appendCloseoutRerunTargetsFn = appendCloseoutRerunTargets,
 }) {
 	const results = [];
+	let rerunAppend = null;
 
-	for (const target of targets) {
+	for (let index = 0; index < targets.length; index += 1) {
+		const target = targets[index];
 		const prNumber = String(target.pr);
 		const bodyFile = path.resolve(target.body_file);
 
@@ -195,10 +205,30 @@ export async function runBatchPostMergeCloseout({
 			results.push(
 				summarizeTargetResult({
 					prNumber,
-					phase: 'closeout',
+					phase: isGitHubRateLimitError(error) ? 'rate_limit' : 'closeout',
 					error,
 				}),
 			);
+
+			if (isGitHubRateLimitError(error)) {
+				const remainingTargets = targets.slice(index).map((entry) =>
+					toRerunTargetFromBatchTarget(entry, process.cwd()),
+				);
+				rerunAppend = appendCloseoutRerunTargetsFn({
+					targets: remainingTargets,
+					description: `Rate-limited closeout targets queued from ${manifestPath}.`,
+				});
+				for (const queuedTarget of remainingTargets.slice(1)) {
+					results.push({
+						pr: String(queuedTarget.pr),
+						status: 'queued',
+						phase: 'rate_limit_rerun',
+						failure_reason: 'rate_limit_queue',
+						body_file: queuedTarget.body_file,
+					});
+				}
+				break;
+			}
 		}
 	}
 
@@ -212,6 +242,7 @@ export async function runBatchPostMergeCloseout({
 		targets,
 		results,
 		duplicateClose,
+		rerunAppend,
 		dryRun,
 	});
 

--- a/tests/github-issue-api.test.mjs
+++ b/tests/github-issue-api.test.mjs
@@ -19,6 +19,11 @@ describe('github rate limit helpers', () => {
 		expect(computeBackoffDelayMs(2, 1000)).toBe(2000);
 		expect(computeBackoffDelayMs(3, 500)).toBe(2000);
 	});
+
+	it('caps exponential backoff at the configured maximum', () => {
+		expect(computeBackoffDelayMs(10, 1000, 30000)).toBe(30000);
+		expect(computeBackoffDelayMs(3, 1000, 1500)).toBe(1500);
+	});
 });
 
 describe('githubRepoRequest', () => {

--- a/tests/github-issue-api.test.mjs
+++ b/tests/github-issue-api.test.mjs
@@ -1,5 +1,25 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { githubRepoRequest } from '../scripts/ci/github_issue_api.mjs';
+import {
+	GitHubRateLimitError,
+	computeBackoffDelayMs,
+	githubRepoRequest,
+	isGitHubRateLimitResponse,
+} from '../scripts/ci/github_issue_api.mjs';
+
+describe('github rate limit helpers', () => {
+	it('detects 429 and rate-limited 403 responses', () => {
+		expect(isGitHubRateLimitResponse(429, '')).toBe(true);
+		expect(isGitHubRateLimitResponse(403, 'API rate limit exceeded')).toBe(true);
+		expect(isGitHubRateLimitResponse(403, 'secondary rate limit')).toBe(true);
+		expect(isGitHubRateLimitResponse(403, 'forbidden')).toBe(false);
+	});
+
+	it('computes exponential backoff delays', () => {
+		expect(computeBackoffDelayMs(1, 1000)).toBe(1000);
+		expect(computeBackoffDelayMs(2, 1000)).toBe(2000);
+		expect(computeBackoffDelayMs(3, 500)).toBe(2000);
+	});
+});
 
 describe('githubRepoRequest', () => {
 	afterEach(() => {
@@ -75,5 +95,63 @@ describe('githubRepoRequest', () => {
 				body: { title: 'test' },
 			}),
 		).rejects.toThrow('POST /issues failed: 403 forbidden');
+	});
+
+	it('retries rate-limit responses with bounded exponential backoff', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: false,
+				status: 429,
+				text: async () => 'rate limit',
+			})
+			.mockResolvedValueOnce({
+				ok: false,
+				status: 403,
+				text: async () => 'secondary rate limit',
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true }),
+			});
+		const sleepFn = vi.fn(async () => {});
+
+		const result = await githubRepoRequest({
+			token: 'test-token',
+			repository: 'owner/repo',
+			path: '/issues/1',
+			maxRetries: 3,
+			initialBackoffMs: 10,
+			sleepFn,
+			fetchFn: fetchMock,
+		});
+
+		expect(result).toEqual({ ok: true });
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(sleepFn).toHaveBeenCalledTimes(2);
+		expect(sleepFn.mock.calls.map(([delay]) => delay)).toEqual([10, 20]);
+	});
+
+	it('throws GitHubRateLimitError after retry budget is exhausted', async () => {
+		const fetchMock = vi.fn(async () => ({
+			ok: false,
+			status: 429,
+			text: async () => 'rate limit',
+		}));
+
+		await expect(
+			githubRepoRequest({
+				token: 'test-token',
+				repository: 'owner/repo',
+				path: '/issues/1',
+				maxRetries: 2,
+				initialBackoffMs: 1,
+				sleepFn: async () => {},
+				fetchFn: fetchMock,
+			}),
+		).rejects.toBeInstanceOf(GitHubRateLimitError);
+
+		expect(fetchMock).toHaveBeenCalledTimes(3);
 	});
 });

--- a/tests/post-merge-closeout-batch.test.mjs
+++ b/tests/post-merge-closeout-batch.test.mjs
@@ -6,6 +6,8 @@ import { describe, expect, it, vi } from 'vitest';
 import {
 	appendCloseoutRerunTargets,
 	mergeRerunTargets,
+	normalizeCloseoutTarget,
+	readRerunManifest,
 } from '../scripts/ci/append_closeout_rerun_targets.mjs';
 import { GitHubRateLimitError } from '../scripts/ci/github_issue_api.mjs';
 import {
@@ -254,6 +256,40 @@ describe('post-merge closeout batch', () => {
 			sync_action: 'post_merge_success',
 			source_issue: '2',
 			remediation_required: false,
+		});
+	});
+
+	it('normalizes source_issue values and rejects invalid numbers', () => {
+		expect(
+			normalizeCloseoutTarget({
+				pr: 1,
+				body_file: 'scripts/ci/post-merge-closeout/pr-1-body.md',
+				source_issue: '#1965',
+			}),
+		).toEqual({
+			pr: 1,
+			body_file: 'scripts/ci/post-merge-closeout/pr-1-body.md',
+			source_issue: 1965,
+		});
+
+		expect(() =>
+			normalizeCloseoutTarget({
+				pr: 1,
+				body_file: 'scripts/ci/post-merge-closeout/pr-1-body.md',
+				source_issue: 'not-a-number',
+			}),
+		).toThrow(/numeric source_issue/);
+	});
+
+	it('treats an empty rerun manifest file as an empty target list', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'closeout-rerun-empty-'));
+		const manifestPath = path.join(dir, 'targets-ci-pending-rerun.json');
+		fs.writeFileSync(manifestPath, '');
+
+		expect(readRerunManifest(manifestPath, dir)).toEqual({
+			manifestPath,
+			payload: { targets: [] },
+			targets: [],
 		});
 	});
 

--- a/tests/post-merge-closeout-batch.test.mjs
+++ b/tests/post-merge-closeout-batch.test.mjs
@@ -4,6 +4,11 @@ import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+	appendCloseoutRerunTargets,
+	mergeRerunTargets,
+} from '../scripts/ci/append_closeout_rerun_targets.mjs';
+import { GitHubRateLimitError } from '../scripts/ci/github_issue_api.mjs';
+import {
 	closeRemediationIssuesForPr,
 	remediationCloseComment,
 	remediationIssuesForPr,
@@ -250,5 +255,102 @@ describe('post-merge closeout batch', () => {
 			source_issue: '2',
 			remediation_required: false,
 		});
+	});
+
+	it('merges rerun targets idempotently by PR number', () => {
+		const merged = mergeRerunTargets(
+			[{ pr: 10, body_file: 'scripts/ci/post-merge-closeout/pr-10-body.md', merge_sha: 'abc' }],
+			[
+				{ pr: 10, body_file: 'scripts/ci/post-merge-closeout/pr-10-body.md', merge_sha: 'def' },
+				{ pr: 11, body_file: 'scripts/ci/post-merge-closeout/pr-11-body.md' },
+			],
+		);
+
+		expect(merged).toEqual([
+			{ pr: 10, body_file: 'scripts/ci/post-merge-closeout/pr-10-body.md', merge_sha: 'def' },
+			{ pr: 11, body_file: 'scripts/ci/post-merge-closeout/pr-11-body.md' },
+		]);
+	});
+
+	it('appends rate-limited batch targets to the rerun manifest without duplicating PRs', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'closeout-rerun-'));
+		const manifestPath = path.join(dir, 'targets-ci-pending-rerun.json');
+		fs.writeFileSync(
+			manifestPath,
+			`${JSON.stringify(
+				{
+					triggered_at: '2026-06-01T00:00:00Z',
+					targets: [{ pr: 10, body_file: 'scripts/ci/post-merge-closeout/pr-10-body.md' }],
+				},
+				null,
+				2,
+			)}\n`,
+		);
+
+		const first = appendCloseoutRerunTargets({
+			manifestPath,
+			targets: [
+				{ pr: 10, body_file: 'scripts/ci/post-merge-closeout/pr-10-body.md', merge_sha: 'new-sha' },
+				{ pr: 11, body_file: 'scripts/ci/post-merge-closeout/pr-11-body.md' },
+			],
+			triggeredAt: '2026-06-25T00:00:00Z',
+		});
+		const second = appendCloseoutRerunTargets({
+			manifestPath,
+			targets: [{ pr: 11, body_file: 'scripts/ci/post-merge-closeout/pr-11-body.md' }],
+			triggeredAt: '2026-06-25T00:01:00Z',
+		});
+
+		expect(first.added).toEqual(['11']);
+		expect(first.targets.map((target) => target.pr)).toEqual([10, 11]);
+		expect(second.added).toEqual([]);
+		expect(second.targets).toHaveLength(2);
+	});
+
+	it('queues remaining batch targets when closeout hits a GitHub rate limit', async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'closeout-batch-rate-limit-'));
+		const manifestPath = path.join(dir, 'targets-ci-pending-rerun.json');
+		const bodyOne = path.join(dir, 'one.md');
+		const bodyTwo = path.join(dir, 'two.md');
+		const bodyThree = path.join(dir, 'three.md');
+		for (const bodyPath of [bodyOne, bodyTwo, bodyThree]) {
+			fs.writeFileSync(
+				bodyPath,
+				'- **Issue:** #1\n\n## CHANGE SUMMARY\nx\n\n## BUILD / TEST / VERIFICATION\nx\n\n## ACCEPTANCE CRITERIA\nx\n',
+			);
+		}
+
+		const runPostMergeCloseout = vi
+			.fn()
+			.mockResolvedValueOnce({
+				status: 'pass',
+				sync_action: 'post_merge_success',
+				source_issue: '1',
+				remediation_required: false,
+			})
+			.mockRejectedValueOnce(new GitHubRateLimitError('GET', '/pulls/2', 403, 'rate limit'));
+
+		const outcome = await runBatchPostMergeCloseout({
+			token: 'token',
+			repository: 'owner/repo',
+			targets: [
+				{ pr: 1, body_file: bodyOne },
+				{ pr: 2, body_file: bodyTwo },
+				{ pr: 3, body_file: bodyThree },
+			],
+			closeDuplicateRemediationIssuesFn: vi.fn().mockResolvedValue({ closed: [] }),
+			runPostMergeCloseoutFn: runPostMergeCloseout,
+			appendCloseoutRerunTargetsFn: (options) =>
+				appendCloseoutRerunTargets({ ...options, manifestPath }),
+		});
+
+		expect(runPostMergeCloseout).toHaveBeenCalledTimes(2);
+		expect(outcome.rerunAppend?.targets.map((target) => target.pr)).toEqual([2, 3]);
+		expect(outcome.results).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ pr: '2', status: 'error', phase: 'rate_limit' }),
+				expect.objectContaining({ pr: '3', status: 'queued', phase: 'rate_limit_rerun' }),
+			]),
+		);
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #1965

## PRE-OPEN GATE PREFLIGHT (MANDATORY)
- [x] Confirm exactly one same-repository, open, non-PR source issue exists.
- [x] Confirm one accepted issue-accounting line is present before opening or updating the PR.
- [x] Read the workflow files that will run for this PR's touched paths before opening the PR.
- [x] Read `docs/reference/governance/troubleshooting-data-surface-requirements.md` before making any merge-readiness claim.
- [x] Confirm PR body file allowlist exactly matches the final changed-file list before opening.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## QUEUE / DEPENDENCY MAP STATUS (REQUIRED FOR LAUNCHED-PROGRAM QUEUE TASKS)
- Dependency-map result: pass — Program #1963 Task 002 follows merged Task 001 (#1964 / PR #1972).
- Next queue item: #1966 — Per-target manifest pruning on partial_failure (Task 003)
- Continue/halt decision: halt — Task 003 begins only after Task 002 merges and post-merge closeout is verified.

## PRE-MERGE CLOSEOUT PREDICTION (REQUIRED BEFORE READY FOR MERGE)
- Pre-merge closeout prediction: pass
- Source issue state before merge: open
- Expected post-merge source issue action: auto-close
- Reviewer disposition parseability: pass
- Queue continuation after closeout: halt — verify Task 002 closeout before starting Task 003 (#1966)

## PROGRESS + READINESS (MANDATORY)
- Phase: Program #1963 implementation — Task 002
- Task: GitHub API resilience and rate-limit rerun queue (#1965)
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: awaiting trusted review on head `2ace46b0` after Gemini remediation commit
- Notes: Gemini inline findings addressed in commit `2ace46b0`; CI re-running on updated head.

## DOCUMENTATION SOURCE (MANDATORY)
- [ ] DIATAXIS_FULL
- [x] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`
- `scripts/ci/github_issue_api.mjs`
- `scripts/ci/run_batch_post_merge_closeout.mjs`

## LABEL
- Intent label for this PR: infra

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Additional design/reference docs used for this PR:
  - `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `scripts/ci/github_issue_api.mjs`
- `scripts/ci/run_batch_post_merge_closeout.mjs`
- `scripts/ci/append_closeout_rerun_targets.mjs`
- `tests/github-issue-api.test.mjs`
- `tests/post-merge-closeout-batch.test.mjs`
- `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## CHANGE SUMMARY
- Add bounded exponential backoff retry for GitHub 403/429 rate-limit responses in `github_issue_api.mjs`, capped at 30s.
- Add `append_closeout_rerun_targets.mjs` to idempotently queue failed batch targets in `targets-ci-pending-rerun.json`.
- Validate `source_issue`, handle empty rerun manifests, and guard missing `--manifest` values.
- Update batch closeout to append current and remaining targets on rate-limit failure instead of losing them.
- Extend unit tests for retry, rerun append idempotency, manifest safety, and batch rate-limit queue behavior.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `npx vitest run tests/github-issue-api.test.mjs tests/post-merge-closeout-batch.test.mjs` — PASS (23 tests)
- Gate verification:
  - Commit-level workflow runs inspected: PENDING on head `2ace46b0`
  - PR-level governance/accounting workflows inspected: PENDING on head `2ace46b0`
- Result summary:
  - PASS (local)

## DOCUMENTATION UPDATES
- [x] Documentation updated in this PR
- Files:
  - `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`

## REVIEWER RESPONSE ACCOUNTING
- [x] Reviewed all reviewer comments.
- [x] Reviewed all bot comments.
- [x] Reviewed all GitHub review threads.
- [x] Every actionable reviewer comment has a PR-body disposition with `review-comment:<id>`.
- [x] Every GitHub review thread has an explicit thread-state disposition: resolved, outdated, or intentionally left unresolved with rationale.
- review-comment:3471076161 — accepted — cap backoff delay with `maxBackoffMs` default 30000 in `computeBackoffDelayMs` — thread state: resolved
- review-comment:3471076179 — accepted — validate and normalize `source_issue` before manifest write — thread state: resolved
- review-comment:3471076192 — accepted — treat empty rerun manifest file as empty targets array — thread state: resolved
- review-comment:3471076199 — accepted — fallback to default manifest when `--manifest` has no value — thread state: resolved

## ACCEPTANCE CRITERIA
- [x] 403/429 rate-limit responses retry with bounded backoff.
- [x] Rate-limited batch targets append to rerun manifest idempotently.
- [x] Tests cover retry and rerun append behavior.
- [x] Post-merge source issue closure is delegated to the repository closeout workflow after merge.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches final diff exactly
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] Local checks executed and passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-142e3c1a-96a1-488f-9e89-d31ed73bfb0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-142e3c1a-96a1-488f-9e89-d31ed73bfb0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds capped exponential backoff for GitHub 403/429 (including secondary rate limits) and a rerun queue so batch post-merge closeouts don’t drop targets. Addresses #1965 by queueing the current and remaining targets into a safe, deduped manifest for reruns.

- **New Features**
  - Retries GitHub requests with capped backoff; injects `sleepFn`/`fetchFn` for tests; throws `GitHubRateLimitError` when exhausted (`scripts/ci/github_issue_api.mjs`).
  - Adds `scripts/ci/append_closeout_rerun_targets.mjs` to normalize targets, handle empty manifests, and idempotently merge into `targets-ci-pending-rerun.json` with `triggered_at` and description.
  - Updates `scripts/ci/run_batch_post_merge_closeout.mjs` to detect rate limits, queue current + remaining targets, and mark later ones as `queued` with `rate_limit`/`rate_limit_rerun` phases in the report.
  - Extends tests for rate-limit detection, backoff capping/retries, manifest safety, and queueing; updates tracker docs.

<sup>Written for commit 2ace46b059fe14fe3625c28ec8a35590cfebf355. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->