### PR TITLE
ops(#1966): Per-target manifest pruning on partial_failure

### DIFF
--- a/docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md
+++ b/docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md
@@ -75,4 +75,5 @@ Task 001 (path-scoped manifest replay on push)
 | Task | Issue | Status | Merge evidence |
 | --- | --- | --- | --- |
 | 001 | #1964 | complete | PR #1972 @ `82517eb0280dbdaa337a2080dadf51e64d46d651` |
-| 002 | #1965 | in progress | — |
+| 002 | #1965 | complete | PR #1976 @ `21abad7eb3b0682108e4c29c2f9372eb58160b62` |
+| 003 | #1966 | in progress | — |

--- a/scripts/ci/prune_closeout_manifest.mjs
+++ b/scripts/ci/prune_closeout_manifest.mjs
@@ -46,10 +46,14 @@ export function pruneCloseoutManifest(manifestPath, successfulPrs = new Set(), {
 	return { manifestPath: resolved, ...result };
 }
 
+export function isPruneEligibleReportStatus(status = '') {
+	return status === 'success' || status === 'partial_failure';
+}
+
 export function pruneCloseoutManifestFromReport({ manifestPath, report, dryRun = false } = {}) {
 	const resolved = path.resolve(manifestPath);
-	if (report?.status !== 'success') {
-		return { manifestPath: resolved, pruned: 0, remaining: null, skipped: 'report_not_success' };
+	if (!isPruneEligibleReportStatus(report?.status)) {
+		return { manifestPath: resolved, pruned: 0, remaining: null, skipped: 'report_not_prune_eligible' };
 	}
 	const successfulPrs = successfulCloseoutPrs(report);
 	if (successfulPrs.size === 0) {

--- a/scripts/ci/run_batch_post_merge_closeout.mjs
+++ b/scripts/ci/run_batch_post_merge_closeout.mjs
@@ -7,7 +7,7 @@ import { pathToFileURL } from 'node:url';
 import { closeDuplicateRemediationIssues } from './close_duplicate_remediation_issues.mjs';
 import { runPostMergeCloseout } from './run_post_merge_closeout.mjs';
 import { WORKFLOW_RUN_SCOPE_MERGE_ONLY } from './post_merge_validator.mjs';
-import { pruneCloseoutManifestFromReport } from './prune_closeout_manifest.mjs';
+import { pruneCloseoutManifestFromReport, isPruneEligibleReportStatus } from './prune_closeout_manifest.mjs';
 import { isGitHubRateLimitError } from './github_issue_api.mjs';
 import {
 	appendCloseoutRerunTargets,
@@ -247,7 +247,7 @@ export async function runBatchPostMergeCloseout({
 	});
 
 	let manifestPrune = null;
-	if (!dryRun && report.status === 'success') {
+	if (!dryRun && isPruneEligibleReportStatus(report.status)) {
 		manifestPrune = pruneCloseoutManifestFromReportFn({ manifestPath, report, dryRun: false });
 		report = { ...report, manifestPrune };
 	}

--- a/scripts/ci/run_batch_post_merge_closeout.mjs
+++ b/scripts/ci/run_batch_post_merge_closeout.mjs
@@ -18,6 +18,14 @@ export const BATCH_CLOSEOUT_REPORT_PATH = 'post-merge-batch-closeout.json';
 const DEFAULT_MANIFEST = 'scripts/ci/post-merge-closeout/targets.json';
 const POST_MERGE_RESULT_PATH = 'post-merge-result.json';
 
+export function shouldPruneBatchManifest(manifestPath = DEFAULT_MANIFEST, dryRun = false) {
+	if (dryRun) return false;
+	if (process.env.VITEST === 'true' && path.resolve(manifestPath) === path.resolve(DEFAULT_MANIFEST)) {
+		return false;
+	}
+	return true;
+}
+
 export function loadCloseoutTargets(manifestPath = DEFAULT_MANIFEST) {
 	const resolved = path.resolve(manifestPath);
 	const raw = JSON.parse(fs.readFileSync(resolved, 'utf8'));
@@ -247,7 +255,7 @@ export async function runBatchPostMergeCloseout({
 	});
 
 	let manifestPrune = null;
-	if (!dryRun && isPruneEligibleReportStatus(report.status)) {
+	if (shouldPruneBatchManifest(manifestPath, dryRun) && isPruneEligibleReportStatus(report.status)) {
 		manifestPrune = pruneCloseoutManifestFromReportFn({ manifestPath, report, dryRun: false });
 		report = { ...report, manifestPrune };
 	}

--- a/tests/batch-post-merge-closeout.test.mjs
+++ b/tests/batch-post-merge-closeout.test.mjs
@@ -47,24 +47,6 @@ afterEach(() => {
 
 describe('batch post-merge closeout reporting', () => {
 	it('records missing body file failures without aborting other targets', async () => {
-		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'batch-closeout-partial-'));
-		tempDirs.push(tempDir);
-		const manifestPath = path.join(tempDir, 'targets.json');
-		const passingBody = 'scripts/ci/post-merge-closeout/pr-1243-body.md';
-		fs.writeFileSync(
-			manifestPath,
-			`${JSON.stringify(
-				{
-					targets: [
-						{ pr: 1239, body_file: 'scripts/ci/post-merge-closeout/does-not-exist.md' },
-						{ pr: 1243, body_file: passingBody },
-					],
-				},
-				null,
-				2,
-			)}\n`,
-		);
-
 		const runPostMergeCloseoutFn = vi.fn(async () => ({
 			status: 'pass',
 			sync_action: 'post_merge_success',
@@ -75,10 +57,9 @@ describe('batch post-merge closeout reporting', () => {
 		const report = await runBatchPostMergeCloseout({
 			token: 'token',
 			repository: 'org/repo',
-			manifestPath,
 			targets: [
 				{ pr: 1239, body_file: 'scripts/ci/post-merge-closeout/does-not-exist.md' },
-				{ pr: 1243, body_file: passingBody },
+				{ pr: 1243, body_file: 'scripts/ci/post-merge-closeout/pr-1243-body.md' },
 			],
 			runPostMergeCloseoutFn,
 			closeDuplicateRemediationIssuesFn: async () => ({ closed: [] }),
@@ -94,10 +75,6 @@ describe('batch post-merge closeout reporting', () => {
 		});
 		expect(report.results[1]).toMatchObject({ pr: '1243', status: 'pass' });
 		expect(report.status).toBe('partial_failure');
-		expect(report.manifestPrune).toMatchObject({ pruned: 1, remaining: 1 });
-		expect(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).targets).toEqual([
-			{ pr: 1239, body_file: 'scripts/ci/post-merge-closeout/does-not-exist.md' },
-		]);
 	});
 
 	it('records per-target validation failures with diagnostic detail', async () => {

--- a/tests/batch-post-merge-closeout.test.mjs
+++ b/tests/batch-post-merge-closeout.test.mjs
@@ -47,6 +47,24 @@ afterEach(() => {
 
 describe('batch post-merge closeout reporting', () => {
 	it('records missing body file failures without aborting other targets', async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'batch-closeout-partial-'));
+		tempDirs.push(tempDir);
+		const manifestPath = path.join(tempDir, 'targets.json');
+		const passingBody = 'scripts/ci/post-merge-closeout/pr-1243-body.md';
+		fs.writeFileSync(
+			manifestPath,
+			`${JSON.stringify(
+				{
+					targets: [
+						{ pr: 1239, body_file: 'scripts/ci/post-merge-closeout/does-not-exist.md' },
+						{ pr: 1243, body_file: passingBody },
+					],
+				},
+				null,
+				2,
+			)}\n`,
+		);
+
 		const runPostMergeCloseoutFn = vi.fn(async () => ({
 			status: 'pass',
 			sync_action: 'post_merge_success',
@@ -57,9 +75,10 @@ describe('batch post-merge closeout reporting', () => {
 		const report = await runBatchPostMergeCloseout({
 			token: 'token',
 			repository: 'org/repo',
+			manifestPath,
 			targets: [
 				{ pr: 1239, body_file: 'scripts/ci/post-merge-closeout/does-not-exist.md' },
-				{ pr: 1243, body_file: 'scripts/ci/post-merge-closeout/pr-1243-body.md' },
+				{ pr: 1243, body_file: passingBody },
 			],
 			runPostMergeCloseoutFn,
 			closeDuplicateRemediationIssuesFn: async () => ({ closed: [] }),
@@ -75,6 +94,10 @@ describe('batch post-merge closeout reporting', () => {
 		});
 		expect(report.results[1]).toMatchObject({ pr: '1243', status: 'pass' });
 		expect(report.status).toBe('partial_failure');
+		expect(report.manifestPrune).toMatchObject({ pruned: 1, remaining: 1 });
+		expect(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).targets).toEqual([
+			{ pr: 1239, body_file: 'scripts/ci/post-merge-closeout/does-not-exist.md' },
+		]);
 	});
 
 	it('records per-target validation failures with diagnostic detail', async () => {

--- a/tests/post-merge-closeout-batch.test.mjs
+++ b/tests/post-merge-closeout-batch.test.mjs
@@ -27,10 +27,11 @@ import {
 } from '../scripts/ci/post_merge_validator.mjs';
 
 describe('post-merge closeout batch', () => {
-	it('loads legacy completed closeout targets from targets.json', () => {
+	it('loads legacy completed closeout targets for merged PRs 1239 and 1243', () => {
 		const { targets } = loadCloseoutTargets('scripts/ci/post-merge-closeout/targets.json');
-		expect(targets.map((target) => target.pr)).toEqual([1239]);
+		expect(targets.map((target) => target.pr)).toEqual([1239, 1243]);
 		expect(targets[0].body_file).toContain('pr-1239-body.md');
+		expect(targets[1].body_file).toContain('pr-1243-body.md');
 	});
 
 	it('rejects null targets in the manifest without throwing parse errors', () => {

--- a/tests/post-merge-closeout-batch.test.mjs
+++ b/tests/post-merge-closeout-batch.test.mjs
@@ -19,6 +19,7 @@ import {
 import {
 	loadCloseoutTargets,
 	runBatchPostMergeCloseout,
+	shouldPruneBatchManifest,
 } from '../scripts/ci/run_batch_post_merge_closeout.mjs';
 import {
 	selectWorkflowRunsForValidation,
@@ -390,62 +391,74 @@ describe('post-merge closeout batch', () => {
 		);
 	});
 
+	it('skips default manifest pruning during vitest runs', () => {
+		expect(
+			shouldPruneBatchManifest('scripts/ci/post-merge-closeout/targets.json', false),
+		).toBe(false);
+		expect(shouldPruneBatchManifest('/tmp/custom-targets.json', false)).toBe(true);
+		expect(shouldPruneBatchManifest('/tmp/custom-targets.json', true)).toBe(false);
+	});
+
 	it('prunes passing targets from the manifest after a partial_failure batch', async () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'closeout-batch-partial-prune-'));
-		const manifestPath = path.join(dir, 'targets.json');
-		const bodyPass = path.join(dir, 'pass.md');
-		const bodyFail = path.join(dir, 'fail.md');
-		for (const bodyPath of [bodyPass, bodyFail]) {
+		try {
+			const manifestPath = path.join(dir, 'targets.json');
+			const bodyPass = path.join(dir, 'pass.md');
+			const bodyFail = path.join(dir, 'fail.md');
+			for (const bodyPath of [bodyPass, bodyFail]) {
+				fs.writeFileSync(
+					bodyPath,
+					'- **Issue:** #1\n\n## CHANGE SUMMARY\nx\n\n## BUILD / TEST / VERIFICATION\nx\n\n## ACCEPTANCE CRITERIA\nx\n',
+				);
+			}
 			fs.writeFileSync(
-				bodyPath,
-				'- **Issue:** #1\n\n## CHANGE SUMMARY\nx\n\n## BUILD / TEST / VERIFICATION\nx\n\n## ACCEPTANCE CRITERIA\nx\n',
+				manifestPath,
+				`${JSON.stringify(
+					{
+						targets: [
+							{ pr: 1, body_file: bodyPass },
+							{ pr: 2, body_file: bodyFail },
+						],
+					},
+					null,
+					2,
+				)}\n`,
 			);
-		}
-		fs.writeFileSync(
-			manifestPath,
-			`${JSON.stringify(
-				{
-					targets: [
-						{ pr: 1, body_file: bodyPass },
-						{ pr: 2, body_file: bodyFail },
-					],
-				},
-				null,
-				2,
-			)}\n`,
-		);
 
-		const runPostMergeCloseout = vi
-			.fn()
-			.mockResolvedValueOnce({
-				status: 'pass',
-				sync_action: 'post_merge_success',
-				source_issue: '1',
-				remediation_required: false,
-			})
-			.mockResolvedValueOnce({
-				status: 'fail',
-				sync_action: 'post_merge_failure',
-				source_issue: '2',
-				remediation_required: true,
+			const runPostMergeCloseout = vi
+				.fn()
+				.mockResolvedValueOnce({
+					status: 'pass',
+					sync_action: 'post_merge_success',
+					source_issue: '1',
+					remediation_required: false,
+				})
+				.mockResolvedValueOnce({
+					status: 'fail',
+					sync_action: 'post_merge_failure',
+					source_issue: '2',
+					remediation_required: true,
+				});
+
+			const outcome = await runBatchPostMergeCloseout({
+				token: 'token',
+				repository: 'owner/repo',
+				manifestPath,
+				targets: [
+					{ pr: 1, body_file: bodyPass },
+					{ pr: 2, body_file: bodyFail },
+				],
+				runPostMergeCloseoutFn: runPostMergeCloseout,
+				closeDuplicateRemediationIssuesFn: vi.fn().mockResolvedValue({ closed: [] }),
 			});
 
-		const outcome = await runBatchPostMergeCloseout({
-			token: 'token',
-			repository: 'owner/repo',
-			manifestPath,
-			targets: [
-				{ pr: 1, body_file: bodyPass },
+			expect(outcome.status).toBe('partial_failure');
+			expect(outcome.manifestPrune).toMatchObject({ pruned: 1, remaining: 1 });
+			expect(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).targets).toEqual([
 				{ pr: 2, body_file: bodyFail },
-			],
-			runPostMergeCloseoutFn: runPostMergeCloseout,
-			closeDuplicateRemediationIssuesFn: vi.fn().mockResolvedValue({ closed: [] }),
-		});
-
-		expect(outcome.status).toBe('partial_failure');
-		expect(outcome.manifestPrune).toMatchObject({ pruned: 1, remaining: 1 });
-		expect(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).targets).toEqual([
-			{ pr: 2, body_file: bodyFail },
-		]);
+			]);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
 	});
 });

--- a/tests/post-merge-closeout-batch.test.mjs
+++ b/tests/post-merge-closeout-batch.test.mjs
@@ -27,11 +27,10 @@ import {
 } from '../scripts/ci/post_merge_validator.mjs';
 
 describe('post-merge closeout batch', () => {
-	it('loads legacy completed closeout targets for merged PRs 1239 and 1243', () => {
+	it('loads legacy completed closeout targets from targets.json', () => {
 		const { targets } = loadCloseoutTargets('scripts/ci/post-merge-closeout/targets.json');
-		expect(targets.map((target) => target.pr)).toEqual([1239, 1243]);
+		expect(targets.map((target) => target.pr)).toEqual([1239]);
 		expect(targets[0].body_file).toContain('pr-1239-body.md');
-		expect(targets[1].body_file).toContain('pr-1243-body.md');
 	});
 
 	it('rejects null targets in the manifest without throwing parse errors', () => {
@@ -388,5 +387,64 @@ describe('post-merge closeout batch', () => {
 				expect.objectContaining({ pr: '3', status: 'queued', phase: 'rate_limit_rerun' }),
 			]),
 		);
+	});
+
+	it('prunes passing targets from the manifest after a partial_failure batch', async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'closeout-batch-partial-prune-'));
+		const manifestPath = path.join(dir, 'targets.json');
+		const bodyPass = path.join(dir, 'pass.md');
+		const bodyFail = path.join(dir, 'fail.md');
+		for (const bodyPath of [bodyPass, bodyFail]) {
+			fs.writeFileSync(
+				bodyPath,
+				'- **Issue:** #1\n\n## CHANGE SUMMARY\nx\n\n## BUILD / TEST / VERIFICATION\nx\n\n## ACCEPTANCE CRITERIA\nx\n',
+			);
+		}
+		fs.writeFileSync(
+			manifestPath,
+			`${JSON.stringify(
+				{
+					targets: [
+						{ pr: 1, body_file: bodyPass },
+						{ pr: 2, body_file: bodyFail },
+					],
+				},
+				null,
+				2,
+			)}\n`,
+		);
+
+		const runPostMergeCloseout = vi
+			.fn()
+			.mockResolvedValueOnce({
+				status: 'pass',
+				sync_action: 'post_merge_success',
+				source_issue: '1',
+				remediation_required: false,
+			})
+			.mockResolvedValueOnce({
+				status: 'fail',
+				sync_action: 'post_merge_failure',
+				source_issue: '2',
+				remediation_required: true,
+			});
+
+		const outcome = await runBatchPostMergeCloseout({
+			token: 'token',
+			repository: 'owner/repo',
+			manifestPath,
+			targets: [
+				{ pr: 1, body_file: bodyPass },
+				{ pr: 2, body_file: bodyFail },
+			],
+			runPostMergeCloseoutFn: runPostMergeCloseout,
+			closeDuplicateRemediationIssuesFn: vi.fn().mockResolvedValue({ closed: [] }),
+		});
+
+		expect(outcome.status).toBe('partial_failure');
+		expect(outcome.manifestPrune).toMatchObject({ pruned: 1, remaining: 1 });
+		expect(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).targets).toEqual([
+			{ pr: 2, body_file: bodyFail },
+		]);
 	});
 });

--- a/tests/prune-closeout-manifest.test.mjs
+++ b/tests/prune-closeout-manifest.test.mjs
@@ -1,0 +1,115 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+	isPruneEligibleReportStatus,
+	pruneCloseoutManifestContent,
+	pruneCloseoutManifestFromReport,
+	successfulCloseoutPrs,
+} from '../scripts/ci/prune_closeout_manifest.mjs';
+
+const tempDirs = [];
+
+afterEach(() => {
+	for (const dir of tempDirs) {
+		try {
+			fs.rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// ignore cleanup errors
+		}
+	}
+	tempDirs.length = 0;
+});
+
+describe('prune closeout manifest helpers', () => {
+	it('treats success and partial_failure as prune-eligible report statuses', () => {
+		expect(isPruneEligibleReportStatus('success')).toBe(true);
+		expect(isPruneEligibleReportStatus('partial_failure')).toBe(true);
+		expect(isPruneEligibleReportStatus('failure')).toBe(false);
+		expect(isPruneEligibleReportStatus('error')).toBe(false);
+	});
+
+	it('identifies only post_merge_success PRs as prune-eligible', () => {
+		const prs = successfulCloseoutPrs({
+			results: [
+				{ pr: 1, status: 'pass', sync_action: 'post_merge_success' },
+				{ pr: 2, status: 'pass', sync_action: 'post_merge_remediation' },
+				{ pr: 3, status: 'fail', sync_action: 'post_merge_failure' },
+			],
+		});
+
+		expect([...prs]).toEqual(['1']);
+	});
+
+	it('prunes only successful targets from a partial_failure report', () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prune-partial-'));
+		tempDirs.push(tempDir);
+		const manifestPath = path.join(tempDir, 'targets.json');
+		fs.writeFileSync(
+			manifestPath,
+			`${JSON.stringify(
+				{
+					targets: [
+						{ pr: 10, body_file: 'scripts/ci/post-merge-closeout/pr-10-body.md' },
+						{ pr: 11, body_file: 'scripts/ci/post-merge-closeout/pr-11-body.md' },
+					],
+				},
+				null,
+				2,
+			)}\n`,
+		);
+
+		const result = pruneCloseoutManifestFromReport({
+			manifestPath,
+			report: {
+				status: 'partial_failure',
+				results: [
+					{ pr: '10', status: 'pass', sync_action: 'post_merge_success' },
+					{ pr: '11', status: 'fail', sync_action: 'post_merge_failure' },
+				],
+			},
+		});
+
+		expect(result).toMatchObject({ pruned: 1, remaining: 1 });
+		expect(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).targets).toEqual([
+			{ pr: 11, body_file: 'scripts/ci/post-merge-closeout/pr-11-body.md' },
+		]);
+	});
+
+	it('skips pruning for full failure reports', () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prune-failure-'));
+		tempDirs.push(tempDir);
+		const manifestPath = path.join(tempDir, 'targets.json');
+		fs.writeFileSync(
+			manifestPath,
+			`${JSON.stringify({ targets: [{ pr: 1, body_file: 'scripts/ci/post-merge-closeout/pr-1-body.md' }] })}\n`,
+		);
+
+		const result = pruneCloseoutManifestFromReport({
+			manifestPath,
+			report: {
+				status: 'failure',
+				results: [{ pr: '1', status: 'fail', sync_action: 'post_merge_failure' }],
+			},
+		});
+
+		expect(result).toMatchObject({
+			skipped: 'report_not_prune_eligible',
+			pruned: 0,
+		});
+		expect(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).targets).toHaveLength(1);
+	});
+
+	it('keeps an empty manifest valid after pruning', () => {
+		const result = pruneCloseoutManifestContent(
+			`${JSON.stringify({ triggered_at: '2026-06-14T00:00:00Z', targets: [{ pr: 1 }] })}\n`,
+			new Set(['1']),
+		);
+
+		expect(result.pruned).toBe(1);
+		expect(JSON.parse(result.content)).toEqual({ triggered_at: '2026-06-14T00:00:00Z', targets: [] });
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #1966

## PRE-OPEN GATE PREFLIGHT (MANDATORY)
- [x] Confirm exactly one same-repository, open, non-PR source issue exists.
- [x] Confirm one accepted issue-accounting line is present before opening or updating the PR.
- [x] Read the workflow files that will run for this PR's touched paths before opening the PR.
- [x] Read `docs/reference/governance/troubleshooting-data-surface-requirements.md` before making any merge-readiness claim.
- [x] Confirm PR body file allowlist exactly matches the final changed-file list before opening.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## QUEUE / DEPENDENCY MAP STATUS (REQUIRED FOR LAUNCHED-PROGRAM QUEUE TASKS)
- Dependency-map result: pass — Program #1963 Task 003 follows merged Task 002 (#1965 / PR #1976).
- Next queue item: #1967 — Active manifest registry and completed-wave retirement (Task 004)
- Continue/halt decision: halt — Task 004 begins only after Task 003 merges and post-merge closeout is verified.

## PRE-MERGE CLOSEOUT PREDICTION (REQUIRED BEFORE READY FOR MERGE)
- Pre-merge closeout prediction: pass
- Source issue state before merge: open
- Expected post-merge source issue action: auto-close
- Reviewer disposition parseability: pass
- Queue continuation after closeout: halt — verify Task 003 closeout before starting Task 004 (#1967)

## PROGRESS + READINESS (MANDATORY)
- Phase: Program #1963 implementation — Task 003
- Task: Per-target manifest pruning on partial_failure (#1966)
- Status: READY FOR MERGE
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: none
- Notes: All required gates green on head `502b397a`.

## DOCUMENTATION SOURCE (MANDATORY)
- [ ] DIATAXIS_FULL
- [x] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`
- `scripts/ci/prune_closeout_manifest.mjs`
- `scripts/ci/run_batch_post_merge_closeout.mjs`

## LABEL
- Intent label for this PR: infra

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Additional design/reference docs used for this PR:
  - `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `scripts/ci/prune_closeout_manifest.mjs`
- `scripts/ci/run_batch_post_merge_closeout.mjs`
- `tests/prune-closeout-manifest.test.mjs`
- `tests/post-merge-closeout-batch.test.mjs`
- `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## CHANGE SUMMARY
- Add `isPruneEligibleReportStatus` so manifest pruning runs on `success` and `partial_failure` batch reports.
- Prune only targets with `post_merge_success`; failed targets remain for retry.
- Wire batch closeout to invoke manifest prune for partial_failure outcomes.
- Skip default-manifest pruning during Vitest to avoid mutating repo fixture files in unrelated tests.
- Add unit tests for mixed pass/fail prune behavior and partial_failure batch integration.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `npm test` — PASS (876 tests)
  - `npx vitest run tests/prune-closeout-manifest.test.mjs tests/post-merge-closeout-batch.test.mjs` — PASS
- Gate verification:
  - Commit-level workflow runs inspected: PASS on head `502b397a`
  - PR-level governance/accounting workflows inspected: PASS on head `502b397a`
- Result summary:
  - PASS (local + CI)

## DOCUMENTATION UPDATES
- [x] Documentation updated in this PR
- Files:
  - `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`

## REVIEWER RESPONSE ACCOUNTING
- [x] Reviewed all reviewer comments.
- [x] Reviewed all bot comments.
- [x] Reviewed all GitHub review threads.
- [x] Every actionable reviewer comment has a PR-body disposition with `review-comment:<id>`.
- [x] Every GitHub review thread has an explicit thread-state disposition: resolved, outdated, or intentionally left unresolved with rationale.
- review-comment:3471127975 — accepted — wrap partial_failure prune integration test in try/finally with fs.rmSync cleanup — thread state: resolved

## ACCEPTANCE CRITERIA
- [x] Passing targets removed from manifest after partial_failure batch.
- [x] Failed targets remain for retry.
- [x] Tests cover mixed pass/fail prune behavior.
- [x] Post-merge source issue closure is delegated to the repository closeout workflow after merge.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches final diff exactly
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] Local checks executed and passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-142e3c1a-96a1-488f-9e89-d31ed73bfb0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-142e3c1a-96a1-488f-9e89-d31ed73bfb0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables per-target manifest pruning when batch post-merge closeout returns success or partial_failure. Passing targets are removed; failed targets stay, and default-manifest pruning is skipped during `vitest` to avoid mutating fixtures.

- **New Features**
  - Added `isPruneEligibleReportStatus`; batch runner prunes on `success` and `partial_failure` and returns `manifestPrune`.
  - Prunes only targets with `post_merge_success`; others remain in the manifest.
  - Added `shouldPruneBatchManifest` to skip pruning the default manifest in `vitest` and on dry runs.
  - Expanded tests for prune helpers and partial-failure updates; skip code is `report_not_prune_eligible`. Tracker doc updated.

Linked to #1966.

<sup>Written for commit 502b397af2757394f33b3eb467c769898151a470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->