### PR TITLE
feat(#2044): social wall platform fallback links

### DIFF
--- a/docs/ops/pmo/website-public-launch-relaunch-readiness.md
+++ b/docs/ops/pmo/website-public-launch-relaunch-readiness.md
@@ -77,8 +77,8 @@ At the end of Program #2039:
 | ---: | ---: | --- | --- |
 | 001 | #2041 | Launch gap inventory and public page readiness review | Complete — `docs/ops/reports/website-public-launch-gap-inventory.md` |
 | 002 | #2042 | Public content polish and launch copy reconciliation | Complete — `docs/ops/reports/website-public-launch-copy-reconciliation.md` |
-| 003 | #2043 | Admin Club Staging page at `/admin/clubstaging` | In progress — PR pending review |
-| 004 | #2044 | Media/social reliability and fallback implementation | Ready after Tasks 001 and 003 |
+| 003 | #2043 | Admin Club Staging page at `/admin/clubstaging` | Complete — PR #2099 |
+| 004 | #2044 | Media/social reliability and fallback implementation | In progress — PR pending review |
 | 005 | #2045 | Donation/fundraiser route readiness and campaign boundary review | Ready after Task 001 |
 | 006 | #2046 | SEO analytics sitemap and social-card readiness | Ready after Task 002 |
 | 007 | #2047 | Production launch checklist smoke tests rollback and evidence model | Ready after Tasks 001-006 |

--- a/docs/ops/reports/website-public-launch-social-reliability.md
+++ b/docs/ops/reports/website-public-launch-social-reliability.md
@@ -1,0 +1,44 @@
+---
+Doc Type: Report
+Audience: Human + AI
+Authority Level: Program Evidence
+Status: Draft until #2044 PR merge
+source issue: #2044
+Parent Program: #2039
+Owns: Task 004 media/social reliability and fallback evidence
+Does Not Own: Vendor contract changes, scraping, or new paid social integrations
+Canonical Reference: /docs/ops/reports/website-public-launch-gap-inventory.md
+related issues: #2039, #2041, #2043, #2044, #2045, #2046, #2047
+Last Reviewed: 2026-06-30
+---
+
+# Website Public Launch Social Reliability
+
+## Purpose
+
+Record Task #2044 fallback behavior for the homepage Elfsight social wall.
+
+## Current known truth
+
+- Homepage `SocialWall` still uses the existing Elfsight widget (`elfsight-app-805f3c5c-67cd-4edf-bde6-2d5978e386a8`).
+- Widget load failures or timeouts now render repo-owned fallback links for Facebook, Instagram, X/Twitter, and Pinterest.
+- Fallback links point to platform-origin URLs; operator-owned official profile URLs remain a Bill/Atlas content decision.
+
+## Platform handling
+
+| Platform | Widget dependency | Fallback behavior |
+| --- | --- | --- |
+| Facebook | Elfsight feed | Direct platform link + reliability note |
+| Instagram | Elfsight feed + CSP image hosts | Direct platform link + reliability note |
+| X/Twitter | Elfsight feed | Direct platform link + reliability note |
+| Pinterest | Optional in widget feed | Direct platform link + reliability note |
+
+## Out of scope
+
+- Scraping or bypassing platform terms
+- New paid social vendors without explicit approval
+- Replacing Elfsight in this task
+
+## Operator follow-up
+
+Bill/Atlas may replace generic platform home links with verified official Lou Gehrig Fan Club profile URLs when those accounts are confirmed.

--- a/src/components/SocialWall.tsx
+++ b/src/components/SocialWall.tsx
@@ -1,10 +1,14 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import {
+  getSocialFallbackPlatforms,
+  SOCIAL_FALLBACK_HEADLINE,
+  SOCIAL_WALL_WIDGET_ID,
+} from '@/lib/socialFallbacks';
 import styles from './social-wall.module.css';
 
 const PLATFORM_SRC = 'https://elfsightcdn.com/platform.js';
-const WIDGET_ID = 'elfsight-app-805f3c5c-67cd-4edf-bde6-2d5978e386a8';
 
 declare global {
   interface Window {
@@ -16,13 +20,14 @@ declare global {
 
 export default function SocialWall() {
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const fallbackPlatforms = getSocialFallbackPlatforms();
 
   useEffect(() => {
     let cancelled = false;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const existingScript = document.querySelector<HTMLScriptElement>(
-      `script[src="${PLATFORM_SRC}"]`
+      `script[src="${PLATFORM_SRC}"]`,
     );
 
     const init = () => {
@@ -45,13 +50,11 @@ export default function SocialWall() {
       script.onload = init;
       script.onerror = fail;
       document.body.appendChild(script);
+    } else if (window.elfsight) {
+      init();
     } else {
-      if (window.elfsight) {
-        init();
-      } else {
-        existingScript.addEventListener('load', init, { once: true });
-        existingScript.addEventListener('error', fail, { once: true });
-      }
+      existingScript.addEventListener('load', init, { once: true });
+      existingScript.addEventListener('error', fail, { once: true });
     }
 
     timeoutId = setTimeout(fail, 8000);
@@ -62,20 +65,33 @@ export default function SocialWall() {
     };
   }, []);
 
+  const showFallback = status === 'error';
+
   return (
     <section id="social-wall" className={styles.section}>
       <div className={styles.container}>
         <h2 className={styles.sectionTitle}>Social Wall</h2>
+        <p className={styles.subtitle}>Live fan posts from Facebook, Instagram, X, and Pinterest when available.</p>
         <div className={styles.embed}>
           {status === 'loading' ? (
             <p className={styles.fallback}>Loading social wall content...</p>
           ) : null}
-          {status === 'error' ? (
-            <p className={styles.fallback}>
-              Social wall is temporarily unavailable. Please check back soon.
-            </p>
+          {showFallback ? (
+            <div className={styles.fallbackPanel} role="status" aria-live="polite">
+              <p className={styles.fallback}>{SOCIAL_FALLBACK_HEADLINE}</p>
+              <ul className={styles.fallbackList}>
+                {fallbackPlatforms.map((platform) => (
+                  <li key={platform.id}>
+                    <a href={platform.href} target="_blank" rel="noopener noreferrer">
+                      Visit Lou Gehrig Fan Club on {platform.label}
+                    </a>
+                    <span className={styles.fallbackNote}>{platform.reliabilityNote}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
           ) : null}
-          <div className={WIDGET_ID} data-elfsight-app-lazy />
+          <div className={SOCIAL_WALL_WIDGET_ID} data-elfsight-app-lazy />
         </div>
       </div>
     </section>

--- a/src/components/social-wall.module.css
+++ b/src/components/social-wall.module.css
@@ -15,6 +15,14 @@
   color: var(--lgfc-blue);
 }
 
+.subtitle {
+  margin: 0 0 16px 0;
+  text-align: center;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: #4b5563;
+}
+
 .embed {
   max-width: 1120px;
   margin: 0 auto 16px auto;
@@ -30,5 +38,34 @@
   text-align: center;
   font-size: 0.9375rem;
   line-height: 1.5;
+  color: #6b7280;
+}
+
+.fallbackPanel {
+  margin-bottom: 16px;
+  padding: 16px;
+  border-radius: 8px;
+  background: #f8fafc;
+  border: 1px solid #dbe3f2;
+}
+
+.fallbackList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.fallbackList a {
+  font-weight: 600;
+  color: var(--lgfc-blue);
+}
+
+.fallbackNote {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.8125rem;
+  line-height: 1.45;
   color: #6b7280;
 }

--- a/src/lib/socialFallbacks.ts
+++ b/src/lib/socialFallbacks.ts
@@ -1,0 +1,42 @@
+export type SocialFallbackPlatform = {
+  id: 'facebook' | 'instagram' | 'x' | 'pinterest';
+  label: string;
+  href: string;
+  reliabilityNote: string;
+};
+
+export const SOCIAL_WALL_WIDGET_ID = 'elfsight-app-805f3c5c-67cd-4edf-bde6-2d5978e386a8';
+
+export const SOCIAL_FALLBACK_PLATFORMS: SocialFallbackPlatform[] = [
+  {
+    id: 'facebook',
+    label: 'Facebook',
+    href: 'https://www.facebook.com/',
+    reliabilityNote: 'Elfsight may omit Facebook posts when the widget feed is unavailable; use the official Facebook presence directly.',
+  },
+  {
+    id: 'instagram',
+    label: 'Instagram',
+    href: 'https://www.instagram.com/',
+    reliabilityNote: 'Instagram embeds depend on third-party widget availability and CSP allowances.',
+  },
+  {
+    id: 'x',
+    label: 'X (Twitter)',
+    href: 'https://x.com/',
+    reliabilityNote: 'X/Twitter cards in the widget may fail independently of the rest of the social wall.',
+  },
+  {
+    id: 'pinterest',
+    label: 'Pinterest',
+    href: 'https://www.pinterest.com/',
+    reliabilityNote: 'Pinterest is optional in the Elfsight feed; the homepage must not break when it is omitted.',
+  },
+];
+
+export const SOCIAL_FALLBACK_HEADLINE =
+  'Follow the Lou Gehrig Fan Club on the platforms below while the embedded social wall loads or when the widget is unavailable.';
+
+export function getSocialFallbackPlatforms(): SocialFallbackPlatform[] {
+  return SOCIAL_FALLBACK_PLATFORMS.map((platform) => ({ ...platform }));
+}

--- a/tests/social-fallbacks.test.ts
+++ b/tests/social-fallbacks.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getSocialFallbackPlatforms,
+  SOCIAL_FALLBACK_PLATFORMS,
+  SOCIAL_WALL_WIDGET_ID,
+} from '@/lib/socialFallbacks';
+
+describe('socialFallbacks (#2044)', () => {
+  it('defines fallback coverage for Facebook, Instagram, X, and Pinterest', () => {
+    const ids = SOCIAL_FALLBACK_PLATFORMS.map((platform) => platform.id);
+    expect(ids).toEqual(['facebook', 'instagram', 'x', 'pinterest']);
+  });
+
+  it('returns platform-origin links for every fallback entry', () => {
+    for (const platform of getSocialFallbackPlatforms()) {
+      expect(platform.href).toMatch(/^https:\/\//);
+      expect(platform.label.length).toBeGreaterThan(0);
+      expect(platform.reliabilityNote.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps the Elfsight widget id stable for SocialWall', () => {
+    expect(SOCIAL_WALL_WIDGET_ID).toContain('elfsight-app-');
+  });
+});

--- a/tests/social-wall.test.tsx
+++ b/tests/social-wall.test.tsx
@@ -1,0 +1,35 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SocialWall from '@/components/SocialWall';
+
+describe('SocialWall (#2044)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading copy before the widget resolves', () => {
+    render(<SocialWall />);
+    expect(screen.getByText('Loading social wall content...')).toBeInTheDocument();
+  });
+
+  it('shows platform fallback links when the widget fails to load', () => {
+    render(<SocialWall />);
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent(/Follow the Lou Gehrig Fan Club/i);
+    expect(screen.getByRole('link', { name: /Facebook/i })).toHaveAttribute('href', 'https://www.facebook.com/');
+    expect(screen.getByRole('link', { name: /Instagram/i })).toHaveAttribute('href', 'https://www.instagram.com/');
+    expect(screen.getByRole('link', { name: /X \(Twitter\)/i })).toHaveAttribute('href', 'https://x.com/');
+    expect(screen.getByRole('link', { name: /Pinterest/i })).toHaveAttribute('href', 'https://www.pinterest.com/');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- **Issue:** #2044

## FILE-TOUCH ALLOWLIST (MANDATORY)
Allowed files:
- `src/lib/socialFallbacks.ts`
- `src/components/SocialWall.tsx`
- `src/components/social-wall.module.css`
- `tests/social-fallbacks.test.ts`
- `tests/social-wall.test.tsx`
- `docs/ops/reports/website-public-launch-social-reliability.md`
- `docs/ops/pmo/website-public-launch-relaunch-readiness.md`

## CHANGE SUMMARY
- Add repo-owned social fallback model for Facebook, Instagram, X, and Pinterest.
- Render platform-origin links when the Elfsight widget fails or times out.
- Add Task 004 reliability evidence report and tests.

## BUILD / TEST / VERIFICATION
- `npm run build` — PASS
- `npm test -- tests/social-fallbacks.test.ts tests/social-wall.test.tsx` — PASS (5 tests)

## REVIEWER RESPONSE ACCOUNTING
- none at PR open

## ACCEPTANCE CRITERIA
- [x] Media/social surfaces degrade cleanly if embeds fail.
- [x] Facebook, Instagram, X/Twitter, Pinterest handling is documented.
- [x] Displayed social fallback content links to originating platforms.
- [x] No paid/vendor dependency added.
- [ ] All required CI gates green on latest head (pending PR CI).

## PROGRESS + READINESS (MANDATORY)
- Status: READY FOR REVIEW
<!-- CURSOR_AGENT_PR_BODY_END -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reliable fallback for the homepage social wall: if the Elfsight widget fails or times out, we show direct links to Facebook, Instagram, X, and Pinterest. Supports issue #2044 (Program #2039 Task 004) with tests and an ops report.

- **New Features**
  - Show a repo-owned fallback panel with platform-origin links after an 8s timeout or load error.
  - Centralize config in `src/lib/socialFallbacks.ts` (includes `SOCIAL_WALL_WIDGET_ID` and fallback copy).
  - Update `SocialWall` UI with a subtitle and accessible status panel; add minimal styles in `social-wall.module.css`.

- **Tests & Docs**
  - Add unit tests for fallback coverage and `SocialWall` timeout behavior.
  - Add ops report `docs/ops/reports/website-public-launch-social-reliability.md` and update readiness tracker.

<sup>Written for commit 7660ad21e6916ec5a74ff813254700ec889a05ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wdhunter645/next-starter-template/pull/2108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->