### PR TITLE
ops(#1967): Active manifest registry and completed-wave retirement

### DIFF
--- a/.github/workflows/post-merge-pr-body-closeout.yml
+++ b/.github/workflows/post-merge-pr-body-closeout.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches: [main]
     paths:
+      - scripts/ci/post-merge-closeout/targets-active.json
       - scripts/ci/post-merge-closeout/targets-ci-pending-rerun.json
       - scripts/ci/post-merge-closeout/targets-ci-pending.json
       - scripts/ci/post-merge-closeout/targets-remediation-backlog.json
-      - scripts/ci/post-merge-closeout/targets-ops-burn-down-wave1.json
-      - scripts/ci/post-merge-closeout/targets-ops-burn-down-wave2.json
-      - scripts/ci/post-merge-closeout/targets-ops-burn-down-wave3a-remediation.json
       - scripts/ci/post-merge-closeout/targets-ops-burn-down-wave3b.json
   workflow_dispatch:
     inputs:
@@ -85,7 +83,12 @@ jobs:
           else
             CHANGED_PATHS="$(git diff --name-only "${BEFORE_SHA}" "${GITHUB_SHA}")"
           fi
-          printf '%s\n' "${CHANGED_PATHS}" | node scripts/ci/resolve_closeout_manifests_from_push.mjs --stdin-paths
+          if echo "${CHANGED_PATHS}" | grep -qx 'scripts/ci/post-merge-closeout/targets-active.json'; then
+            echo "Active manifest registry changed; replaying full active manifest set from registry"
+            echo "closeout_manifests=" >> "${GITHUB_OUTPUT}"
+          else
+            printf '%s\n' "${CHANGED_PATHS}" | node scripts/ci/resolve_closeout_manifests_from_push.mjs --stdin-paths
+          fi
 
       - name: Batch closeout for all pending CI manifests
         if: |

--- a/docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md
+++ b/docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md
@@ -76,4 +76,18 @@ Task 001 (path-scoped manifest replay on push)
 | --- | --- | --- | --- |
 | 001 | #1964 | complete | PR #1972 @ `82517eb0280dbdaa337a2080dadf51e64d46d651` |
 | 002 | #1965 | complete | PR #1976 @ `21abad7eb3b0682108e4c29c2f9372eb58160b62` |
-| 003 | #1966 | in progress | — |
+| 003 | #1966 | complete | PR #1977 @ `30cbf066ebffef574207f194e91ab47d13697748` |
+| 004 | #1967 | in progress | — |
+
+## Archived closeout manifests (Task 004)
+
+Completed Program #1923 wave manifests remain in-repo for manual `workflow_dispatch` replay but are excluded from `scripts/ci/post-merge-closeout/targets-active.json` automatic replay:
+
+| Manifest | Status |
+| --- | --- |
+| `targets-ops-burn-down-wave1.json` | archived |
+| `targets-ops-burn-down-wave2.json` | archived |
+| `targets-ops-burn-down-wave3a.json` | archived |
+| `targets-ops-burn-down-wave3a-remediation.json` | archived |
+
+Active automatic replay is defined by `targets-active.json`.

--- a/docs/reference/ci/post-merge-validation-surface.md
+++ b/docs/reference/ci/post-merge-validation-surface.md
@@ -34,7 +34,7 @@ Mutable PR-head gate code must not execute as trusted enforcement logic.
 |---|---|---|
 | `gate-post-merge-readiness.yml` | GATE — Post-Merge Readiness | Pre-merge blocker for PR body metadata, allowlist evidence, placeholders, and reviewer dispositions that would fail closeout |
 | `post-merge-closeout.yml` | Post-Merge Detection | Sole automatic post-merge source-issue closeout owner per merge: body apply when configured, validate, one orchestrator sync, PR comment, reviewer audit on failure |
-| `post-merge-pr-body-closeout.yml` | Post-Merge PR Body Closeout | Manual single-PR closeout, batch manifests, and push-triggered backfill only (no automatic merge trigger) |
+| `post-merge-pr-body-closeout.yml` | Post-Merge PR Body Closeout | Manual single-PR closeout, batch manifests, and push-triggered backfill only (no automatic merge trigger). Push paths include `targets-active.json` and active manifest files; completed wave manifests replay only via explicit `workflow_dispatch`. |
 | `post-merge-intent-verification.yml` | Post-Merge Maintainer Body Apply | Targeted PR synchronize and workflow-dispatch maintainer PR body apply path for legacy open PRs |
 | `post-merge-remediation.yml` | Post-Merge Remediation | Opens remediation issues only when Post-Merge Detection fails |
 | `gate-close-work-issue.yml` | gate-close-work-issue | Parked no-op legacy issue closer; performs no issue mutation and is not an effective closeout owner |
@@ -107,6 +107,7 @@ Duplicate remediation issue cleanup remains unchanged. Canonical remediation iss
 | `scripts/ci/post_merge_validation_surface.mjs` | Surface inventory validator |
 | `scripts/ci/close_duplicate_remediation_issues.mjs` | Closes duplicate remediation issues only |
 | `scripts/ci/post_merge_self_heal_backlog.mjs` | Backlog scan, safe-close, and `ops-pr-escalation` handoff for open exception issues |
+| `scripts/ci/run_post_merge_closeout_all_manifests.mjs` | Loads active manifest registry (`targets-active.json`) and runs batch closeout across active manifests |
 | `scripts/orchestrator/sync-pr-state.mjs` | Applies orchestrator labels and source-issue closeout |
 
 ## Rollback

--- a/scripts/ci/post-merge-closeout/targets-active.json
+++ b/scripts/ci/post-merge-closeout/targets-active.json
@@ -1,0 +1,15 @@
+{
+  "description": "Canonical active closeout manifest registry for automatic replay. Completed Program #1923 wave manifests are archived and replay only via explicit workflow_dispatch.",
+  "manifests": [
+    "scripts/ci/post-merge-closeout/targets-ci-pending-rerun.json",
+    "scripts/ci/post-merge-closeout/targets-ci-pending.json",
+    "scripts/ci/post-merge-closeout/targets-remediation-backlog.json",
+    "scripts/ci/post-merge-closeout/targets-ops-burn-down-wave3b.json"
+  ],
+  "archived_manifests": [
+    "scripts/ci/post-merge-closeout/targets-ops-burn-down-wave1.json",
+    "scripts/ci/post-merge-closeout/targets-ops-burn-down-wave2.json",
+    "scripts/ci/post-merge-closeout/targets-ops-burn-down-wave3a.json",
+    "scripts/ci/post-merge-closeout/targets-ops-burn-down-wave3a-remediation.json"
+  ]
+}

--- a/scripts/ci/run_post_merge_closeout_all_manifests.mjs
+++ b/scripts/ci/run_post_merge_closeout_all_manifests.mjs
@@ -2,7 +2,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import {
 	BATCH_CLOSEOUT_REPORT_PATH,
@@ -12,11 +12,13 @@ import {
 	buildBatchCloseoutReport,
 } from './run_batch_post_merge_closeout.mjs';
 
+const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
 export const ACTIVE_MANIFEST_REGISTRY = 'scripts/ci/post-merge-closeout/targets-active.json';
 
 export function loadActiveManifestRegistry(
 	registryPath = ACTIVE_MANIFEST_REGISTRY,
-	workspace = process.cwd(),
+	workspace = REPOSITORY_ROOT,
 ) {
 	const resolved = path.resolve(workspace, registryPath);
 	const payload = JSON.parse(fs.readFileSync(resolved, 'utf8'));

--- a/scripts/ci/run_post_merge_closeout_all_manifests.mjs
+++ b/scripts/ci/run_post_merge_closeout_all_manifests.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import fs from 'node:fs';
+import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import {
@@ -10,15 +12,29 @@ import {
 	buildBatchCloseoutReport,
 } from './run_batch_post_merge_closeout.mjs';
 
-export const DEFAULT_MANIFESTS = [
-	'scripts/ci/post-merge-closeout/targets-ci-pending-rerun.json',
-	'scripts/ci/post-merge-closeout/targets-ci-pending.json',
-	'scripts/ci/post-merge-closeout/targets-remediation-backlog.json',
-	'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave1.json',
-	'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave2.json',
-	'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave3a-remediation.json',
-	'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave3b.json',
-];
+export const ACTIVE_MANIFEST_REGISTRY = 'scripts/ci/post-merge-closeout/targets-active.json';
+
+export function loadActiveManifestRegistry(
+	registryPath = ACTIVE_MANIFEST_REGISTRY,
+	workspace = process.cwd(),
+) {
+	const resolved = path.resolve(workspace, registryPath);
+	const payload = JSON.parse(fs.readFileSync(resolved, 'utf8'));
+	const manifests = Array.isArray(payload) ? payload : payload?.manifests;
+	if (!Array.isArray(manifests)) {
+		throw new Error(`Active manifest registry must include a manifests array: ${resolved}`);
+	}
+
+	return {
+		registryPath: resolved,
+		manifests: manifests.map((entry) => String(entry).replace(/\\/g, '/').replace(/^\.\//, '')),
+		archivedManifests: Array.isArray(payload?.archived_manifests)
+			? payload.archived_manifests.map((entry) => String(entry).replace(/\\/g, '/').replace(/^\.\//, ''))
+			: [],
+	};
+}
+
+export const DEFAULT_MANIFESTS = loadActiveManifestRegistry().manifests;
 
 export async function runAllPostMergeCloseoutManifests({
 	token,

--- a/tests/post-merge-closeout-all-manifests.test.mjs
+++ b/tests/post-merge-closeout-all-manifests.test.mjs
@@ -1,19 +1,34 @@
 import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_MANIFESTS } from '../scripts/ci/run_post_merge_closeout_all_manifests.mjs';
+import {
+	ACTIVE_MANIFEST_REGISTRY,
+	DEFAULT_MANIFESTS,
+	loadActiveManifestRegistry,
+} from '../scripts/ci/run_post_merge_closeout_all_manifests.mjs';
 import { loadCloseoutTargets } from '../scripts/ci/run_batch_post_merge_closeout.mjs';
 
+const COMPLETED_WAVE_MANIFESTS = [
+	'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave1.json',
+	'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave2.json',
+	'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave3a.json',
+	'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave3a-remediation.json',
+];
+
 describe('post-merge closeout all manifests', () => {
-	it('defines rerun, CI pending, and remediation backlog manifests', () => {
-		expect(DEFAULT_MANIFESTS).toEqual([
+	it('loads DEFAULT_MANIFESTS from the active registry without completed waves', () => {
+		const { manifests, archivedManifests } = loadActiveManifestRegistry();
+		expect(manifests).toEqual(DEFAULT_MANIFESTS);
+		expect(manifests).toEqual([
 			'scripts/ci/post-merge-closeout/targets-ci-pending-rerun.json',
 			'scripts/ci/post-merge-closeout/targets-ci-pending.json',
 			'scripts/ci/post-merge-closeout/targets-remediation-backlog.json',
-			'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave1.json',
-			'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave2.json',
-			'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave3a-remediation.json',
 			'scripts/ci/post-merge-closeout/targets-ops-burn-down-wave3b.json',
 		]);
+		for (const manifestPath of COMPLETED_WAVE_MANIFESTS) {
+			expect(manifests).not.toContain(manifestPath);
+		}
+		expect(archivedManifests).toEqual(COMPLETED_WAVE_MANIFESTS);
+		expect(ACTIVE_MANIFEST_REGISTRY).toBe('scripts/ci/post-merge-closeout/targets-active.json');
 	});
 
 	it('loads PR #1858 closeout rerun target after #1855 remediation merge closeout', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #1967

## PRE-OPEN GATE PREFLIGHT (MANDATORY)
- [x] Confirm exactly one same-repository, open, non-PR source issue exists.
- [x] Confirm one accepted issue-accounting line is present before opening or updating the PR.
- [x] Read the workflow files that will run for this PR's touched paths before opening the PR.
- [x] Read `docs/reference/governance/troubleshooting-data-surface-requirements.md` before making any merge-readiness claim.
- [x] Confirm PR body file allowlist exactly matches the final changed-file list before opening.

## MANDATORY FIRST STEP (ZIP SAFETY)
- [x] No ZIP file exists in the repo root
- [x] Final diff confirms no ZIP file is committed

## QUEUE / DEPENDENCY MAP STATUS (REQUIRED FOR LAUNCHED-PROGRAM QUEUE TASKS)
- Dependency-map result: pass — Program #1963 Task 004 follows merged Task 003 (#1966 / PR #1977).
- Next queue item: #1968 — Closeout body generator late-reviewer alignment (Task 005)
- Continue/halt decision: halt — Task 005 begins only after Task 004 merges and post-merge closeout is verified.

## PRE-MERGE CLOSEOUT PREDICTION (REQUIRED BEFORE READY FOR MERGE)
- Pre-merge closeout prediction: pass
- Source issue state before merge: open
- Expected post-merge source issue action: auto-close
- Reviewer disposition parseability: pass
- Queue continuation after closeout: halt — verify Task 004 closeout before starting Task 005 (#1968)

## PROGRESS + READINESS (MANDATORY)
- Phase: Program #1963 implementation — Task 004
- Task: Active manifest registry and completed-wave retirement (#1967)
- Status: READY FOR REVIEW
- Scope Confirmed: YES
- Out-of-Scope Changes Present: NO
- Blocking Issues: awaiting trusted review on merged head after main sync (#2030 hotfix)
- Notes: Full suite 876/876 pass locally.

## DOCUMENTATION SOURCE (MANDATORY)
- [ ] DIATAXIS_FULL
- [x] DIATAXIS_ROUTED
- [ ] LEGACY_FALLBACK

Source Files Used:
- `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`
- `docs/reference/ci/post-merge-validation-surface.md`
- `scripts/ci/run_post_merge_closeout_all_manifests.mjs`

## LABEL
- Intent label for this PR: infra

## DESIGN SOURCE OF TRUTH (NON-NEGOTIABLE)
- Canonical process reference: `/docs/governance/PR_PROCESS.md`
- Canonical governance reference: `/docs/governance/PR_GOVERNANCE.md`
- Additional design/reference docs used for this PR:
  - `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`
  - `docs/reference/ci/post-merge-validation-surface.md`

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `scripts/ci/post-merge-closeout/targets-active.json`
- `scripts/ci/run_post_merge_closeout_all_manifests.mjs`
- `.github/workflows/post-merge-pr-body-closeout.yml`
- `tests/post-merge-closeout-all-manifests.test.mjs`
- `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`
- `docs/reference/ci/post-merge-validation-surface.md`

All other files are out of scope

## VISUAL / UX INVARIANTS (MANDATORY)
- [x] Header, footer, navigation, auth, and route invariants preserved unless explicitly in scope
- [x] No unauthorized visual drift introduced
- [x] No out-of-scope UX changes introduced
- [x] Store behavior, Join/Login behavior, and Fan Club/Admin gating remain compliant unless explicitly in scope

## DRIFT GATE ALIGNMENT (MANDATORY)
- [x] Exactly ONE intent label applied
- [x] File changes match allowlist exactly
- [x] No mixed-intent changes present

## CHANGE SUMMARY
- Add `targets-active.json` as the canonical active closeout manifest registry.
- Load `DEFAULT_MANIFESTS` from the active registry in `run_post_merge_closeout_all_manifests.mjs`.
- Retire completed wave1/wave2/wave3a manifests from automatic default replay (archive paths documented in tracker).
- Update push workflow paths to include the active registry and remove completed wave manifests.
- Replay full active set when the registry file changes on push.

## BUILD / TEST / VERIFICATION
- Commands run:
  - `npm test` — PASS (876 tests)
  - `npx vitest run tests/post-merge-closeout-all-manifests.test.mjs` — PASS
- Gate verification:
  - Commit-level workflow runs inspected: PENDING on latest head
  - PR-level governance/accounting workflows inspected: PENDING on latest head
- Result summary:
  - PASS (local)

## DOCUMENTATION UPDATES
- [x] Documentation updated in this PR
- Files:
  - `docs/ops/trackers/PROGRAM-POST-MERGE-CLOSEOUT-AUTOMATION-IMPLEMENTATION-QUEUE.md`
  - `docs/reference/ci/post-merge-validation-surface.md`

## REVIEWER RESPONSE ACCOUNTING
- [x] Reviewed all reviewer comments.
- [x] Reviewed all bot comments.
- [x] Reviewed all GitHub review threads.
- [x] Every actionable reviewer comment has a PR-body disposition with `review-comment:<id>`.
- [x] Every GitHub review thread has an explicit thread-state disposition: resolved, outdated, or intentionally left unresolved with rationale.
- review-comment:3474606551 — accepted — resolve active registry workspace from repository root via import.meta.url — thread state: resolved
- review-comment:3474606559 — accepted — default loadActiveManifestRegistry workspace to REPOSITORY_ROOT instead of process.cwd — thread state: resolved

## ACCEPTANCE CRITERIA
- [x] `DEFAULT_MANIFESTS` loads from active registry.
- [x] Completed waves not in active registry unless explicitly dispatched.
- [x] Workflow push paths include active registry file.
- [x] Post-merge source issue closure is delegated to the repository closeout workflow after merge.

## REQUIRED PRE-REVIEW SELF-CHECK
- [x] PR body contains all required sections with exact headings
- [x] Allowed files section matches final diff exactly
- [x] ZIP safety confirmed
- [x] Intent label correct and singular
- [x] Local checks executed and passed
- Head SHA: `587ffee` (includes merged #2030 hotfix)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-142e3c1a-96a1-488f-9e89-d31ed73bfb0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-142e3c1a-96a1-488f-9e89-d31ed73bfb0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `scripts/ci/post-merge-closeout/targets-active.json` as the single source of truth for active post-merge closeout manifests and retires completed waves from automatic replay. Implements #1967 by loading the active set from the registry and replaying it on push when the registry changes.

- **New Features**
  - Load `DEFAULT_MANIFESTS` via `loadActiveManifestRegistry()` from `targets-active.json` in `run_post_merge_closeout_all_manifests.mjs`.
  - On push, replay the full active set when the registry changes; push paths include the registry and exclude archived waves.
  - Archive `wave1/2/3a` manifests for manual `workflow_dispatch` only; tracker and reference docs updated.

- **Bug Fixes**
  - Resolve the active registry from the repository root to avoid `cwd`-dependent path issues.

<sup>Written for commit 585b0068f78244c37623672b0b4b0487f618823a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/1978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->